### PR TITLE
Add back in missing defaut Paths for GetAllAvailableAndroidNdks and GetAllAvailableAndroidSdks

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -87,18 +87,19 @@ namespace Xamarin.Android.Tools
 					yield return RegistryEx.GetValueString (root, ANDROID_INSTALLER_PATH, ANDROID_INSTALLER_KEY, wow);
 
 			// Check some hardcoded paths for good measure
-			var xamarin_private = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), "Xamarin", "MonoAndroid", "android-sdk-windows");
-			var android_default = Path.Combine (OS.ProgramFilesX86, "Android", "android-sdk-windows");
-			var cdrive_default = @"C:\android-sdk-windows";
-
-			if (ValidateAndroidSdkLocation (xamarin_private))
-				yield return xamarin_private;
-
-			if (ValidateAndroidSdkLocation (android_default))
-				yield return android_default;
-
-			if (ValidateAndroidSdkLocation (cdrive_default))
-				yield return cdrive_default;
+			var paths = new string [] {
+				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), "Xamarin", "MonoAndroid", "android-sdk-windows"),
+				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86), "Android", "android-sdk"),
+				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86), "Android", "android-sdk-windows"),
+				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ProgramFiles), "Android", "android-sdk"),
+				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), "Android", "android-sdk"),
+				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.CommonApplicationData), "Android", "android-sdk"),
+				@"C:\android-sdk-windows"
+			};
+			foreach (var basePath in paths)
+				if (Directory.Exists (basePath))
+					if (ValidateAndroidSdkLocation (basePath))
+						yield return basePath;
 		}
 
 		protected override string GetJavaSdkPath ()
@@ -163,11 +164,13 @@ namespace Xamarin.Android.Tools
 
 			// Check some hardcoded paths for good measure
 			var xamarin_private = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), "Xamarin", "MonoAndroid");
-			var android_default = Path.Combine (OS.ProgramFilesX86, "Android");
+			var vs_default = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.CommonApplicationData), "Microsoft", "AndroidNDK");
+			var vs_default32bit = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.CommonApplicationData), "Microsoft", "AndroidNDK32");
 			var vs_2017_default = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.CommonApplicationData), "Microsoft", "AndroidNDK64");
+			var android_default = Path.Combine (OS.ProgramFilesX86, "Android");
 			var cdrive_default = @"C:\";
 
-			foreach (var basePath in new string [] {xamarin_private, android_default, vs_2017_default, cdrive_default})
+			foreach (var basePath in new string [] {xamarin_private, android_default, vs_default, vs_default32bit, vs_2017_default, cdrive_default})
 				if (Directory.Exists (basePath))
 					foreach (var dir in Directory.GetDirectories (basePath, "android-ndk-r*"))
 						if (ValidateAndroidNdkLocation (dir))


### PR DESCRIPTION
During the implementation of the new xamarin-android-tools we lost the changes in [1]. These are needed on windows to make sure we are using legacy install locations of the SDK/NDK if they exist.

[1] xamarin/androidtools#57