### PR TITLE
[Mac] Use the new JdkInfo to fetch the Java SDK path and fix validation

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -108,20 +109,7 @@ namespace Xamarin.Android.Tools
 
 		protected override string GetJavaSdkPath ()
 		{
-			var preferedJavaSdkPath = PreferedJavaSdkPath;
-			if (!string.IsNullOrEmpty (preferedJavaSdkPath))
-				return preferedJavaSdkPath;
-
-			// Look in PATH
-			foreach (var path in ProcessUtils.FindExecutablesInPath (JarSigner)) {
-				// Strip off "bin"
-				var dir = Path.GetDirectoryName (path);
-
-				if (ValidateJavaSdkLocation (dir))
-					return dir;
-			}
-
-			return null;
+			return JdkInfo.GetKnownSystemJdkInfos (Logger).FirstOrDefault ()?.HomePath;
 		}
 
 		public override bool ValidateJavaSdkLocation (string loc)

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -138,30 +138,7 @@ namespace Xamarin.Android.Tools
 			var result = base.ValidateJavaSdkLocation (loc);
 
 			if (result) {
-				if (loc == "/usr") {
-					// handle apple's java stub
-					const string javaHomeExe = "/usr/libexec/java_home";
-
-					if (File.Exists (javaHomeExe)) {
-						// returns true if there is a java installed
-						var javaHomeTask = ProcessUtils.ExecuteToolAsync<bool> (javaHomeExe,
-							(output) => {
-								if (output.Contains ("(null)")) {
-									return false;
-								}
-
-								return true;
-							}, System.Threading.CancellationToken.None
-						);
-
-						if (!javaHomeTask.Result) {
-							return false;
-						}
-					}
-				} else {
-					// Handle OpenJDK or other paths
-					return File.Exists (Path.Combine (loc, "bin", "javac"));
-				}
+				return File.Exists (Path.Combine (loc, "bin", "javac"));
 			}
 
 			return result;

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -81,7 +81,6 @@ namespace Xamarin.Android.Tools
 					if (ValidateJavaSdkLocation (path))
 						return path;
 				}
-
 				return null;
 			}
 		}
@@ -112,14 +111,6 @@ namespace Xamarin.Android.Tools
 			var preferedJavaSdkPath = PreferedJavaSdkPath;
 			if (!string.IsNullOrEmpty (preferedJavaSdkPath))
 				return preferedJavaSdkPath;
-
-			var javaHomeEnv = Environment.GetEnvironmentVariable ("JAVA_HOME");
-			if (!String.IsNullOrEmpty (javaHomeEnv) && ValidateJavaSdkLocation (javaHomeEnv))
-				return javaHomeEnv;
-
-			var libExecJavaHome = GetUsrLibExecJavaHomeSdkPath ();
-			if (!String.IsNullOrEmpty (libExecJavaHome) && ValidateJavaSdkLocation (libExecJavaHome))
-				return libExecJavaHome;
 
 			// Look in PATH
 			foreach (var path in FindExecutableInPath (JarSigner)) {
@@ -209,27 +200,6 @@ namespace Xamarin.Android.Tools
 
 			androidEl.SetAttributeValue ("path", path);
 			SaveConfig (doc);
-		}
-
-		string GetUsrLibExecJavaHomeSdkPath ()
-		{
-			const string javaHomeExe = "/usr/libexec/java_home";
-
-			if (File.Exists (javaHomeExe)) {
-				var javaHomeTask = ProcessUtils.ExecuteToolAsync<string> (javaHomeExe,
-					(output) => {
-						if (output.Contains ("(null)")) {
-							return null;
-						}
-
-						return output;
-					}, System.Threading.CancellationToken.None
-				);
-
-				return javaHomeTask.Result;
-			}
-
-			return null;
 		}
 
 		void SaveConfig (XDocument doc)


### PR DESCRIPTION
Use JdkInfo to get the Java SDK path, and fix Java SDK validation to work with OpenJDK.

Fixes VSTS #652760 and VSTS #646086