### PR TITLE
[android] Set JavaSdkPath on JAVA_HOME and PATH environment variables

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -222,5 +222,26 @@ namespace Xamarin.Android.Tools
 			return true;
 		}
 		#endregion
+
+		public override void Initialize(string androidSdkPath = null, string androidNdkPath = null, string javaSdkPath = null)
+		{
+			base.Initialize(androidSdkPath, androidNdkPath, javaSdkPath);
+
+			var jdkPath = JavaSdkPath;
+			if (!string.IsNullOrEmpty(jdkPath)) {
+				var cur = Environment.GetEnvironmentVariable("JAVA_HOME");
+				if (!string.IsNullOrEmpty(cur))
+					Environment.SetEnvironmentVariable("JAVA_HOME", jdkPath);
+
+				var javaBinPath = this.JavaBinPath;
+				if (!string.IsNullOrEmpty(javaBinPath)) {
+					var environmentPath = Environment.GetEnvironmentVariable("PATH");
+					if (!environmentPath.Contains(javaBinPath)){
+						var processPath = string.Concat(javaBinPath, Path.PathSeparator, environmentPath);
+						Environment.SetEnvironmentVariable("PATH", processPath);
+					}
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
This change ensures that the environment variables JAVA_HOME (if it is defined) and PATH are pointed to the JavaSdk path defined by the AndroidSdkInfo.

This is set each time that AndroidSdkInfo is refreshed with a new path.