### PR TITLE
OSVersion is an alias for Framework Version

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
@@ -75,8 +75,14 @@ namespace Xamarin.Android.Tools
 
 		public int? GetApiLevelFromFrameworkVersion (string frameworkVersion)
 		{
-			return installedVersions.FirstOrDefault (v => v.FrameworkVersion == frameworkVersion)?.ApiLevel ??
-				KnownVersions.FirstOrDefault (v => v.FrameworkVersion == frameworkVersion)?.ApiLevel;
+			return installedVersions.FirstOrDefault (v => MatchesFrameworkVersion (v, frameworkVersion))?.ApiLevel ??
+				KnownVersions.FirstOrDefault (v => MatchesFrameworkVersion (v, frameworkVersion))?.ApiLevel;
+		}
+
+		static bool MatchesFrameworkVersion (AndroidVersion version, string frameworkVersion)
+		{
+			return version.FrameworkVersion == frameworkVersion ||
+				version.OSVersion == frameworkVersion;
 		}
 
 		public int? GetApiLevelFromId (string id)
@@ -110,8 +116,8 @@ namespace Xamarin.Android.Tools
 
 		public string GetIdFromFrameworkVersion (string frameworkVersion)
 		{
-			return installedVersions.FirstOrDefault (v => v.FrameworkVersion == frameworkVersion)?.Id ??
-				KnownVersions.FirstOrDefault (v => v.FrameworkVersion == frameworkVersion)?.Id;
+			return installedVersions.FirstOrDefault (v => MatchesFrameworkVersion (v, frameworkVersion))?.Id ??
+				KnownVersions.FirstOrDefault (v => MatchesFrameworkVersion (v, frameworkVersion))?.Id;
 		}
 
 		public string GetFrameworkVersionFromApiLevel (int apiLevel)

--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidVersionsTests.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidVersionsTests.cs
@@ -127,13 +127,19 @@ namespace Xamarin.Android.Tools.Tests
 
 			Assert.AreEqual (null,  versions.GetApiLevelFromFrameworkVersion (null));
 			Assert.AreEqual (1,     versions.GetApiLevelFromFrameworkVersion ("v1.0"));
+			Assert.AreEqual (1,     versions.GetApiLevelFromFrameworkVersion ("1.0"));
 			Assert.AreEqual (2,     versions.GetApiLevelFromFrameworkVersion ("v1.1"));
+			Assert.AreEqual (2,     versions.GetApiLevelFromFrameworkVersion ("1.1"));
 			Assert.AreEqual (3,     versions.GetApiLevelFromFrameworkVersion ("v1.2"));
+			Assert.AreEqual (3,     versions.GetApiLevelFromFrameworkVersion ("1.2"));
 			Assert.AreEqual (null,  versions.GetApiLevelFromFrameworkVersion ("v1.3"));
+			Assert.AreEqual (null,  versions.GetApiLevelFromFrameworkVersion ("1.3"));
 			Assert.AreEqual (14,    versions.GetApiLevelFromFrameworkVersion ("v4.0"));
+			Assert.AreEqual (14,    versions.GetApiLevelFromFrameworkVersion ("4.0"));
 
 			// via KnownVersions
 			Assert.AreEqual (4,     versions.GetApiLevelFromFrameworkVersion ("v1.6"));
+			Assert.AreEqual (4,     versions.GetApiLevelFromFrameworkVersion ("1.6"));
 		}
 
 		[Test]
@@ -192,14 +198,20 @@ namespace Xamarin.Android.Tools.Tests
 
 			Assert.AreEqual (null,  versions.GetIdFromFrameworkVersion (null));
 			Assert.AreEqual ("A",   versions.GetIdFromFrameworkVersion ("v1.0"));
+			Assert.AreEqual ("A",   versions.GetIdFromFrameworkVersion ("1.0"));
 			Assert.AreEqual ("B",   versions.GetIdFromFrameworkVersion ("v1.1"));
+			Assert.AreEqual ("B",   versions.GetIdFromFrameworkVersion ("1.1"));
 			Assert.AreEqual ("C",   versions.GetIdFromFrameworkVersion ("v1.2"));
+			Assert.AreEqual ("C",   versions.GetIdFromFrameworkVersion ("1.2"));
 			Assert.AreEqual ("II",  versions.GetIdFromFrameworkVersion ("v4.0"));
+			Assert.AreEqual ("II",  versions.GetIdFromFrameworkVersion ("4.0"));
 
+			Assert.AreEqual (null,  versions.GetIdFromFrameworkVersion ("v0.99"));
 			Assert.AreEqual (null,  versions.GetIdFromFrameworkVersion ("0.99"));
 
 			// via KnownVersions
 			Assert.AreEqual ("10",  versions.GetIdFromFrameworkVersion ("v2.3"));
+			Assert.AreEqual ("10",  versions.GetIdFromFrameworkVersion ("2.3"));
 		}
 
 		[Test]


### PR DESCRIPTION
Context: https://github.com/xamarin/androidtools/pull/87

Commit aad97f16 assumed that "OS Version" and "Framework Version" were
two related yet distinct constructs, such that e.g.
`AndroidVersions.GetIdFromFrameworkVersion()` only needed to worry
about "Framework Versions".

There was no functionality to look up *anything* by "OS Version",
though such a thing could now be cobbled together via LINQ,
`AndroidVersions.InstalledBindingVersions`, and
`AndroidVersion.OSVersion`.

Unfortunately, when it came time to update `androidtools` to use
`xamarin-android-tools` (this repo), that overlooked assumption reared
its head, cause many unit tests to fail *because* there was an
underlying need to lookup API levels/IDs/etc. via OS Version.

This leaves a choice:

 1. "Unify" OS Version and Framework Version *here*, so that e.g.
    `AndroidVersions.GetIdFromFrameworkVersion()` can work with
    OS Versions, or

 2. Keep them separate, and add a set of "overloads" to
    `AndroidVersions` which deal with OS Versions, or

 3. Keep this repo "clean," and add the appropriate LINQ-fu to
    `androidtools` so that lookups by OS Name continue to work, while
    the xamarin-android-tools repo is unchanged.

Given that OS Version and Framework Version are *already* related --
`AndroidVersion.FrameworkVersion` is `"v" + osVersion`! -- *and* that
I have doubts about whether the LINQ approach will actually work,
update the semantics of `AndroidVersions.Get*FromFrameworkVersion()`
so that they accept OS Versions in addition to Framework Versions.