### PR TITLE
Set OpenJdk path as default if it is available on windows

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -105,46 +105,48 @@ namespace Xamarin.Android.Tools
 		protected override string GetJavaSdkPath ()
 		{
 			var preferredJdkPath = GetPreferredJdkPath ();
-			if (!string.IsNullOrEmpty(preferredJdkPath))
+			if (!string.IsNullOrEmpty (preferredJdkPath))
 				return preferredJdkPath;
 
 			var openJdkPath = GetOpenJdkPath ();
 			if (!string.IsNullOrEmpty (openJdkPath))
 				return openJdkPath;
 
-			return GetOracleJdkPath();
+			return GetOracleJdkPath ();
 		}
 
-		private string GetPreferredJdkPath () {
+		private string GetPreferredJdkPath ()
+		{
 			// check the user specified path
 			var roots = new[] { RegistryEx.CurrentUser, RegistryEx.LocalMachine };
 			const RegistryEx.Wow64 wow = RegistryEx.Wow64.Key32;
-			var regKey = GetMDRegistryKey();
+			var regKey = GetMDRegistryKey ();
 
 			foreach (var root in roots) {
-				if (CheckRegistryKeyForExecutable(root, regKey, MDREG_JAVA_SDK, wow, "bin", JarSigner))
-					return RegistryEx.GetValueString(root, regKey, MDREG_JAVA_SDK, wow);
+				if (CheckRegistryKeyForExecutable (root, regKey, MDREG_JAVA_SDK, wow, "bin", JarSigner))
+					return RegistryEx.GetValueString (root, regKey, MDREG_JAVA_SDK, wow);
 			}
 
 			return null;
 		}
 
-		private string GetOpenJdkPath () {
+		private string GetOpenJdkPath ()
+		{
 			var root = RegistryEx.LocalMachine;
 			var wows = new[] { RegistryEx.Wow64.Key32, RegistryEx.Wow64.Key64 };
 			var subKey = @"SOFTWARE\Microsoft\VisualStudio\Android";
 			var valueName = "JavaHome";
 
 			foreach (var wow in wows) {
-				if (CheckRegistryKeyForExecutable(root, subKey, valueName, wow, "bin", JarSigner))
-					return RegistryEx.GetValueString(root, subKey, valueName, wow);
+				if (CheckRegistryKeyForExecutable (root, subKey, valueName, wow, "bin", JarSigner))
+					return RegistryEx.GetValueString (root, subKey, valueName, wow);
 			}
 
 			return null;
 		}
 
-		private string GetOracleJdkPath () { 
-			
+		private string GetOracleJdkPath ()
+		{ 
 			string subkey = @"SOFTWARE\JavaSoft\Java Development Kit";
 
 			Logger (TraceLevel.Info, "Looking for Java 6 SDK...");

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -104,16 +104,47 @@ namespace Xamarin.Android.Tools
 
 		protected override string GetJavaSdkPath ()
 		{
+			var preferredJdkPath = GetPreferredJdkPath ();
+			if (!string.IsNullOrEmpty(preferredJdkPath))
+				return preferredJdkPath;
+
+			var openJdkPath = GetOpenJdkPath ();
+			if (!string.IsNullOrEmpty (openJdkPath))
+				return openJdkPath;
+
+			return GetOracleJdkPath();
+		}
+
+		private string GetPreferredJdkPath () {
 			// check the user specified path
 			var roots = new[] { RegistryEx.CurrentUser, RegistryEx.LocalMachine };
 			const RegistryEx.Wow64 wow = RegistryEx.Wow64.Key32;
-			var regKey = GetMDRegistryKey ();
+			var regKey = GetMDRegistryKey();
 
 			foreach (var root in roots) {
-				if (CheckRegistryKeyForExecutable (root, regKey, MDREG_JAVA_SDK, wow, "bin", JarSigner))
-					return RegistryEx.GetValueString (root, regKey, MDREG_JAVA_SDK, wow);
+				if (CheckRegistryKeyForExecutable(root, regKey, MDREG_JAVA_SDK, wow, "bin", JarSigner))
+					return RegistryEx.GetValueString(root, regKey, MDREG_JAVA_SDK, wow);
 			}
 
+			return null;
+		}
+
+		private string GetOpenJdkPath () {
+			var root = RegistryEx.LocalMachine;
+			var wows = new[] { RegistryEx.Wow64.Key32, RegistryEx.Wow64.Key64 };
+			var subKey = @"SOFTWARE\Microsoft\VisualStudio\Android";
+			var valueName = "JavaHome";
+
+			foreach (var wow in wows) {
+				if (CheckRegistryKeyForExecutable(root, subKey, valueName, wow, "bin", JarSigner))
+					return RegistryEx.GetValueString(root, subKey, valueName, wow);
+			}
+
+			return null;
+		}
+
+		private string GetOracleJdkPath () { 
+			
 			string subkey = @"SOFTWARE\JavaSoft\Java Development Kit";
 
 			Logger (TraceLevel.Info, "Looking for Java 6 SDK...");


### PR DESCRIPTION
On Windows, as part of VisualStudio installer, we can install the Microsoft OpenJdk version.
This jdk has priority when we select the default for the user.