### PR TITLE
Add Missing code to check old paths

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -80,6 +80,11 @@ namespace Xamarin.Android.Tools
 				if (ValidateAndroidSdkLocation (dir))
 					yield return dir;
 			}
+
+			// Check some hardcoded paths for good measure
+			var macSdkPath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), "Library", "Android", "sdk");
+			if (ValidateAndroidSdkLocation (macSdkPath))
+				yield return macSdkPath;
 		}
 
 		protected override string GetJavaSdkPath ()


### PR DESCRIPTION
We missed some old hardcoded paths for MacOS. This PR adds them back.