### PR TITLE
Expose AllAndroidSdks as VS4Mac Installer depends on it

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -122,6 +122,12 @@ namespace Xamarin.Android.Tools
 			get { return sdk.AndroidSdkPath; }
 		}
 
+		public string [] AllAndroidSdkPaths {
+			get {
+				return sdk.AllAndroidSdks ?? new string [0];
+			}
+		}
+
 		public string JavaSdkPath {
 			get { return sdk.JavaSdkPath; }
 		}


### PR DESCRIPTION
It is needed to allow user to select between existing/new SDK locations