### PR TITLE
Allow finding NDK location based on $PATH

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -93,7 +93,8 @@ namespace Xamarin.Android.Tools
 				yield return preferedSdkPath;
 
 			// Look in PATH
-			foreach (var path in ProcessUtils.FindExecutablesInPath (Adb)) {
+			foreach (var adb in ProcessUtils.FindExecutablesInPath (Adb)) {
+				var path = Path.GetDirectoryName (adb);
 				// Strip off "platform-tools"
 				var dir = Path.GetDirectoryName (path);
 
@@ -119,9 +120,10 @@ namespace Xamarin.Android.Tools
 				yield return preferedNdkPath;
 
 			// Look in PATH
-			foreach (var path in ProcessUtils.FindExecutablesInPath (NdkStack)) {
-				if (ValidateAndroidNdkLocation (path))
-					yield return path;
+			foreach (var ndkStack in ProcessUtils.FindExecutablesInPath (NdkStack)) {
+				var ndkDir  = Path.GetDirectoryName (ndkStack);
+				if (ValidateAndroidNdkLocation (ndkDir))
+					yield return ndkDir;
 			}
 		}
 


### PR DESCRIPTION
Context: https://github.com/xamarin/androidtools/pull/119
Context: https://devdiv.visualstudio.com/DevDiv/DevDiv%20Team/_build?buildId=1908630

Context: https://github.com/xamarin/androidtools/pull/120
Context: https://devdiv.visualstudio.com/DevDiv/DevDiv%20Team/_build?buildId=1908776

How does `AndroidSdkInfo` determine the appropriate value to return
from `AndroidSdkInfo.AndroidNdkPath`?

Firstly, it checks `$HOME/.config/xbuild/monodroid-config.xml`.

If that file doesn't exist, or it doesn't contain a
`/monodroid/android-ndk/@path` attribute value, then `AndroidSdkInfo`
checks `$PATH`, and attempts to find `ndk-stack`.  If `ndk-stack` can
be found in `$PATH`, the containing directory is used:

	$ mv $HOME/.config/xbuild/monodroid-config.xml{,.none}

	$ PATH=/path/to/my/ndk:$PATH csharp -r:Xamarin.Android.Tools.AndroidSdk.dll
	csharp> using System.Diagnostics;
	csharp> using Xamarin.Android.Tools;
	csharp> Action<TraceLevel, string> logger = (level, value) => Console.WriteLine ($"[{level}] {value}");
	csharp> var info = new AndroidSdkInfo (logger);
	csharp> info.AndroidNdkPath;
	"/path/to/my/ndk"

Unfortunately, commit 0cec16c4 broke this behavior; afterward,
`info.AndroidNdkPath` would return `null`, bceause commit 0cec16c4
inadvertently broke `$PATH`-based probing for `ndk-stack`.

Oops. :-(

Specifically, it was the "cleanup" in 0cec16c4, replacing
`AndroidSdkBase.FindExecutableInPath()` with
`ProcessUtils.FindExecutablesInPath()`.  While these are similarly
named, they had an important semantic difference: the former returned
the *directory* containing an executable, while the latter returned
the full path for the executable.

Double oops.

Review commit 0cec16c4 and review all
`ProcessUtils.FindExecutablesInPath()` use to ensure that when a
directory is desired, we actually get a directory, not the path to
`ndk-stack` itself.

This allows `$PATH`-based NDK lookup to work again.