### PR TITLE
Fix test DetectAndSetPreferredJavaSdkPathToLatest

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidSdkInfoTests.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidSdkInfoTests.cs
@@ -192,8 +192,11 @@ namespace Xamarin.Android.Tools.Tests
 			finally {
 				AppDomain.CurrentDomain.SetData ($"GetMacOSMicrosoftJdkPaths jdks override! {typeof (JdkInfo).AssemblyQualifiedName}", null);
 				Directory.Delete (jdks, recursive: true);
-				if (File.Exists (backupConfig))
-					File.Move (backupConfig, UnixConfigPath);
+                if (File.Exists(backupConfig))
+                {
+                    File.Delete(UnixConfigPath);
+                    File.Move(backupConfig, UnixConfigPath);
+                }
 			}
 		}
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidSdkInfoTests.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidSdkInfoTests.cs
@@ -192,11 +192,10 @@ namespace Xamarin.Android.Tools.Tests
 			finally {
 				AppDomain.CurrentDomain.SetData ($"GetMacOSMicrosoftJdkPaths jdks override! {typeof (JdkInfo).AssemblyQualifiedName}", null);
 				Directory.Delete (jdks, recursive: true);
-                if (File.Exists(backupConfig))
-                {
-                    File.Delete(UnixConfigPath);
-                    File.Move(backupConfig, UnixConfigPath);
-                }
+				if (File.Exists (backupConfig)) {
+					File.Delete (UnixConfigPath);
+					File.Move (backupConfig, UnixConfigPath);
+				}
 			}
 		}
 


### PR DESCRIPTION
The test backs up monodroid-config.xml, but when it tries to move the
backup to its original place it fails because the version created during
the test is in its place.