### PR TITLE
[VS] Set JavaSdkPath on JAVA_HOME and PATH environment variables and Set OpenJdk path as default if it is available on windows

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -222,5 +222,26 @@ namespace Xamarin.Android.Tools
 			return true;
 		}
 		#endregion
+
+		public override void Initialize (string androidSdkPath = null, string androidNdkPath = null, string javaSdkPath = null)
+		{
+			base.Initialize (androidSdkPath, androidNdkPath, javaSdkPath);
+
+			var jdkPath = JavaSdkPath;
+			if (!string.IsNullOrEmpty (jdkPath)) {
+				var cur = Environment.GetEnvironmentVariable ("JAVA_HOME");
+				if (!string.IsNullOrEmpty (cur))
+					Environment.SetEnvironmentVariable ("JAVA_HOME", jdkPath);
+
+				var javaBinPath = this.JavaBinPath;
+				if (!string.IsNullOrEmpty (javaBinPath)) {
+					var environmentPath = Environment.GetEnvironmentVariable ("PATH");
+					if (!environmentPath.Contains (javaBinPath)) {
+						var processPath = string.Concat (javaBinPath, Path.PathSeparator, environmentPath);
+						Environment.SetEnvironmentVariable ("PATH", processPath);
+					}
+				}
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -104,6 +104,19 @@ namespace Xamarin.Android.Tools
 
 		protected override string GetJavaSdkPath ()
 		{
+			var preferredJdkPath = GetPreferredJdkPath ();
+			if (!string.IsNullOrEmpty (preferredJdkPath))
+				return preferredJdkPath;
+
+			var openJdkPath = GetOpenJdkPath ();
+			if (!string.IsNullOrEmpty (openJdkPath))
+				return openJdkPath;
+
+			return GetOracleJdkPath ();
+		}
+
+		private string GetPreferredJdkPath ()
+		{
 			// check the user specified path
 			var roots = new[] { RegistryEx.CurrentUser, RegistryEx.LocalMachine };
 			const RegistryEx.Wow64 wow = RegistryEx.Wow64.Key32;
@@ -114,6 +127,26 @@ namespace Xamarin.Android.Tools
 					return RegistryEx.GetValueString (root, regKey, MDREG_JAVA_SDK, wow);
 			}
 
+			return null;
+		}
+
+		private string GetOpenJdkPath ()
+		{
+			var root = RegistryEx.LocalMachine;
+			var wows = new[] { RegistryEx.Wow64.Key32, RegistryEx.Wow64.Key64 };
+			var subKey = @"SOFTWARE\Microsoft\VisualStudio\Android";
+			var valueName = "JavaHome";
+
+			foreach (var wow in wows) {
+				if (CheckRegistryKeyForExecutable (root, subKey, valueName, wow, "bin", JarSigner))
+					return RegistryEx.GetValueString (root, subKey, valueName, wow);
+			}
+
+			return null;
+		}
+
+		private string GetOracleJdkPath ()
+		{ 
 			string subkey = @"SOFTWARE\JavaSoft\Java Development Kit";
 
 			Logger (TraceLevel.Info, "Looking for Java 6 SDK...");


### PR DESCRIPTION
-[android] Set JavaSdkPath on JAVA_HOME and PATH environment variables
This change ensures that the environment variables JAVA_HOME (if it is defined) and PATH are pointed to the JavaSdk path defined by the AndroidSdkInfo.

This is set each time that AndroidSdkInfo is refreshed with a new path.

-Set OpenJdk path as default if it is available on windows
On Windows, as part of VisualStudio installer, we can install the Microsoft OpenJdk version.
This jdk has priority when we select the default for the user.