### PR TITLE
Look for the SDK entries in the correct registry key.

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -33,39 +33,49 @@ namespace Xamarin.Android.Tools
 		public override string PreferedAndroidSdkPath {
 			get {
 				var wow = RegistryEx.Wow64.Key32;
-				if (CheckRegistryKeyForExecutable (RegistryEx.CurrentUser, MDREG_KEY, MDREG_ANDROID_SDK, wow, "platform-tools", Adb))
-					return RegistryEx.GetValueString (RegistryEx.CurrentUser, MDREG_KEY, MDREG_ANDROID_SDK, wow);
+				var regKey = GetMDRegistryKey ();
+				if (CheckRegistryKeyForExecutable (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_SDK, wow, "platform-tools", Adb))
+					return RegistryEx.GetValueString (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_SDK, wow);
 				return null;
 			}
 		}
 		public override string PreferedAndroidNdkPath {
 			get {
 				var wow = RegistryEx.Wow64.Key32;
-				if (CheckRegistryKeyForExecutable (RegistryEx.CurrentUser, MDREG_KEY, MDREG_ANDROID_NDK, wow, ".", NdkStack))
-					return RegistryEx.GetValueString (RegistryEx.CurrentUser, MDREG_KEY, MDREG_ANDROID_NDK, wow);
+				var regKey = GetMDRegistryKey ();
+				if (CheckRegistryKeyForExecutable (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_NDK, wow, ".", NdkStack))
+					return RegistryEx.GetValueString (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_NDK, wow);
 				return null;
 			}
 		}
 		public override string PreferedJavaSdkPath {
 			get {
 				var wow = RegistryEx.Wow64.Key32;
-				if (CheckRegistryKeyForExecutable (RegistryEx.CurrentUser, MDREG_KEY, MDREG_JAVA_SDK, wow, "bin", JarSigner))
-					return RegistryEx.GetValueString (RegistryEx.CurrentUser, MDREG_KEY, MDREG_JAVA_SDK, wow);
+				var regKey = GetMDRegistryKey ();
+				if (CheckRegistryKeyForExecutable (RegistryEx.CurrentUser, regKey, MDREG_JAVA_SDK, wow, "bin", JarSigner))
+					return RegistryEx.GetValueString (RegistryEx.CurrentUser, regKey, MDREG_JAVA_SDK, wow);
 				return null;
 			}
+		}
+
+		string GetMDRegistryKey ()
+		{
+			var regKey = Environment.GetEnvironmentVariable ("XAMARIN_ANDROID_REGKEY");
+			return string.IsNullOrWhiteSpace (regKey) ? MDREG_KEY : regKey;
 		}
 
 		protected override IEnumerable<string> GetAllAvailableAndroidSdks ()
 		{
 			var roots = new[] { RegistryEx.CurrentUser, RegistryEx.LocalMachine };
 			var wow = RegistryEx.Wow64.Key32;
+			var regKey = GetMDRegistryKey ();
 
 			Logger (TraceLevel.Info, "Looking for Android SDK...");
 
 			// Check for the key the user gave us in the VS/addin options
 			foreach (var root in roots)
-				if (CheckRegistryKeyForExecutable (root, MDREG_KEY, MDREG_ANDROID_SDK, wow, "platform-tools", Adb))
-					yield return RegistryEx.GetValueString (root, MDREG_KEY, MDREG_ANDROID_SDK, wow);
+				if (CheckRegistryKeyForExecutable (root, regKey, MDREG_ANDROID_SDK, wow, "platform-tools", Adb))
+					yield return RegistryEx.GetValueString (root, regKey, MDREG_ANDROID_SDK, wow);
 
 			// Check for the key written by the Xamarin installer
 			if (CheckRegistryKeyForExecutable (RegistryEx.CurrentUser, XAMARIN_ANDROID_INSTALLER_PATH, XAMARIN_ANDROID_INSTALLER_KEY, wow, "platform-tools", Adb))
@@ -96,10 +106,11 @@ namespace Xamarin.Android.Tools
 			// check the user specified path
 			var roots = new[] { RegistryEx.CurrentUser, RegistryEx.LocalMachine };
 			const RegistryEx.Wow64 wow = RegistryEx.Wow64.Key32;
+			var regKey = GetMDRegistryKey ();
 
 			foreach (var root in roots) {
-				if (CheckRegistryKeyForExecutable (root, MDREG_KEY, MDREG_JAVA_SDK, wow, "bin", JarSigner))
-					return RegistryEx.GetValueString (root, MDREG_KEY, MDREG_JAVA_SDK, wow);
+				if (CheckRegistryKeyForExecutable (root, regKey, MDREG_JAVA_SDK, wow, "bin", JarSigner))
+					return RegistryEx.GetValueString (root, regKey, MDREG_JAVA_SDK, wow);
 			}
 
 			string subkey = @"SOFTWARE\JavaSoft\Java Development Kit";
@@ -135,13 +146,14 @@ namespace Xamarin.Android.Tools
 		{
 			var roots = new[] { RegistryEx.CurrentUser, RegistryEx.LocalMachine };
 			var wow = RegistryEx.Wow64.Key32;
+			var regKey = GetMDRegistryKey ();
 
 			Logger (TraceLevel.Info, "Looking for Android NDK...");
 
 			// Check for the key the user gave us in the VS/addin options
 			foreach (var root in roots)
-				if (CheckRegistryKeyForExecutable (root, MDREG_KEY, MDREG_ANDROID_NDK, wow, ".", NdkStack))
-					yield return RegistryEx.GetValueString (root, MDREG_KEY, MDREG_ANDROID_NDK, wow);
+				if (CheckRegistryKeyForExecutable (root, regKey, MDREG_ANDROID_NDK, wow, ".", NdkStack))
+					yield return RegistryEx.GetValueString (root, regKey, MDREG_ANDROID_NDK, wow);
 
 			/*
 			// Check for the key written by the Xamarin installer
@@ -169,17 +181,20 @@ namespace Xamarin.Android.Tools
 
 		public override void SetPreferredAndroidSdkPath (string path)
 		{
-			RegistryEx.SetValueString (RegistryEx.CurrentUser, MDREG_KEY, MDREG_ANDROID_SDK, path ?? "", RegistryEx.Wow64.Key32);
+			var regKey = GetMDRegistryKey ();
+			RegistryEx.SetValueString (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_SDK, path ?? "", RegistryEx.Wow64.Key32);
 		}
 
 		public override void SetPreferredJavaSdkPath (string path)
 		{
-			RegistryEx.SetValueString (RegistryEx.CurrentUser, MDREG_KEY, MDREG_JAVA_SDK, path ?? "", RegistryEx.Wow64.Key32);
+			var regKey = GetMDRegistryKey ();
+			RegistryEx.SetValueString (RegistryEx.CurrentUser, regKey, MDREG_JAVA_SDK, path ?? "", RegistryEx.Wow64.Key32);
 		}
 
 		public override void SetPreferredAndroidNdkPath (string path)
 		{
-			RegistryEx.SetValueString (RegistryEx.CurrentUser, MDREG_KEY, MDREG_ANDROID_NDK, path ?? "", RegistryEx.Wow64.Key32);
+			var regKey = GetMDRegistryKey ();
+			RegistryEx.SetValueString (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_NDK, path ?? "", RegistryEx.Wow64.Key32);
 		}
 
 		#region Helper Methods


### PR DESCRIPTION
We were looking for the saved VS SDK entires in the wrong
registry key. VS 2017 passes the registry key via the
`XAMARIN_ANDROID_REGKEY` environment variable.