### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Unstable framework versions are used

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
@@ -62,10 +62,12 @@ namespace Xamarin.Android.Tools
 		{
 			foreach (var version in versions) {
 				installedVersions.Add (version);
-				if (MaxStableVersion == null || (version.Stable && MaxStableVersion.TargetFrameworkVersion < version.TargetFrameworkVersion)) {
+				if (!version.Stable)
+					continue;
+				if (MaxStableVersion == null || (MaxStableVersion.TargetFrameworkVersion < version.TargetFrameworkVersion)) {
 					MaxStableVersion    = version;
 				}
-				if (MinStableVersion == null || (version.Stable && MinStableVersion.TargetFrameworkVersion > version.TargetFrameworkVersion)) {
+				if (MinStableVersion == null || (MinStableVersion.TargetFrameworkVersion > version.TargetFrameworkVersion)) {
 					MinStableVersion = version;
 				}
 			}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidVersionsTests.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidVersionsTests.cs
@@ -100,7 +100,7 @@ namespace Xamarin.Android.Tools.Tests
 				var versions    = new AndroidVersions (new [] {
 					Path.Combine (frameworkDir, "MonoAndroid", "v5.1"),
 					Path.Combine (frameworkDir, "MonoAndroid", "v6.0"),
-					Path.Combine (frameworkDir, "MonoAndroid", "v108.1.99")
+					Path.Combine (frameworkDir, "MonoAndroid", "v108.1.99"),
 				});
 				Assert.IsNotNull (versions.FrameworkDirectories);
 				Assert.AreEqual (1,     versions.FrameworkDirectories.Count);

--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidVersionsTests.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidVersionsTests.cs
@@ -40,6 +40,16 @@ namespace Xamarin.Android.Tools.Tests
 		}
 
 		[Test]
+		public void Contructor_UnstableVersions ()
+		{
+			var versions = new AndroidVersions (
+				new [] { new AndroidVersion (apiLevel: 100, osVersion: "100.0", codeName: "Test", id: "Z", stable: false) }
+			);
+			Assert.IsNull (versions.MaxStableVersion);
+			Assert.IsNull (versions.MinStableVersion);
+		}
+
+		[Test]
 		public void Constructor_FrameworkDirectories ()
 		{
 			var frameworkDir    = Path.GetTempFileName ();

--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidVersionsTests.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidVersionsTests.cs
@@ -77,9 +77,20 @@ namespace Xamarin.Android.Tools.Tests
 					"  <Stable>False</Stable>",
 					"</AndroidApiInfo>",
 				});
+				Directory.CreateDirectory (Path.Combine (frameworkDir, "MonoAndroid", "v108.1.99"));
+				File.WriteAllLines (Path.Combine (frameworkDir, "MonoAndroid", "v108.1.99", "AndroidApiInfo.xml"), new []{
+					"<AndroidApiInfo>",
+					"  <Id>Z</Id>",
+					"  <Level>127</Level>",
+					"  <Name>Z</Name>",
+					"  <Version>v108.1.99</Version>",
+					"  <Stable>False</Stable>",
+					"</AndroidApiInfo>",
+				});
 				var versions    = new AndroidVersions (new [] {
 					Path.Combine (frameworkDir, "MonoAndroid", "v5.1"),
-					Path.Combine (frameworkDir, "MonoAndroid", "v6.0")
+					Path.Combine (frameworkDir, "MonoAndroid", "v6.0"),
+					Path.Combine (frameworkDir, "MonoAndroid", "v108.1.99")
 				});
 				Assert.IsNotNull (versions.FrameworkDirectories);
 				Assert.AreEqual (1,     versions.FrameworkDirectories.Count);


### PR DESCRIPTION
We had a bug on our logic to calculate the `MaxStableVersion`.
The first time through the `LoadVersions` method `MaxStableVersion`
would ALWAYS be `null`. As a result regardless of whether the
first version was stable or not it would be assigned to the
property. This would then cause build failures later down the
build process because we were using an unstable api.

So the fix it to completely ignore unstable apis. This way the
first STABLE api we find will be the first value we assign.