### PR TITLE
[tests] Unit tests for finding NDK location based on $PATH

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -144,7 +144,7 @@ namespace Xamarin.Android.Tools
 			sdk.SetPreferredAndroidNdkPath(path);
 		}
 
-		static void DefaultConsoleLogger (TraceLevel level, string message)
+		internal static void DefaultConsoleLogger (TraceLevel level, string message)
 		{
 			switch (level) {
 			case TraceLevel.Error:

--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -207,14 +207,16 @@ namespace Xamarin.Android.Tools
 			return props;
 		}
 
-		public static IEnumerable<JdkInfo> GetKnownSystemJdkInfos (Action<TraceLevel, string> logger)
+		public static IEnumerable<JdkInfo> GetKnownSystemJdkInfos (Action<TraceLevel, string> logger = null)
 		{
+			logger  = logger ?? AndroidSdkInfo.DefaultConsoleLogger;
+
 			return GetWindowsJdks (logger)
 				.Concat (GetConfiguredJdks (logger))
 				.Concat (GetMacOSMicrosoftJdks (logger))
 				.Concat (GetJavaHomeEnvironmentJdks (logger))
-				.Concat (GetLibexecJdks (logger))
 				.Concat (GetPathEnvironmentJdks (logger))
+				.Concat (GetLibexecJdks (logger))
 				.Concat (GetJavaAlternativesJdks (logger))
 				;
 		}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -205,6 +205,8 @@ namespace Xamarin.Android.Tools
 			}
 		}
 
+		static  readonly    string  GetUnixConfigDirOverrideName            = $"UnixConfigPath directory override! {typeof (AndroidSdkInfo).AssemblyQualifiedName}";
+
 		// There's a small problem with the code below. Namely, if it runs under `sudo` the folder location
 		// returned by Environment.GetFolderPath will depend on how sudo was invoked:
 		//
@@ -231,8 +233,12 @@ namespace Xamarin.Android.Tools
 		//
 		private static string UnixConfigPath {
 			get {
-				var p = Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData);
-				return Path.Combine (Path.Combine (p, "xbuild"), "monodroid-config.xml");
+				var p   = AppDomain.CurrentDomain.GetData (GetUnixConfigDirOverrideName)?.ToString ();
+				if (string.IsNullOrEmpty (p)) {
+					p   = Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData);
+					p   = Path.Combine (p, "xbuild");
+				}
+				return Path.Combine (p, "monodroid-config.xml");
 			}
 		}
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/JdkInfoTests.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/JdkInfoTests.cs
@@ -58,8 +58,18 @@ namespace Xamarin.Android.Tools.Tests
 			Directory.CreateDirectory (jli);
 			Directory.CreateDirectory (jre);
 
+
+			string java =
+				$"echo Property settings:{Environment.NewLine}" +
+				$"echo \"    java.home = {dir}\"{Environment.NewLine}" +
+				$"echo \"    java.vendor = Xamarin.Android Unit Tests\"{Environment.NewLine}" +
+				$"echo \"    java.version = 100.100.100\"{Environment.NewLine}" +
+				$"echo \"    xamarin.multi-line = line the first\"{Environment.NewLine}" +
+				$"echo \"        line the second\"{Environment.NewLine}" +
+				$"echo \"        .\"{Environment.NewLine}";
+
 			CreateShellScript (Path.Combine (bin, "jar"), "");
-			CreateShellScript (Path.Combine (bin, "java"), JavaScript);
+			CreateShellScript (Path.Combine (bin, "java"), java);
 			CreateShellScript (Path.Combine (bin, "javac"), "");
 			CreateShellScript (Path.Combine (dir, "jli", "libjli.dylib"), "");
 			CreateShellScript (Path.Combine (jre, "libjvm.so"), "");
@@ -71,14 +81,6 @@ namespace Xamarin.Android.Tools.Tests
 		{
 			Directory.Delete (FauxJdkDir, recursive: true);
 		}
-
-		static readonly string JavaScript =
-			$"echo Property settings:{Environment.NewLine}" +
-			$"echo \"    java.vendor = Xamarin.Android Unit Tests\"{Environment.NewLine}" +
-			$"echo \"    java.version = 100.100.100\"{Environment.NewLine}" +
-			$"echo \"    xamarin.multi-line = line the first\"{Environment.NewLine}" +
-			$"echo \"        line the second\"{Environment.NewLine}" +
-			$"echo \"        .\"{Environment.NewLine}";
 
 		static void CreateShellScript (string path, string contents)
 		{
@@ -142,10 +144,13 @@ namespace Xamarin.Android.Tools.Tests
 		{
 			var jdk     = new JdkInfo (FauxJdkDir);
 
-			Assert.AreEqual (3, jdk.JavaSettingsPropertyKeys.Count ());
+			Assert.AreEqual (4, jdk.JavaSettingsPropertyKeys.Count ());
 
 			Assert.IsFalse(jdk.GetJavaSettingsPropertyValue ("does-not-exist", out var _));
 			Assert.IsFalse(jdk.GetJavaSettingsPropertyValues ("does-not-exist", out var _));
+
+			Assert.IsTrue (jdk.GetJavaSettingsPropertyValue ("java.home", out var home));
+			Assert.AreEqual (FauxJdkDir, home);
 
 			Assert.IsTrue (jdk.GetJavaSettingsPropertyValue ("java.version", out var version));
 			Assert.AreEqual ("100.100.100", version);


### PR DESCRIPTION
Commit 511d580b didn't provide unit tests to ensure that the
Android NDK could be found based on probing `$PATH` for `ndk-stack`.

Update `AndroidSdkInfoTests` to ensure that the NDK to be found based
on `$PATH`, as well as the Android SDK and JDK.

Additionally, JDK-via-$PATH detection hit a few hiccups:

 1. `JdkInfo.GetKnownSystemJdkInfos()` would always check
    `/usr/libexec/java_home` before `$PATH`, meaning it wasn't
    possible to test JDK-via-$PATH!

    Alter the ordering of `JdkInfo.GetKnownSystemJdkInfos()` so that
    we probe `$PATH` before hitting `/usr/libexec/java_home`.

 2. `JdkInfo` requires that the `java.home` property be printed, which
    `JdkInfoTests.CreateFauxJdk()` didn't print, which caused the fake
    JDK to be skipped.  Fix `JdkInfoTests.CreateFauxJdk()` so that the
    resulting `java` is acceptable by `JdkInfo`.

Additionally, for greater `monodroid-config.xml` sanity (see also
a4aad186 and b42c2177), instead of backing up the *global*
`monodroid-config.xml` file, instead allow the location of
`monodroid-config.xml` to be overridden by the unit tests by setting a
value accessible by `AppDomain.GetData()`, a'la a4aad186.

Finally, allow the `logger` parameter to
`JdkInfo.GetKnownSystemJdkInfos()` to be optional; if not provided, it
will print to the Console.