### PR TITLE
Add AndroidVersions

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdk.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdk.cs
@@ -20,13 +20,7 @@ namespace Xamarin.Android.Tools
 				sdk.Initialize (androidSdkPath ?? sdk.PreferedAndroidSdkPath, androidNdkPath ?? sdk.PreferedAndroidNdkPath,
 					javaSdkPath ?? sdk.PreferedJavaSdkPath);
 				if (IsInstalled) {
-					var levels = GetInstalledPlatformVersions ().Select (l => l.ApiLevel.ToString ()).ToArray ();
-					string levelList;
-					if (levels == null || levels.Length == 0)
-						levelList = "(none)";
-					else
-						levelList = string.Join (", ", levels);
-					AndroidLogger.LogInfo (null, "Found Android SDK. API levels: {0}", levelList);
+					AndroidLogger.LogInfo (null, "Found Android SDK.");
 				} else {
 					AndroidLogger.LogInfo (null, "Did not find Android SDK");
 				}
@@ -80,13 +74,6 @@ namespace Xamarin.Android.Tools
 			return null;
 		}
 
-		// it was useful when android-21 was android-L, or android-23 was android-MNC.
-		// We will use this when similar preview release is out.
-		static string ToApiName (int apiLevel)
-		{
-			return apiLevel.ToString ();
-		}
-
 		static string ValidatePath (string path)
 		{
 			if (String.IsNullOrEmpty (path))
@@ -96,30 +83,33 @@ namespace Xamarin.Android.Tools
 
 		public static string GetPlatformDirectory (int apiLevel)
 		{
-			return Path.Combine (AndroidSdkPath, "platforms", "android-" + ToApiName (apiLevel));
+			return GetPlatformDirectoryFromId (apiLevel.ToString ());
 		}
 
-		public static string GetPlatformDirectory (string osVersion)
+		public static string GetPlatformDirectoryFromId (string id)
 		{
-			var level = AndroidVersion.TryOSVersionToApiLevel (osVersion);
-			if (level == 0)
-				return null;
-			return GetPlatformDirectory (level);
+			return Path.Combine (AndroidSdkPath, "platforms", "android-" + id);
+		}
+
+		public static string TryGetPlatformDirectoryFromApiLevel (string apiLevel, AndroidVersions versions)
+		{
+			var id  = versions.GetIdFromApiLevel (apiLevel);
+			var dir = GetPlatformDirectoryFromId (id);
+
+			if (Directory.Exists (dir))
+				return dir;
+
+			var level   = versions.GetApiLevelFromId (id);
+			dir         = level.HasValue ? GetPlatformDirectory (level.Value) : null;
+			if (dir != null && Directory.Exists (dir))
+				return dir;
+
+			return null;
 		}
 
 		public static bool IsPlatformInstalled (int apiLevel)
 		{
 			return apiLevel != 0 && Directory.Exists (GetPlatformDirectory (apiLevel));
-		}
-
-		public static IEnumerable<AndroidVersion> GetInstalledPlatformVersions ()
-		{
-			var knownAndInstalledSdkLevels = AndroidVersion.KnownVersions.Where (v => IsPlatformInstalled (v.ApiLevel));
-
-			return knownAndInstalledSdkLevels.Where (version => {
-				var apiLevel = MonoDroidSdk.GetApiLevelForFrameworkVersion (version.OSVersion);
-				return MonoDroidSdk.IsSupportedFrameworkLevel (apiLevel);
-			});
 		}
 
 		public static bool IsInstalled {

--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Xamarin.Android.Tools
+{
+	public class AndroidVersions
+	{
+		List<AndroidVersion>                installedVersions = new List<AndroidVersion> ();
+
+		public  IReadOnlyList<string>       FrameworkDirectories            { get; }
+		public  AndroidVersion              MaxStableVersion                { get; private set; }
+
+		public AndroidVersions (IEnumerable<string> frameworkDirectories)
+		{
+			if (frameworkDirectories == null)
+				throw new ArgumentNullException (nameof (frameworkDirectories));
+
+			var dirs    = new List<string> ();
+
+			foreach (var d in frameworkDirectories) {
+				if (!Directory.Exists (d))
+					throw new ArgumentException ($"`{d}` must be a directory!", nameof (frameworkDirectories));
+
+				var dp  = d.TrimEnd (Path.DirectorySeparatorChar);
+				var dn  = Path.GetFileName (dp);
+				// In "normal" use, `dp` will contain e.g. `...\MonoAndroid\v1.0`.
+				// We want the `MonoAndroid` dir, not the versioned dir.
+				var p   = dn.StartsWith ("v", StringComparison.Ordinal) ? Path.GetDirectoryName (dp) : dp;
+				dirs.Add (Path.GetFullPath (p));
+			}
+
+			dirs    = dirs.Distinct (StringComparer.OrdinalIgnoreCase)
+				.ToList ();
+
+			FrameworkDirectories    = new ReadOnlyCollection<string> (dirs);
+
+			var versions = dirs.SelectMany (d => Directory.EnumerateFiles (d, "AndroidApiInfo.xml", SearchOption.AllDirectories))
+				.Select (file => AndroidVersion.Load (file));
+
+			LoadVersions (versions);
+		}
+
+		public AndroidVersions (IEnumerable<AndroidVersion> versions)
+		{
+			if (versions == null)
+				throw new ArgumentNullException (nameof (versions));
+
+			FrameworkDirectories    = new ReadOnlyCollection<string> (new string [0]);
+
+			LoadVersions (versions);
+		}
+
+		void LoadVersions (IEnumerable<AndroidVersion> versions)
+		{
+			foreach (var version in versions) {
+				installedVersions.Add (version);
+				if (MaxStableVersion == null || (version.Stable && MaxStableVersion.TargetFrameworkVersion < version.TargetFrameworkVersion)) {
+					MaxStableVersion    = version;
+				}
+			}
+		}
+
+		public int? GetApiLevelFromFrameworkVersion (string frameworkVersion)
+		{
+			return installedVersions.FirstOrDefault (v => v.FrameworkVersion == frameworkVersion)?.ApiLevel ??
+				KnownVersions.FirstOrDefault (v => v.FrameworkVersion == frameworkVersion)?.ApiLevel;
+		}
+
+		public int? GetApiLevelFromId (string id)
+		{
+			return installedVersions.FirstOrDefault (v => MatchesId (v, id))?.ApiLevel ??
+				KnownVersions.FirstOrDefault (v => MatchesId (v, id))?.ApiLevel;
+		}
+
+		static bool MatchesId (AndroidVersion version, string id)
+		{
+			return version.Id == id ||
+				(version.AlternateIds?.Contains (id) ?? false) ||
+				(version.ApiLevel.ToString () == id);
+		}
+
+		public string GetIdFromApiLevel (int apiLevel)
+		{
+			return installedVersions.FirstOrDefault (v => v.ApiLevel == apiLevel)?.Id ??
+				KnownVersions.FirstOrDefault (v => v.ApiLevel == apiLevel)?.Id;
+		}
+
+		// Sometimes, e.g. when new API levels are introduced, the "API level" is a letter, not a number,
+		// e.g. 'API-H' for API-11, 'API-O' for API-26, etc.
+		public string GetIdFromApiLevel (string apiLevel)
+		{
+			if (int.TryParse (apiLevel, out var platform))
+				return GetIdFromApiLevel (platform);
+			return installedVersions.FirstOrDefault (v => MatchesId (v, apiLevel))?.Id ??
+				KnownVersions.FirstOrDefault (v => MatchesId (v, apiLevel))?.Id;
+		}
+
+		public string GetIdFromFrameworkVersion (string frameworkVersion)
+		{
+			return installedVersions.FirstOrDefault (v => v.FrameworkVersion == frameworkVersion)?.Id ??
+				KnownVersions.FirstOrDefault (v => v.FrameworkVersion == frameworkVersion)?.Id;
+		}
+
+		public string GetFrameworkVersionFromApiLevel (int apiLevel)
+		{
+			return installedVersions.FirstOrDefault (v => v.ApiLevel == apiLevel)?.FrameworkVersion ??
+				KnownVersions.FirstOrDefault (v => v.ApiLevel == apiLevel)?.FrameworkVersion;
+		}
+
+		public string GetFrameworkVersionFromId (string id)
+		{
+			return installedVersions.FirstOrDefault (v => MatchesId (v, id))?.FrameworkVersion ??
+				KnownVersions.FirstOrDefault (v => MatchesId (v, id))?.FrameworkVersion;
+		}
+
+		static readonly AndroidVersion [] KnownVersions = new [] {
+			new AndroidVersion (4,  "1.6",   "Donut"),
+			new AndroidVersion (5,  "2.0",   "Eclair"),
+			new AndroidVersion (6,  "2.0.1", "Eclair"),
+			new AndroidVersion (7,  "2.1",   "Eclair"),
+			new AndroidVersion (8,  "2.2",   "Froyo"),
+			new AndroidVersion (10, "2.3",   "Gingerbread"),
+			new AndroidVersion (11, "3.0",   "Honeycomb") {
+				AlternateIds = new[]{ "H" },
+			},
+			new AndroidVersion (12, "3.1",   "Honeycomb"),
+			new AndroidVersion (13, "3.2",   "Honeycomb"),
+			new AndroidVersion (14, "4.0",   "Ice Cream Sandwich"),
+			new AndroidVersion (15, "4.0.3", "Ice Cream Sandwich"),
+			new AndroidVersion (16, "4.1",   "Jelly Bean"),
+			new AndroidVersion (17, "4.2",   "Jelly Bean"),
+			new AndroidVersion (18, "4.3",   "Jelly Bean"),
+			new AndroidVersion (19, "4.4",   "Kit Kat"),
+			new AndroidVersion (20, "4.4.87", "Kit Kat + Wear support"),
+			new AndroidVersion (21, "5.0",   "Lollipop") {
+				AlternateIds = new[]{ "L" },
+			},
+			new AndroidVersion (22, "5.1",   "Lollipop"),
+			new AndroidVersion (23, "6.0",   "Marshmallow") {
+				AlternateIds = new[]{ "M" },
+			},
+			new AndroidVersion (24, "7.0",   "Nougat") {
+				AlternateIds = new[]{ "N" },
+			},
+			new AndroidVersion (25, "7.1",   "Nougat"),
+			new AndroidVersion (26, "8.0",   "Oreo") {
+				AlternateIds = new[]{ "O" },
+			},
+		};
+	}
+
+	class EqualityComparer<T> : IEqualityComparer<T>
+	{
+		Func<T, T, bool>    equals;
+		Func<T, int>        getHashCode;
+
+		public EqualityComparer (Func<T, T, bool> equals, Func<T, int> getHashCode = null)
+		{
+			this.equals         = equals;
+			this.getHashCode    = getHashCode ?? (v => v.GetHashCode ());
+		}
+
+		public bool Equals (T x, T y)
+		{
+			return equals (x, y);
+		}
+
+		public int GetHashCode (T obj)
+		{
+			return getHashCode (obj);
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/MonoDroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/MonoDroidSdkBase.cs
@@ -242,7 +242,7 @@ namespace Xamarin.Android.Tools
 
 		readonly Dictionary<Version, string>  SupportedFrameworks = new Dictionary<Version, string> ();
 
-		static readonly Dictionary<Version, string> FrameworkToApiLevels = new Dictionary<Version, string> (AndroidVersion.KnownVersions.ToDictionary<AndroidVersion, Version, string> (k => k.Version, v => v.ApiLevel.ToString ()));
+		static readonly Dictionary<Version, string> FrameworkToApiLevels = new Dictionary<Version, string> ();
 		static readonly Dictionary<Version, string> LegacyFrameworkToApiLevels = new Dictionary<Version, string> {
 			{ new Version (4, 5), "21" } // L Preview
 		};

--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidVersionTests.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidVersionTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+using NUnit.Framework;
+
+namespace Xamarin.Android.Tools.Tests
+{
+	[TestFixture]
+	public class AndroidVersionTests
+	{
+		[Test]
+		public void Constructor_Exceptions ()
+		{
+			Assert.Throws<ArgumentNullException> (() => new AndroidVersion (0, null));
+			Assert.Throws<ArgumentException> (() => new AndroidVersion (0, "not a number"));
+		}
+
+		[Test]
+		public void Constructor ()
+		{
+			var v   = new AndroidVersion (apiLevel: 1, osVersion: "2.3", codeName: "Four", id: "E", stable: false);
+			Assert.AreEqual (1,                     v.ApiLevel);
+			Assert.AreEqual ("E",                   v.Id);
+			Assert.AreEqual ("Four",                v.CodeName);
+			Assert.AreEqual ("2.3",                 v.OSVersion);
+			Assert.AreEqual (new Version (2, 3),    v.TargetFrameworkVersion);
+			Assert.AreEqual ("v2.3",                v.FrameworkVersion);
+			Assert.AreEqual (false,                 v.Stable);
+		}
+
+		[Test]
+		public void Load_NoFile ()
+		{
+			Assert.Throws<ArgumentNullException> (() => AndroidVersion.Load ((string) null));
+
+			var p   = Path.GetTempFileName ();
+			File.Delete (p);
+			Assert.Throws<FileNotFoundException> (() => AndroidVersion.Load (p));
+		}
+
+		[Test]
+		public void Load_NoStream ()
+		{
+			Assert.Throws<ArgumentNullException> (() => AndroidVersion.Load ((Stream) null));
+		}
+
+		[Test]
+		public void Load ()
+		{
+			var xml = @"<AndroidApiInfo>
+  <Id>O</Id>
+  <Level>26</Level>
+  <Name>Android O</Name>
+  <Version>v7.99.0</Version>
+  <Stable>False</Stable>
+</AndroidApiInfo>";
+			var v   = AndroidVersion.Load (new MemoryStream (Encoding.UTF8.GetBytes (xml)));
+			Assert.AreEqual (26,                        v.ApiLevel);
+			Assert.AreEqual ("O",                       v.Id);
+			Assert.AreEqual ("Android O",               v.CodeName);
+			Assert.AreEqual ("7.99.0",                  v.OSVersion);
+			Assert.AreEqual (new Version (7, 99, 0),    v.TargetFrameworkVersion);
+			Assert.AreEqual ("v7.99.0",                 v.FrameworkVersion);
+			Assert.AreEqual (false,                     v.Stable);
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidVersionsTests.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidVersionsTests.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+using NUnit.Framework;
+
+namespace Xamarin.Android.Tools.Tests
+{
+	[TestFixture]
+	public class AndroidVersionsTests
+	{
+		[Test]
+		public void Constructor_Exceptions ()
+		{
+			Assert.Throws<ArgumentNullException> (() => new AndroidVersions ((IEnumerable<string>) null));
+			Assert.Throws<ArgumentNullException> (() => new AndroidVersions ((IEnumerable<AndroidVersion>) null));
+
+			var tempDir = Path.GetTempFileName ();
+			File.Delete (tempDir);
+			// Directory not found
+			Assert.Throws<ArgumentException>(() => new AndroidVersions (new[]{tempDir}));
+		}
+
+		[Test]
+		public void Constructor_NoDirectories ()
+		{
+			var versions    = new AndroidVersions (new string [0]);
+			Assert.AreEqual (null,  versions.MaxStableVersion);
+			Assert.IsNotNull (versions.FrameworkDirectories);
+			Assert.AreEqual (0,     versions.FrameworkDirectories.Count);
+		}
+
+		[Test]
+		public void Constructor_NoVersions ()
+		{
+			var versions    = new AndroidVersions (new AndroidVersion [0]);
+			Assert.AreEqual (null,  versions.MaxStableVersion);
+			Assert.IsNotNull (versions.FrameworkDirectories);
+			Assert.AreEqual (0,     versions.FrameworkDirectories.Count);
+		}
+
+		[Test]
+		public void Constructor_FrameworkDirectories ()
+		{
+			var frameworkDir    = Path.GetTempFileName ();
+			File.Delete (frameworkDir);
+			Directory.CreateDirectory (frameworkDir);
+			try {
+				Directory.CreateDirectory (Path.Combine (frameworkDir, "MonoAndroid"));
+				Directory.CreateDirectory (Path.Combine (frameworkDir, "MonoAndroid", "v6.0"));
+				File.WriteAllLines (Path.Combine (frameworkDir, "MonoAndroid", "v6.0", "AndroidApiInfo.xml"), new []{
+					"<AndroidApiInfo>",
+					"  <Id>23</Id>",
+					"  <Level>23</Level>",
+					"  <Name>Marshmallow</Name>",
+					"  <Version>v6.0</Version>",
+					"  <Stable>True</Stable>",
+					"</AndroidApiInfo>",
+				});
+				Directory.CreateDirectory (Path.Combine (frameworkDir, "MonoAndroid", "v8.0"));
+				File.WriteAllLines (Path.Combine (frameworkDir, "MonoAndroid", "v8.0", "AndroidApiInfo.xml"), new []{
+					"<AndroidApiInfo>",
+					"  <Id>O</Id>",
+					"  <Level>26</Level>",
+					"  <Name>Oreo</Name>",
+					"  <Version>v8.0</Version>",
+					"  <Stable>False</Stable>",
+					"</AndroidApiInfo>",
+				});
+				var versions    = new AndroidVersions (new [] { Path.Combine (frameworkDir, "MonoAndroid", "v6.0") });
+				Assert.IsNotNull (versions.FrameworkDirectories);
+				Assert.AreEqual (1,     versions.FrameworkDirectories.Count);
+				Assert.AreEqual (Path.Combine (frameworkDir, "MonoAndroid"), versions.FrameworkDirectories [0]);
+				Assert.IsNotNull (versions.MaxStableVersion);
+				Assert.AreEqual (23,    versions.MaxStableVersion.ApiLevel);
+			}
+			finally {
+				Directory.Delete (frameworkDir, recursive: true);
+			}
+		}
+
+		[Test]
+		public void Constructor_Versions ()
+		{
+			var versions = new AndroidVersions (new []{
+				new AndroidVersion (apiLevel: 1, osVersion: "1.0", codeName: "One",     id: "A", stable: true),
+				new AndroidVersion (apiLevel: 2, osVersion: "1.1", codeName: "One.One", id: "B", stable: true),
+			});
+			Assert.IsNotNull (versions.FrameworkDirectories);
+			Assert.AreEqual (0,     versions.FrameworkDirectories.Count);
+			Assert.IsNotNull (versions.MaxStableVersion);
+			Assert.AreEqual (2,     versions.MaxStableVersion.ApiLevel);
+		}
+
+		static AndroidVersions CreateTestVersions ()
+		{
+			return new AndroidVersions (new []{
+				new AndroidVersion (apiLevel: 1,    osVersion: "1.0",   id: "A",    stable: true),
+				new AndroidVersion (apiLevel: 2,    osVersion: "1.1",   id: "B",    stable: false),
+				new AndroidVersion (apiLevel: 3,    osVersion: "1.2",   id: "C",    stable: true),
+				// Hides/shadows a Known Version
+				new AndroidVersion (apiLevel: 14,   osVersion: "4.0",   id: "II",   stable: false),
+			});
+		}
+
+		[Test]
+		public void GetApiLevelFromFrameworkVersion ()
+		{
+			var versions    = CreateTestVersions ();
+
+			Assert.AreEqual (null,  versions.GetApiLevelFromFrameworkVersion (null));
+			Assert.AreEqual (1,     versions.GetApiLevelFromFrameworkVersion ("v1.0"));
+			Assert.AreEqual (2,     versions.GetApiLevelFromFrameworkVersion ("v1.1"));
+			Assert.AreEqual (3,     versions.GetApiLevelFromFrameworkVersion ("v1.2"));
+			Assert.AreEqual (null,  versions.GetApiLevelFromFrameworkVersion ("v1.3"));
+			Assert.AreEqual (14,    versions.GetApiLevelFromFrameworkVersion ("v4.0"));
+
+			// via KnownVersions
+			Assert.AreEqual (4,     versions.GetApiLevelFromFrameworkVersion ("v1.6"));
+		}
+
+		[Test]
+		public void GetApiLevelFromId ()
+		{
+			var versions    = CreateTestVersions ();
+
+			Assert.AreEqual (null,  versions.GetApiLevelFromId (null));
+			Assert.AreEqual (1,     versions.GetApiLevelFromId ("A"));
+			Assert.AreEqual (1,     versions.GetApiLevelFromId ("1"));
+			Assert.AreEqual (2,     versions.GetApiLevelFromId ("B"));
+			Assert.AreEqual (2,     versions.GetApiLevelFromId ("2"));
+			Assert.AreEqual (3,     versions.GetApiLevelFromId ("C"));
+			Assert.AreEqual (3,     versions.GetApiLevelFromId ("3"));
+			Assert.AreEqual (14,    versions.GetApiLevelFromId ("14"));
+			Assert.AreEqual (14,    versions.GetApiLevelFromId ("II"));
+
+			Assert.AreEqual (null,  versions.GetApiLevelFromId ("D"));
+
+			// via KnownVersions
+			Assert.AreEqual (11,    versions.GetApiLevelFromId ("H"));
+		}
+
+		[Test]
+		public void GetIdFromApiLevel ()
+		{
+			var versions    = CreateTestVersions ();
+
+			Assert.AreEqual (null,  versions.GetIdFromApiLevel (null));
+			Assert.AreEqual ("A",   versions.GetIdFromApiLevel (1));
+			Assert.AreEqual ("A",   versions.GetIdFromApiLevel ("1"));
+			Assert.AreEqual ("A",   versions.GetIdFromApiLevel ("A"));
+			Assert.AreEqual ("B",   versions.GetIdFromApiLevel (2));
+			Assert.AreEqual ("B",   versions.GetIdFromApiLevel ("2"));
+			Assert.AreEqual ("B",   versions.GetIdFromApiLevel ("B"));
+			Assert.AreEqual ("C",   versions.GetIdFromApiLevel (3));
+			Assert.AreEqual ("C",   versions.GetIdFromApiLevel ("3"));
+			Assert.AreEqual ("C",   versions.GetIdFromApiLevel ("C"));
+			Assert.AreEqual ("II",  versions.GetIdFromApiLevel ("14"));
+			Assert.AreEqual ("II",  versions.GetIdFromApiLevel ("II"));
+
+			Assert.AreEqual (null,  versions.GetIdFromApiLevel (-1));
+			Assert.AreEqual (null,  versions.GetIdFromApiLevel ("-1"));
+			Assert.AreEqual (null,  versions.GetIdFromApiLevel ("D"));
+
+			// via KnownVersions
+			Assert.AreEqual ("11",  versions.GetIdFromApiLevel (11));
+			Assert.AreEqual ("11",  versions.GetIdFromApiLevel ("11"));
+			Assert.AreEqual ("11",  versions.GetIdFromApiLevel ("H"));
+		}
+
+		[Test]
+		public void GetIdFromFrameworkVersion ()
+		{
+			var versions    = CreateTestVersions ();
+
+			Assert.AreEqual (null,  versions.GetIdFromFrameworkVersion (null));
+			Assert.AreEqual ("A",   versions.GetIdFromFrameworkVersion ("v1.0"));
+			Assert.AreEqual ("B",   versions.GetIdFromFrameworkVersion ("v1.1"));
+			Assert.AreEqual ("C",   versions.GetIdFromFrameworkVersion ("v1.2"));
+			Assert.AreEqual ("II",  versions.GetIdFromFrameworkVersion ("v4.0"));
+
+			Assert.AreEqual (null,  versions.GetIdFromFrameworkVersion ("0.99"));
+
+			// via KnownVersions
+			Assert.AreEqual ("10",  versions.GetIdFromFrameworkVersion ("v2.3"));
+		}
+
+		[Test]
+		public void GetFrameworkVersionFromApiLevel ()
+		{
+			var versions    = CreateTestVersions ();
+
+			Assert.AreEqual (null,      versions.GetFrameworkVersionFromApiLevel (0));
+			Assert.AreEqual ("v1.0",    versions.GetFrameworkVersionFromApiLevel (1));
+			Assert.AreEqual ("v1.1",    versions.GetFrameworkVersionFromApiLevel (2));
+			Assert.AreEqual ("v1.2",    versions.GetFrameworkVersionFromApiLevel (3));
+			Assert.AreEqual ("v4.0",    versions.GetFrameworkVersionFromApiLevel (14));
+
+			// via KnownVersions
+			Assert.AreEqual ("v2.3",    versions.GetFrameworkVersionFromApiLevel (10));
+		}
+
+		[Test]
+		public void GetFrameworkVersionFromId ()
+		{
+			var versions    = CreateTestVersions ();
+
+			Assert.AreEqual (null,      versions.GetFrameworkVersionFromId (null));
+			Assert.AreEqual ("v1.0",    versions.GetFrameworkVersionFromId ("1"));
+			Assert.AreEqual ("v1.0",    versions.GetFrameworkVersionFromId ("A"));
+			Assert.AreEqual ("v1.1",    versions.GetFrameworkVersionFromId ("2"));
+			Assert.AreEqual ("v1.1",    versions.GetFrameworkVersionFromId ("B"));
+			Assert.AreEqual ("v1.2",    versions.GetFrameworkVersionFromId ("3"));
+			Assert.AreEqual ("v1.2",    versions.GetFrameworkVersionFromId ("C"));
+			Assert.AreEqual ("v4.0",    versions.GetFrameworkVersionFromId ("14"));
+			Assert.AreEqual ("v4.0",    versions.GetFrameworkVersionFromId ("II"));
+
+			// via KnownVersions
+			Assert.AreEqual ("v3.0",    versions.GetFrameworkVersionFromId ("11"));
+			Assert.AreEqual ("v3.0",    versions.GetFrameworkVersionFromId ("H"));
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -41,6 +41,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AndroidVersionTests.cs" />
+    <Compile Include="AndroidVersionsTests.cs" />
     <Compile Include="MonoDroidSdkTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
@@ -40,6 +40,7 @@
     <Compile Include="OS.cs" />
     <Compile Include="MonoDroidSdk.cs" />
     <Compile Include="AndroidVersion.cs" />
+    <Compile Include="AndroidVersions.cs" />
     <Compile Include="AndroidSdk.cs" />
     <Compile Include="Sdks\MonoDroidSdkBase.cs" />
     <Compile Include="Sdks\MonoDroidSdkUnix.cs" />


### PR DESCRIPTION
Commit [xamarin-android/8e7d37bb][xa8e] contains a sign of
duplication: in order to use a `Mono.Android.dll` binding assembly,
not only do we need to *build* the binding assembly, but we *also*
need to update `Xamarin.Android.Build.Utilities.dll`/etc. to "know"
about the new binding version (to map API level to
`$(TargetFrameworkVersion)`).

[xa8e]: https://github.com/xamarin/xamarin-android/commit/8e7d37bb

Even "better" (worse), if the new API level is a *preview*, there is
no *consistent* API level. For example, with API-O, `android.jar`
isn't at:

	$(AndroidSdkDirectory)\platforms\android-@API_LEVEL@\android.jar

where `@API_LEVEL@` is 26 (because various codepaths require that the
"api level" be an integer). Instead, it's installed at:

	$(AndroidSdkDirectory)\platforms\android-O\android.jar

where `O` is the "id" of the preview API level.

This "id" is "leaky", in turn requiring that
`Xamarin.Android.Build.Tasks.dll` *also* be updated to deal with the
mappings.

Even "better" (worse), if we *forget* to cross all our our 't's and
dot all of our 'i's, we'll have a binding assembly which can't be
used. (Which is why we needed [xamarin-android/8e7d37bb][xe8e];
without it, the API-O binding can't be used!)

This is all obviously madness. ;-)

[xamarin-android/8942eca0][xa89] contains a fix:

[xa89]: https://github.com/xamarin/xamarin-android/commit/8942eca00a219882f48b5bccf11452f35ddbcaee

 1. The build system is updated to create a new `AndroidApiInfo.xml`
    file within the `$(TargetFrameworkVersion)` directory.
    This contains all the information needed to map Android API
    levels to Ids and Android OS versions and
    `$(TargetFrameworkVersion)` values:

    ```xml
    <AndroidApiInfo>
      <Id>10</Id>
      <Level>10</Level>
      <Name>Gingerbread</Name>
      <Version>v2.3</Version>
    </AndroidApiInfo>
    ```

 2. Add a new `Xamarin.Android.Build.Utilities.AndroidVersions` type
    was added which parses the `AndroidApiInfo.xml` files.

The advantage to all this is that we can support new API level
bindings by just building a new `Mono.Android.dll` and placing an
`AndroidApiInfo.xml` into the appropriate location (next to
`Mono.Android.dll`). No further code changes would be required.

This is all well and good...but it's not entirely useful if *only*
Xamarin.Android makes use of this functionality. The IDEs also need
to be updated to make use of these files.

Copy over `Xamarin.Android.Build.Utilities.AndroidVersions` into the
**xamarin-android-tools** repo as
`Xamarin.Android.Tools.AndroidVersions`, so that we have a path for
eventual IDE support of the new paradigm.