### PR TITLE
[tests] fix test failures on Windows

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidSdkInfoTests.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidSdkInfoTests.cs
@@ -74,6 +74,9 @@ namespace Xamarin.Android.Tools.Tests
 		[Test]
 		public void Constructor_SetValuesFromPath ()
 		{
+			if (OS.IsWindows)
+				Assert.Ignore ("Windows does not look for values in %PATH%");
+
 			CreateSdks (out string root, out string jdk, out string ndk, out string sdk);
 			JdkInfoTests.CreateFauxJdk (jdk, releaseVersion: "1.8.0", releaseBuildNumber: "42", javaVersion: "100.100.100_100");
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/JdkInfoTests.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/JdkInfoTests.cs
@@ -60,15 +60,19 @@ namespace Xamarin.Android.Tools.Tests
 			Directory.CreateDirectory (jli);
 			Directory.CreateDirectory (jre);
 
-
+			string quote = OS.IsWindows ? "" : "\"";
 			string java =
 				$"echo Property settings:{Environment.NewLine}" +
-				$"echo \"    java.home = {dir}\"{Environment.NewLine}" +
-				$"echo \"    java.vendor = Xamarin.Android Unit Tests\"{Environment.NewLine}" +
-				$"echo \"    java.version = {javaVersion}\"{Environment.NewLine}" +
-				$"echo \"    xamarin.multi-line = line the first\"{Environment.NewLine}" +
-				$"echo \"        line the second\"{Environment.NewLine}" +
-				$"echo \"        .\"{Environment.NewLine}";
+				$"echo {quote}    java.home = {dir}{quote}{Environment.NewLine}" +
+				$"echo {quote}    java.vendor = Xamarin.Android Unit Tests{quote}{Environment.NewLine}" +
+				$"echo {quote}    java.version = {javaVersion}{quote}{Environment.NewLine}" +
+				$"echo {quote}    xamarin.multi-line = line the first{quote}{Environment.NewLine}" +
+				$"echo {quote}        line the second{quote}{Environment.NewLine}" +
+				$"echo {quote}        .{quote}{Environment.NewLine}";
+
+			if (OS.IsWindows) {
+				java = $"@echo off{Environment.NewLine}{java}";
+			}
 
 			CreateShellScript (Path.Combine (bin, "jar"), "");
 			CreateShellScript (Path.Combine (bin, "java"), java);
@@ -86,7 +90,7 @@ namespace Xamarin.Android.Tools.Tests
 
 		static void CreateShellScript (string path, string contents)
 		{
-			if (OS.IsWindows)
+			if (OS.IsWindows && string.Compare (Path.GetExtension (path), ".dll", true) != 0)
 				path += ".cmd";
 			using (var script = new StreamWriter (path)) {
 				if (!OS.IsWindows) {


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/blob/b0e6c579f773e55419573e210b648d81b78360ef/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs#L237

Just a few minor things to get these working:
- We need `@echo off` on Windows
- `echo` doesn't need quotes, or it echos the quotes
- We don't need to emit `jvm.dll` as `jvm.dll.cmd`
- There is one test checking `PATH`, which doesn't occur on Windows. It doesn't look in `%PATH%`, so we should ignore it on Windows.