### PR TITLE
[windows] fallback path for Android SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bin
 **/obj
 packages/
 TestResult-*.xml
+.vs/

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -89,13 +89,17 @@ namespace Xamarin.Android.Tools
 			// Check some hardcoded paths for good measure
 			var xamarin_private = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), "Xamarin", "MonoAndroid", "android-sdk-windows");
 			var android_default = Path.Combine (OS.ProgramFilesX86, "Android", "android-sdk-windows");
-			var cdrive_default = @"C:\android-sdk-windows";
+			var vs_2017_default = Path.Combine (OS.ProgramFilesX86, "Android", "android-sdk");
+			var cdrive_default  = @"C:\android-sdk-windows";
 
 			if (ValidateAndroidSdkLocation (xamarin_private))
 				yield return xamarin_private;
 
 			if (ValidateAndroidSdkLocation (android_default))
 				yield return android_default;
+
+			if (ValidateAndroidSdkLocation (vs_2017_default))
+				yield return vs_2017_default;
 
 			if (ValidateAndroidSdkLocation (cdrive_default))
 				yield return cdrive_default;


### PR DESCRIPTION
In cases where `AndroidSdkInfo` is used outside of Visual Studio, such
as Embeddinator-4000, a new fallback path for the Android SDK is needed
on Windows.

At some point in the past, Visual Studio (or Xamarin) Installer
installed to:

    C:\Program Files (x86)\Android\android-sdk-windows

Now it is installed to (VS 2017):

    C:\Program Files (x86)\Android\android-sdk

Helps fix https://github.com/mono/Embeddinator-4000/issues/599 

Changes:
- Added another fallback path for the Android SDK, mirrored what I did
in the past for VS 2017 and the Android NDK
- Added .vs/ to the .gitignore for Windows developers