### PR TITLE
Take BUILD_NUMBER into consideration for Version sorting

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -151,7 +151,7 @@ namespace Xamarin.Android.Tools
 				Console.Error.WriteLine (message);
 				break;
 			default:
-				Console.WriteLine (message);
+				Console.WriteLine ($"[{level}] {message}");
 				break;
 			}
 		}

--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -53,7 +53,7 @@ namespace Xamarin.Android.Tools
 			JavaPath            = ProcessUtils.FindExecutablesInDirectory (binPath, "java").FirstOrDefault ();
 			JavacPath           = ProcessUtils.FindExecutablesInDirectory (binPath, "javac").FirstOrDefault ();
 			JdkJvmPath = OS.IsMac
-				? FindLibrariesInDirectory (HomePath, "jli").FirstOrDefault ()
+				? FindLibrariesInDirectory (Path.Combine (HomePath, "jre"), "jli").FirstOrDefault ()
 				: FindLibrariesInDirectory (Path.Combine (HomePath, "jre"), "jvm").FirstOrDefault ();
 
 			ValidateFile ("jar",    JarPath);
@@ -115,6 +115,8 @@ namespace Xamarin.Android.Tools
 
 		static IEnumerable<string> FindLibrariesInDirectory (string dir, string libraryName)
 		{
+			if (!Directory.Exists (dir))
+				return Enumerable.Empty<string> ();
 			var library = string.Format (OS.NativeLibraryFormat, libraryName);
 			return Directory.EnumerateFiles (dir, library, SearchOption.AllDirectories);
 		}
@@ -125,29 +127,44 @@ namespace Xamarin.Android.Tools
 				throw new ArgumentException ($"Could not find required file `{name}` within `{HomePath}`; is this a valid JDK?", "homePath");
 		}
 
-		static  Regex   VersionExtractor  = new Regex (@"(?<version>[\d]+(\.\d+)+)(_(?<patch>\d+))?", RegexOptions.Compiled);
+		static  Regex   NonDigitMatcher     = new Regex (@"[^\d]", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
 		Version GetJavaVersion ()
 		{
 			string version = null;
-			if (!ReleaseProperties.TryGetValue ("JAVA_VERSION", out version)) {
-				if (GetJavaSettingsPropertyValue ("java.version", out string vs))
-					version = vs;
+			if (ReleaseProperties.TryGetValue ("JAVA_VERSION", out version) && !string.IsNullOrEmpty (version)) {
+				version = GetParsableVersion (version);
+				if (ReleaseProperties.TryGetValue ("BUILD_NUMBER", out var build) && !string.IsNullOrEmpty (build))
+					version += "." + build;
 			}
-			if (version == null)
-				throw new NotSupportedException ("Could not determine Java version");
-			var m = VersionExtractor.Match (version);
-			if (!m.Success)
+			else if (GetJavaSettingsPropertyValue ("java.version", out version) && !string.IsNullOrEmpty (version)) {
+				version = GetParsableVersion (version);
+			}
+			if (string.IsNullOrEmpty (version))
+				throw new NotSupportedException ("Could not determine Java version.");
+			var normalizedVersion   = NonDigitMatcher.Replace (version, ".");
+			var versionParts        = normalizedVersion.Split (new[]{"."}, StringSplitOptions.RemoveEmptyEntries);
+
+			try {
+				if (versionParts.Length < 2)
+					return null;
+				if (versionParts.Length == 2)
+					return new Version (major: int.Parse (versionParts [0]), minor: int.Parse (versionParts [1]));
+				if (versionParts.Length == 3)
+					return new Version (major: int.Parse (versionParts [0]), minor: int.Parse (versionParts [1]), build: int.Parse (versionParts [2]));
+				// We just ignore elements 4+
+				return new Version (major: int.Parse (versionParts [0]), minor: int.Parse (versionParts [1]), build: int.Parse (versionParts [2]), revision: int.Parse (versionParts [3]));
+			}
+			catch (Exception) {
 				return null;
-			version   = m.Groups ["version"].Value;
-			var patch = m.Groups ["patch"].Value;
-			if (!string.IsNullOrEmpty (patch))
-				version += "." + patch;
+			}
+		}
+
+		static string GetParsableVersion (string version)
+		{
 			if (!version.Contains ("."))
 				version += ".0";
-			if (Version.TryParse (version, out Version v))
-				return v;
-			return null;
+			return version;
 		}
 
 		ReadOnlyDictionary<string, string> GetReleaseProperties ()

--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidSdkInfoTests.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidSdkInfoTests.cs
@@ -75,7 +75,7 @@ namespace Xamarin.Android.Tools.Tests
 		public void Constructor_SetValuesFromPath ()
 		{
 			CreateSdks (out string root, out string jdk, out string ndk, out string sdk);
-			JdkInfoTests.CreateFauxJdk (jdk, "1.8.0");
+			JdkInfoTests.CreateFauxJdk (jdk, releaseVersion: "1.8.0", releaseBuildNumber: "42", javaVersion: "100.100.100_100");
 
 			Action<TraceLevel, string> logger = (level, message) => {
 				Console.WriteLine ($"[{level}] {message}");
@@ -267,8 +267,8 @@ namespace Xamarin.Android.Tools.Tests
 					return;
 				}
 				Assert.Throws<NotSupportedException>(() => AndroidSdkInfo.DetectAndSetPreferredJavaSdkPathToLatest (logger));
-				var newJdkPath  = Path.Combine (PreferredJdksOverridePath, "microsoft_dist_openjdk_1.8.999");
-				JdkInfoTests.CreateFauxJdk (newJdkPath, "1.8.999");
+				var newJdkPath  = Path.Combine (PreferredJdksOverridePath, "microsoft_dist_openjdk_1.8.999.9");
+				JdkInfoTests.CreateFauxJdk (newJdkPath, releaseVersion: "1.8.999", releaseBuildNumber: "9", javaVersion: "1.8.999-9");
 
 				if (File.Exists (UnixConfigPath))
 					File.Move (UnixConfigPath, backupConfig);


### PR DESCRIPTION
Fixes: http://work.devdiv.io/661401

The version numbers which the Microsoft OpenJDK packages provide was
not consistent with what `JdkInfo` expected: the `release` file would
have a `JAVA_VERSION` value which was a three-tuple, and didn't
include the `BUILD_NUMBER` value.  For example:

	JAVA_VERSION="1.8.0"
	BUILD_NUMBER=7

Unfortunately, `JdkInfo.GetJavaVersion()` was only taking
`JAVA_VERSION` into consideration, so when multiple different OpenJDK
packages were processed which all had the *same* `JAVA_VERSION` value
but *different* `BUILD_NUMBER` values,
`JdkInfo.GetMacOSMicrosoftJdks()` returned the "wrong" one first.
(In actuality, the one it returned first was not knowable, and was
probably whatever `Directory.EnumerateDirectories()` returned first.)

Simple enough, we just need to take `BUILD_NUMBER` into consideration
as part of constructing `JdkInfo.Version`, right?

Not so fast.  Turns Out™ that the version value held within
`JAVA_VERSION` or the `java.version` property -- which need not be
identical! -- can also contain `-`, not just `_`.  A "Java Version" is
*really" (at least) 4 optional parts:

	JAVA_VERSION : VERSION ('_' UPDATE)? ('-' MILESTONE)? ('-' SUFFIX)?

Which means Java version values such as `1.8.0_1-9-microsoft-b00` are
possible, from various different locations, e.g. the `version` value
vs. the `build` value in `java -version` output:

	$ bin/java -version
	openjdk version "1.8.0-9"
	OpenJDK Runtime Environment (build 1.8.0-9-microsoft-b00)
	OpenJDK 64-Bit Server VM (build 25.71-b00, mixed mode)

Instead of trying to top-down parse a version number, go for a
"bottom-up" parsing:

 1. Replace all *non-digit* characters with `.`
 2. Split the value on (1) on `.`, creating an array, and remove all
    empty values.
 3. Separately parse the values in (2) as part of `System.Version`
    construction.

This allows at least a sane-ish, plausible, `Version` construction.
`1.8.0_161-b12` will be parsed as `new Version(1, 8, 0, 161)` (as
we'll just grab up to the first four values), and we'll gracefully
ignore any other non-digit characters in the string.

This allows us to better construct a `Version` value for Microsoft
OpenJDK packages, allowing us in turn to *sort* the packages, which
allows `JdkInfo>GetMacOSMicrosoftJdks()` to return the highest version
*first*, as is desired.