### PR TITLE
Support for finding Xamarin.Android location with only VS 2017 installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ src/*.dll
 .DS_Store
 bin
 **/obj
+packages/

--- a/src/Xamarin.Android.Tools.Tests/MonoDroidSdkTests.cs
+++ b/src/Xamarin.Android.Tools.Tests/MonoDroidSdkTests.cs
@@ -1,0 +1,69 @@
+﻿using NUnit.Framework;
+using System.Diagnostics;
+using System.IO;
+
+namespace Xamarin.Android.Tools.Tests
+{
+	[TestFixture]
+	class MonoDroidSdkTests
+	{
+		[TestFixtureSetUp]
+		public void FixtureSetUp()
+		{
+			AndroidLogger.Info += OnInfo;
+			AndroidLogger.Warning += OnWarning;
+			AndroidLogger.Error += OnError;
+		}
+
+		[TestFixtureTearDown]
+		public void FixtureTearDown()
+		{
+			AndroidLogger.Info -= OnInfo;
+			AndroidLogger.Warning -= OnWarning;
+			AndroidLogger.Error -= OnError;
+		}
+
+		void OnInfo(string task, string message)
+		{
+			Debug.WriteLine(task + ": " + message);
+		}
+
+		void OnWarning(string task, string message)
+		{
+			Assert.Fail(task + ": " + message);
+		}
+
+		void OnError(string task, string message)
+		{
+			Assert.Fail(task + ": " + message);
+		}
+
+		[Test]
+		public void RefreshWithoutParameters()
+		{
+			//Just checking for exceptions, or AndroidLogger
+			MonoDroidSdk.Refresh();
+		}
+
+		[Test]
+		public void BinPathExists()
+		{
+			string path = MonoDroidSdk.BinPath;
+			Assert.IsTrue(Directory.Exists(path), path + " does not exist!"); 
+		}
+
+		[Test]
+		public void FrameworkPathExists()
+		{
+			string path = MonoDroidSdk.FrameworkPath;
+			Assert.IsTrue(Directory.Exists(path), path + " does not exist!");
+		}
+
+		[Test]
+		public void RuntimePathExists()
+		{
+			string path = MonoDroidSdk.RuntimePath;
+			Assert.IsTrue(Directory.Exists(path), path + " does not exist!");
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.Tests/MonoDroidSdkTests.cs
+++ b/src/Xamarin.Android.Tools.Tests/MonoDroidSdkTests.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Android.Tools.Tests
 	class MonoDroidSdkTests
 	{
 		[TestFixtureSetUp]
-		public void FixtureSetUp()
+		public void FixtureSetUp ()
 		{
 			AndroidLogger.Info += OnInfo;
 			AndroidLogger.Warning += OnWarning;
@@ -16,54 +16,54 @@ namespace Xamarin.Android.Tools.Tests
 		}
 
 		[TestFixtureTearDown]
-		public void FixtureTearDown()
+		public void FixtureTearDown ()
 		{
 			AndroidLogger.Info -= OnInfo;
 			AndroidLogger.Warning -= OnWarning;
 			AndroidLogger.Error -= OnError;
 		}
 
-		void OnInfo(string task, string message)
+		void OnInfo (string task, string message)
 		{
-			Debug.WriteLine(task + ": " + message);
+			Debug.WriteLine (task + ": " + message);
 		}
 
-		void OnWarning(string task, string message)
+		void OnWarning (string task, string message)
 		{
-			Assert.Fail(task + ": " + message);
+			Assert.Fail (task + ": " + message);
 		}
 
-		void OnError(string task, string message)
+		void OnError (string task, string message)
 		{
-			Assert.Fail(task + ": " + message);
+			Assert.Fail (task + ": " + message);
 		}
 
 		[Test]
-		public void RefreshWithoutParameters()
+		public void RefreshWithoutParameters ()
 		{
 			//Just checking for exceptions, or AndroidLogger
-			MonoDroidSdk.Refresh();
+			MonoDroidSdk.Refresh ();
 		}
 
 		[Test]
-		public void BinPathExists()
+		public void BinPathExists ()
 		{
 			string path = MonoDroidSdk.BinPath;
-			Assert.IsTrue(Directory.Exists(path), path + " does not exist!"); 
+			Assert.IsTrue (Directory.Exists (path), path + " does not exist!");
 		}
 
 		[Test]
-		public void FrameworkPathExists()
+		public void FrameworkPathExists ()
 		{
 			string path = MonoDroidSdk.FrameworkPath;
-			Assert.IsTrue(Directory.Exists(path), path + " does not exist!");
+			Assert.IsTrue (Directory.Exists (path), path + " does not exist!");
 		}
 
 		[Test]
-		public void RuntimePathExists()
+		public void RuntimePathExists ()
 		{
 			string path = MonoDroidSdk.RuntimePath;
-			Assert.IsTrue(Directory.Exists(path), path + " does not exist!");
+			Assert.IsTrue (Directory.Exists (path), path + " does not exist!");
 		}
 	}
 }

--- a/src/Xamarin.Android.Tools.Tests/Properties/AssemblyInfo.cs
+++ b/src/Xamarin.Android.Tools.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+﻿using System.Reflection;
+
+[assembly: AssemblyTitle("Xamarin.Android.Tools.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Xamarin.Android.Tools.Tests")]
+[assembly: AssemblyCopyright("Copyright © Xamarin 2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Xamarin.Android.Tools.Tests/Xamarin.Android.Tools.Tests.csproj
+++ b/src/Xamarin.Android.Tools.Tests/Xamarin.Android.Tools.Tests.csproj
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1E5501E8-49C1-4659-838D-CC9720C5208F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Xamarin.Android.Tools.Tests</RootNamespace>
+    <AssemblyName>Xamarin.Android.Tools.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MonoDroidSdkTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Xamarin.Android.Tools\Xamarin.Android.Tools.csproj">
+      <Project>{e34bcfa0-caa4-412c-aa1c-75db8d67d157}</Project>
+      <Name>Xamarin.Android.Tools</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/Xamarin.Android.Tools.Tests/packages.config
+++ b/src/Xamarin.Android.Tools.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+</packages>

--- a/src/Xamarin.Android.Tools.sln
+++ b/src/Xamarin.Android.Tools.sln
@@ -1,7 +1,8 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.Tools", "Xamarin.Android.Tools/Xamarin.Android.Tools.csproj", "{91713046-C358-4647-B162-ED4E1442F3D8}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.Tools", "Xamarin.Android.Tools\Xamarin.Android.Tools.csproj", "{E34BCFA0-CAA4-412C-AA1C-75DB8D67D157}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.Tools.Tests", "Xamarin.Android.Tools.Tests\Xamarin.Android.Tools.Tests.csproj", "{1E5501E8-49C1-4659-838D-CC9720C5208F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -9,9 +10,16 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{91713046-C358-4647-B162-ED4E1442F3D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{91713046-C358-4647-B162-ED4E1442F3D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{91713046-C358-4647-B162-ED4E1442F3D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{91713046-C358-4647-B162-ED4E1442F3D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E34BCFA0-CAA4-412C-AA1C-75DB8D67D157}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E34BCFA0-CAA4-412C-AA1C-75DB8D67D157}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E34BCFA0-CAA4-412C-AA1C-75DB8D67D157}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E34BCFA0-CAA4-412C-AA1C-75DB8D67D157}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E5501E8-49C1-4659-838D-CC9720C5208F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E5501E8-49C1-4659-838D-CC9720C5208F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E5501E8-49C1-4659-838D-CC9720C5208F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E5501E8-49C1-4659-838D-CC9720C5208F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkBase.cs
@@ -108,8 +108,7 @@ namespace Xamarin.Android.Tools
 			return !string.IsNullOrWhiteSpace (loc) &&
 				(File.Exists (Path.Combine (loc, DebugRuntime)) ||    // Normal/expected
 				 File.Exists (Path.Combine (loc, ClassParseExe)) ||    // Normal/expected
-					File.Exists (Path.Combine (loc, "Ionic.Zip.dll")) || // Wrench builds
-					File.Exists (Path.Combine (loc, "Xamarin.Android.Common.targets"))); //VS on Windows
+				 File.Exists (Path.Combine (loc, "Xamarin.Android.Common.targets"))); //VS on Windows
 		}
 
 		protected static bool ValidateFramework (string loc)

--- a/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkBase.cs
@@ -108,7 +108,8 @@ namespace Xamarin.Android.Tools
 			return !string.IsNullOrWhiteSpace (loc) &&
 				(File.Exists (Path.Combine (loc, DebugRuntime)) ||    // Normal/expected
 				 File.Exists (Path.Combine (loc, ClassParseExe)) ||    // Normal/expected
-					File.Exists (Path.Combine (loc, "Ionic.Zip.dll")));  // Wrench builds
+					File.Exists (Path.Combine (loc, "Ionic.Zip.dll")) || // Wrench builds
+					File.Exists (Path.Combine (loc, "Xamarin.Android.Common.targets"))); //VS on Windows
 		}
 
 		protected static bool ValidateFramework (string loc)

--- a/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkWindows.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;
+using System.Diagnostics;
 
 namespace Xamarin.Android.Tools
 {
@@ -18,19 +19,36 @@ namespace Xamarin.Android.Tools
 			string xamarinSdk = Path.Combine (OS.ProgramFilesX86, "MSBuild", "Xamarin", "Android");
 			if (Directory.Exists(xamarinSdk))
 				return xamarinSdk;
-			xamarinSdk = Path.Combine(OS.ProgramFilesX86, "Microsoft Visual Studio", "2017");
-			if (Directory.Exists(xamarinSdk))
-			{
-				xamarinSdk = Directory.GetDirectories(xamarinSdk).FirstOrDefault();
-				if (!string.IsNullOrEmpty(xamarinSdk))
-				{
-					xamarinSdk = Path.Combine(xamarinSdk, "MSBuild", "Xamarin", "Android");
-					if (Directory.Exists(xamarinSdk))
-						return xamarinSdk;
-				}
-			}
-
+			if (TryVSWhere(out xamarinSdk))
+				return xamarinSdk;
 			return OS.ProgramFilesX86 + @"\MSBuild\Novell";
+		}
+
+		bool TryVSWhere(out string xamarinSdk)
+		{
+			xamarinSdk = null;
+
+			//Docs on this tool here: https://github.com/Microsoft/vswhere
+			string vswhere = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Microsoft Visual Studio", "Installer", "vswhere.exe");
+			if (!File.Exists(vswhere))
+				return false;
+
+			//VS Workload ID here: https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-community
+			var p = Process.Start(new ProcessStartInfo
+			{
+				FileName = vswhere,
+				Arguments = "-latest -requires Component.Xamarin -property installationPath",
+				RedirectStandardError = true,
+				RedirectStandardOutput = true,
+				UseShellExecute = false,
+			});
+			p.WaitForExit();
+
+			if (p.ExitCode != 0)
+				return false;
+
+			xamarinSdk = Path.Combine(p.StandardOutput.ReadToEnd().Trim(), "MSBuild", "Xamarin", "Android");
+			return true;
 		}
 
 		static readonly string[] RuntimeToFrameworkPaths = new []{

--- a/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkWindows.cs
@@ -12,6 +12,7 @@ namespace Xamarin.Android.Tools
 			Path.Combine (OS.ProgramFilesX86, "Microsoft Visual Studio", "2017", "Enterprise"),
 			Path.Combine (OS.ProgramFilesX86, "Microsoft Visual Studio", "2017", "Professional"),
 			Path.Combine (OS.ProgramFilesX86, "Microsoft Visual Studio", "2017", "Community"),
+			Path.Combine (OS.ProgramFilesX86, "MSBuild", "Xamarin", "Android"), //VS older than 2017
 		};
 
 		protected override string FindRuntime ()
@@ -22,15 +23,11 @@ namespace Xamarin.Android.Tools
 					return monoAndroidPath;
 			}
 
-			string xamarinSdk = Path.Combine (OS.ProgramFilesX86, "MSBuild", "Xamarin", "Android");
-			if (Directory.Exists(xamarinSdk))
-				return xamarinSdk;
-
 			foreach (var vsPath in VisualStudioPaths) {
-				if (string.IsNullOrEmpty(vsPath))
+				if (string.IsNullOrEmpty (vsPath))
 					continue;
-				xamarinSdk = Path.Combine(vsPath, "MSBuild", "Xamarin", "Android");
-				if (Directory.Exists(xamarinSdk) && ValidateRuntime(xamarinSdk))
+				var xamarinSdk = Path.Combine (vsPath, "MSBuild", "Xamarin", "Android");
+				if (Directory.Exists (xamarinSdk) && ValidateRuntime (xamarinSdk))
 					return xamarinSdk;
 			}
 			return OS.ProgramFilesX86 + @"\MSBuild\Novell";

--- a/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkWindows.cs
@@ -14,10 +14,23 @@ namespace Xamarin.Android.Tools
 				if (Directory.Exists (monoAndroidPath) && ValidateRuntime (monoAndroidPath))
 					return monoAndroidPath;
 			}
+
 			string xamarinSdk = Path.Combine (OS.ProgramFilesX86, "MSBuild", "Xamarin", "Android");
-			return Directory.Exists (xamarinSdk)
-				? xamarinSdk
-					: OS.ProgramFilesX86 + @"\MSBuild\Novell";
+			if (Directory.Exists(xamarinSdk))
+				return xamarinSdk;
+			xamarinSdk = Path.Combine(OS.ProgramFilesX86, "Microsoft Visual Studio", "2017");
+			if (Directory.Exists(xamarinSdk))
+			{
+				xamarinSdk = Directory.GetDirectories(xamarinSdk).FirstOrDefault();
+				if (!string.IsNullOrEmpty(xamarinSdk))
+				{
+					xamarinSdk = Path.Combine(xamarinSdk, "MSBuild", "Xamarin", "Android");
+					if (Directory.Exists(xamarinSdk))
+						return xamarinSdk;
+				}
+			}
+
+			return OS.ProgramFilesX86 + @"\MSBuild\Novell";
 		}
 
 		static readonly string[] RuntimeToFrameworkPaths = new []{

--- a/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools/Sdks/MonoDroidSdkWindows.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Tools
 			Path.Combine (OS.ProgramFilesX86, "Microsoft Visual Studio", "2017", "Enterprise"),
 			Path.Combine (OS.ProgramFilesX86, "Microsoft Visual Studio", "2017", "Professional"),
 			Path.Combine (OS.ProgramFilesX86, "Microsoft Visual Studio", "2017", "Community"),
-			Path.Combine (OS.ProgramFilesX86, "MSBuild", "Xamarin", "Android"), //VS older than 2017
+			Path.Combine (OS.ProgramFilesX86), //VS older than 2017, MSBuild\Xamarin\Android is located in C:\Program Files (x86)\
 		};
 
 		protected override string FindRuntime ()


### PR DESCRIPTION
- Included a unit test project with smoke tests (I just used 2.x NUnit). These are passing on my Windows machine with VS 2017.
~~- Uses [vswhere](https://github.com/Microsoft/vswhere) to locate a VS 2017 installation that includes Xamarin. I think this is the preferred method for locating VS 2017 now.~~
- Looks for VS 2017 in known locations