### PR TITLE
Log what is happening during path selection

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
@@ -122,7 +122,9 @@ namespace Xamarin.Android.Tools
 		/// </summary>
 		public bool ValidateAndroidSdkLocation (string loc)
 		{
-			return !string.IsNullOrEmpty (loc) && ProcessUtils.FindExecutablesInDirectory (Path.Combine (loc, "platform-tools"), Adb).Any ();
+			bool result = !string.IsNullOrEmpty (loc) && ProcessUtils.FindExecutablesInDirectory (Path.Combine (loc, "platform-tools"), Adb).Any ();
+			Logger (TraceLevel.Verbose, $"{nameof (ValidateAndroidSdkLocation)}: `{loc}`, result={result}");
+			return result;
 		}
 
 		/// <summary>
@@ -130,7 +132,9 @@ namespace Xamarin.Android.Tools
 		/// </summary>
 		public virtual bool ValidateJavaSdkLocation (string loc)
 		{
-			return !string.IsNullOrEmpty (loc) && ProcessUtils.FindExecutablesInDirectory (Path.Combine (loc, "bin"), JarSigner).Any ();
+			bool result = !string.IsNullOrEmpty (loc) && ProcessUtils.FindExecutablesInDirectory (Path.Combine (loc, "bin"), JarSigner).Any ();
+			Logger (TraceLevel.Verbose, $"{nameof (ValidateJavaSdkLocation)}: `{loc}`, result={result}");
+			return result;
 		}
 
 		/// <summary>
@@ -138,7 +142,9 @@ namespace Xamarin.Android.Tools
 		/// </summary>
 		public bool ValidateAndroidNdkLocation (string loc)
 		{
-			return !string.IsNullOrEmpty (loc) && ProcessUtils.FindExecutablesInDirectory (loc, NdkStack).Any ();
+			bool result = !string.IsNullOrEmpty (loc) && ProcessUtils.FindExecutablesInDirectory (loc, NdkStack).Any ();
+			Logger (TraceLevel.Verbose, $"{nameof (ValidateAndroidNdkLocation)}: `{loc}`, result={result}");
+			return result;
 		}
 
 		protected static string NullIfEmpty (string s)


### PR DESCRIPTION
Downstream, in the proprietary parts of Xamarin.Android, there is some
strange errors occurring, such as:

    Task "InstallPackageAssemblies"
    InstallPackageAssemblies Task
        ...
        AndroidSdkPath: /Users/builder/android-toolchain/sdk
        AndroidNdkPath: /Users/builder/android-toolchain/ndk
        JavaSdkPath: /usr
    Xamarin.Android.Common.Debugging.targets(479,2): error ADB0000:  Error finding Android/Java SDKs [/Users/builder/jenkins/workspace/monodroid-pr/monodroid/tests/runtime/Xamarin.Android.RuntimeTests.csproj]
    Xamarin.Android.Common.Debugging.targets(479,2): error ADB0000: System.InvalidOperationException: Could not determine Android SDK location. Please provide `androidSdkPath`. [/Users/builder/jenkins/workspace/monodroid-pr/monodroid/tests/runtime/Xamarin.Android.RuntimeTests.csproj]
    Xamarin.Android.Common.Debugging.targets(479,2): error ADB0000:   at Xamarin.Android.Tools.AndroidSdkInfo..ctor (System.Action`2[T1,T2] logger, System.String androidSdkPath, System.String androidNdkPath, System.String javaSdkPath) [0x0004b] in <5fd439f4454d4cc18bc8c35d2b4c840c>:0  [/Users/builder/jenkins/workspace/monodroid-pr/monodroid/tests/runtime/Xamarin.Android.RuntimeTests.csproj]
    Xamarin.Android.Common.Debugging.targets(479,2): error ADB0000:   at Xamarin.AndroidTools.AndroidSdk.Refresh (System.String androidSdkPath, System.String androidNdkPath, System.String javaSdkPath) [0x00000] in <9cb77bd2eef54f10a4aa7622ee40470d>:0  [/Users/builder/jenkins/workspace/monodroid-pr/monodroid/tests/runtime/Xamarin.Android.RuntimeTests.csproj]

We are having a lot of trouble even figuring out what is going on,
since the EXACT SAME paths worked earlier in the same build. Earlier
in the log `ResolveSdks` worked just fine!

I'm hoping this logging information will help us troubleshoot this
issue and other scenarios in the future.