### PR TITLE
Allow AndroidSdkInfo.SetPreferred*Path() to work

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -15,9 +15,7 @@ namespace Xamarin.Android.Tools
 			if (logger == null)
 				throw new ArgumentNullException (nameof (logger));
 
-			sdk = OS.IsWindows
-				? (AndroidSdkBase) new AndroidSdkWindows (logger)
-				: (AndroidSdkBase) new AndroidSdkUnix (logger);
+			sdk = CreateSdk (logger);
 			sdk.Initialize (androidSdkPath, androidNdkPath, javaSdkPath);
 
 			// shouldn't happen, in that sdk.Initialize() should throw instead
@@ -25,6 +23,13 @@ namespace Xamarin.Android.Tools
 				throw new InvalidOperationException ($"Could not determine Android SDK location. Please provide `{nameof (androidSdkPath)}`.");
 			if (string.IsNullOrEmpty (JavaSdkPath))
 				throw new InvalidOperationException ($"Could not determine Java SDK location. Please provide `{nameof (javaSdkPath)}`.");
+		}
+
+		static AndroidSdkBase CreateSdk (Action<TraceLevel, string> logger)
+		{
+			return OS.IsWindows
+				? (AndroidSdkBase) new AndroidSdkWindows (logger)
+				: (AndroidSdkBase) new AndroidSdkUnix (logger);
 		}
 
 		public IEnumerable<string> GetBuildToolsPaths (string preferredBuildToolsVersion)
@@ -125,18 +130,39 @@ namespace Xamarin.Android.Tools
 			get { return sdk.NdkHostPlatform; }
 		}
 
-		public void SetPreferredAndroidNdkPath (string path)
+		public static void SetPreferredAndroidNdkPath (string path, Action<TraceLevel, string> logger = null)
 		{
+			logger  = logger ?? DefaultConsoleLogger;
+
+			var sdk = CreateSdk (logger);
 			sdk.SetPreferredAndroidNdkPath(path);
 		}
 
-		public void SetPreferredAndroidSdkPath (string path)
+		static void DefaultConsoleLogger (TraceLevel level, string message)
 		{
+			switch (level) {
+			case TraceLevel.Error:
+				Console.Error.WriteLine (message);
+				break;
+			default:
+				Console.WriteLine (message);
+				break;
+			}
+		}
+
+		public static void SetPreferredAndroidSdkPath (string path, Action<TraceLevel, string> logger = null)
+		{
+			logger  = logger ?? DefaultConsoleLogger;
+
+			var sdk = CreateSdk (logger);
 			sdk.SetPreferredAndroidSdkPath (path);
 		}
 
-		public void SetPreferredJavaSdkPath (string path)
+		public static void SetPreferredJavaSdkPath (string path, Action<TraceLevel, string> logger = null)
 		{
+			logger  = logger ?? DefaultConsoleLogger;
+
+			var sdk = CreateSdk (logger);
 			sdk.SetPreferredJavaSdkPath (path);
 		}
 	}


### PR DESCRIPTION
Commit f13889c0 added `AndroidSdkInfo.SetPreferredAndroidNdkPath()`,
`AndroidSdkInfo.SetPreferredAndroidSdkPath()`, and
`AndroidSdkInfo.SetPreferredJavaSdkPath()`.

The problem is, these methods are not usable in all scenarios.

The purpose of these methods is to allow e.g. the IDE to allow the
developer to alter the preferred Android NDK, SDK, or JDK paths.
Implicit in this purpose is that the *existing* paths may be invalid.

Thus, if we assume that there is no Android SDK or JDK known by
`AndroidSdkInfo`, but "someone" knows of one and wants to use that in
the future, the obvious thing to do would be to call e.g.
`AndroidSdkInfo.SetPreferredAndroidSdkPath()`.

Therein lines the problem: these are *instance* methods, and the
`AndroidSdkInfo` constructor *requires* that *all* paths be valid,
otherwise the constructor may throw an `InvalidOperationException`.
This renders `SetPreferredAndroidSdkPath()` largely useless: you would
need to construct `AndroidSdkInfo` with a known instance in order to
set a preferred location, which is a tad backwards.

Turn `AndroidSdkInfo.SetPreferredAndroidNdkPath()`,
`AndroidSdkInfo.SetPreferredAndroidSdkPath()`, and
`AndroidSdkInfo.SetPreferredJavaSdkPath()` into `static` methods, so
that they may be called without constructing an `AndroidApiInfo`.