### PR TITLE
Don't require quotes around `release` values

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -144,21 +144,26 @@ namespace Xamarin.Android.Tools
 
 		ReadOnlyDictionary<string, string> GetReleaseProperties ()
 		{
+			var props       = new Dictionary<string, string> ();
 			var releasePath = Path.Combine (HomePath, "release");
 			if (!File.Exists (releasePath))
-				return new ReadOnlyDictionary<string, string> (new Dictionary<string, string> ());
+				return new ReadOnlyDictionary<string, string>(props);
 
-			var props   = new Dictionary<string, string> ();
 			using (var release = File.OpenText (releasePath)) {
 				string line;
 				while ((line = release.ReadLine ()) != null) {
-					const string PropertyDelim  = "=\"";
+					line            = line.Trim ();
+					const string PropertyDelim  = "=";
 					int delim = line.IndexOf (PropertyDelim, StringComparison.Ordinal);
 					if (delim < 0) {
 						props [line] = "";
+						continue;
 					}
-					string  key     = line.Substring (0, delim);
-					string  value   = line.Substring (delim + PropertyDelim.Length, line.Length - delim - PropertyDelim.Length - 1);
+					string  key     = line.Substring (0, delim).Trim ();
+					string  value   = line.Substring (delim + PropertyDelim.Length).Trim ();
+					if (value.StartsWith ("\"", StringComparison.Ordinal) && value.EndsWith ("\"", StringComparison.Ordinal)) {
+						value       = value.Substring (1, value.Length - 2);
+					}
 					props [key] = value;
 				}
 			}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/JdkInfoTests.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/JdkInfoTests.cs
@@ -46,6 +46,8 @@ namespace Xamarin.Android.Tools.Tests
 
 			using (var release = new StreamWriter (Path.Combine (dir, "release"))) {
 				release.WriteLine ($"JAVA_VERSION=\"{version}\"");
+				release.WriteLine ($"BUILD_NUMBER=42");
+				release.WriteLine ($"JUST_A_KEY");
 			}
 
 			var bin = Path.Combine (dir, "bin");
@@ -135,8 +137,10 @@ namespace Xamarin.Android.Tools.Tests
 		{
 			var jdk     = new JdkInfo (FauxJdkDir);
 
-			Assert.AreEqual (1,         jdk.ReleaseProperties.Count);
+			Assert.AreEqual (3,         jdk.ReleaseProperties.Count);
 			Assert.AreEqual ("1.2.3.4", jdk.ReleaseProperties ["JAVA_VERSION"]);
+			Assert.AreEqual ("42",      jdk.ReleaseProperties ["BUILD_NUMBER"]);
+			Assert.AreEqual ("",        jdk.ReleaseProperties ["JUST_A_KEY"]);
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android-tools/issues/39

The `release` file contained within the
[Microsoft OpenJDK Distribution Preview][0] contains an entry which
broke the `release` parser within `JdkInfo`, an entry which doesn't
contain double quotes around the value:

	BUILD_NUMBER=9

This causes an exception to be thrown when `JdkInfo` attempts to parse
the `release` file:

	System.ArgumentOutOfRangeException : Length cannot be less than zero.
	Parameter name: length
	  at System.String.Substring (System.Int32 startIndex, System.Int32 length) [0x0004a] in <7e59c4ad7b424f9eab0db1b78ec1804f>:0
	  at Xamarin.Android.Tools.JdkInfo.GetReleaseProperties () [0x0006b] in <3975ab851981476abded14492926b261>:0
	  at Xamarin.Android.Tools.JdkInfo..ctor (System.String homePath) [0x00159] in <3975ab851981476abded14492926b261>:0

Update `JdkInfo.GetReleaseProperties()` so that the double-quotes
around values are *optional* and not required, so that this `release`
file may be processed without throwing an exception.

[0]: https://dl.xamarin.com/OpenJDK/mac/microsoft-dist-openjdk-1.8.0.9.zip