### PR TITLE
Add AndroidVersions.InstalledBindingVersions property

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -70,6 +70,14 @@ namespace Xamarin.Android.Tools
 			return null;
 		}
 
+		public IEnumerable<AndroidVersion> GetInstalledPlatformVersions (AndroidVersions versions)
+		{
+			if (versions == null)
+				throw new ArgumentNullException (nameof (versions));
+			return versions.InstalledBindingVersions
+				.Where (p => TryGetPlatformDirectoryFromApiLevel (p.Id, versions) != null) ;
+		}
+
 		public string GetPlatformDirectory (int apiLevel)
 		{
 			return GetPlatformDirectoryFromId (apiLevel.ToString ());

--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
@@ -16,6 +16,8 @@ namespace Xamarin.Android.Tools
 		public  AndroidVersion              MaxStableVersion                { get; private set; }
 		public  AndroidVersion              MinStableVersion                { get; private set; }
 
+		public  IReadOnlyList<AndroidVersion>       InstalledBindingVersions    { get; private set; }
+
 		public AndroidVersions (IEnumerable<string> frameworkDirectories)
 		{
 			if (frameworkDirectories == null)
@@ -67,6 +69,8 @@ namespace Xamarin.Android.Tools
 					MinStableVersion = version;
 				}
 			}
+
+			InstalledBindingVersions    = new ReadOnlyCollection<AndroidVersion>(installedVersions);
 		}
 
 		public int? GetApiLevelFromFrameworkVersion (string frameworkVersion)


### PR DESCRIPTION
The `AndroidVersions.InstalledBindingVersions` property returns all
`AndroidVersion`s for which we have a `Mono.Android.dll` binding
assembly. (*Really*, it's for directories which contain an
`AndroidApiInfo.xml`, which we *assume* to mean that there is a
`Mono.Android.dll` binding assembly.)

This property and an associated
`AndroidSdkInfo.GetInstalledPlatformVersions()` method -- which
returns `AndroidVersion` information for all *installed* API levels
within the Android SDK -- allows the internal `androidtools` repo to
reimplement the `AndroidSdk.GetInstalledPlatformVersions()` and
related methods.