### PR TITLE
Locate VS 2017 installation of Android NDK

### DIFF
--- a/src/Xamarin.Android.Tools/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools/Sdks/AndroidSdkWindows.cs
@@ -146,9 +146,10 @@ namespace Xamarin.Android.Tools
 			// Check some hardcoded paths for good measure
 			var xamarin_private = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), "Xamarin", "MonoAndroid");
 			var android_default = Path.Combine (OS.ProgramFilesX86, "Android");
+			var vs_2017_default = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.CommonApplicationData), "Microsoft", "AndroidNDK64");
 			var cdrive_default = @"C:\";
 
-			foreach (var basePath in new string [] {xamarin_private, android_default, cdrive_default})
+			foreach (var basePath in new string [] {xamarin_private, android_default, vs_2017_default, cdrive_default})
 				if (Directory.Exists (basePath))
 					foreach (var dir in Directory.GetDirectories (basePath, "android-ndk-r*"))
 						if (ValidateAndroidNdkLocation (dir))


### PR DESCRIPTION
The VS 2017 installer put my NDK in
`C:\ProgramData\Microsoft\AndroidNDK64\android-ndk-r13b`

I think it should check for its location right before checking `C:\`