### PR TITLE
Better support no installed JDKs on macOS

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -10,10 +10,9 @@ namespace Xamarin.Android.Tools
 	{
 		AndroidSdkBase sdk;
 
-		public AndroidSdkInfo (Action<TraceLevel, string> logger, string androidSdkPath = null, string androidNdkPath = null, string javaSdkPath = null)
+		public AndroidSdkInfo (Action<TraceLevel, string> logger = null, string androidSdkPath = null, string androidNdkPath = null, string javaSdkPath = null)
 		{
-			if (logger == null)
-				throw new ArgumentNullException (nameof (logger));
+			logger  = logger ?? DefaultConsoleLogger;
 
 			sdk = CreateSdk (logger);
 			sdk.Initialize (androidSdkPath, androidNdkPath, javaSdkPath);

--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -345,7 +345,7 @@ namespace Xamarin.Android.Tools
 					if (string.IsNullOrEmpty (e.Data))
 						return;
 					xml.Append (e.Data);
-			});
+			}, includeStderr: false);
 			var plist   = XElement.Parse (xml.ToString ());
 			foreach (var info in plist.Elements ("array").Elements ("dict")) {
 				var JVMHomePath = (XNode) info.Elements ("key").FirstOrDefault (e => e.Value == "JVMHomePath");

--- a/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs
@@ -131,7 +131,7 @@ namespace Xamarin.Android.Tools
 			return tcs.Task;
 		}
 
-		internal static void Exec (ProcessStartInfo processStartInfo, DataReceivedEventHandler output)
+		internal static void Exec (ProcessStartInfo processStartInfo, DataReceivedEventHandler output, bool includeStderr = true)
 		{
 			processStartInfo.UseShellExecute         = false;
 			processStartInfo.RedirectStandardInput   = false;
@@ -144,7 +144,9 @@ namespace Xamarin.Android.Tools
 				StartInfo   = processStartInfo,
 			};
 			p.OutputDataReceived    += output;
-			p.ErrorDataReceived     += output;
+			if (includeStderr) {
+				p.ErrorDataReceived   += output;
+			}
 
 			using (p) {
 				p.Start ();

--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidSdkInfoTests.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidSdkInfoTests.cs
@@ -43,13 +43,6 @@ namespace Xamarin.Android.Tools.Tests
 		}
 
 		[Test]
-		public void Constructor_NullLogger ()
-		{
-			Action<TraceLevel, string> logger = null;
-			Assert.Throws<ArgumentNullException> (() => new AndroidSdkInfo (logger));
-		}
-
-		[Test]
 		public void Constructor_Paths ()
 		{
 			CreateSdks (out string root, out string jdk, out string ndk, out string sdk);


### PR DESCRIPTION
What happens if there is no JDK installed on macOS?

	$ mv ~/Library/Developer/Xamarin/jdk ~/Library/Developer/Xamarin/jdk.bk
	$ sudo mv /Library/Java/JavaVirtualMachines /Library/Java/JavaVirtualMachines.bk

`JdkInfo` doesn't like this, which is to be expected, but *how* it
doesn't like it is...bad:

	$ csharp -r:bin/Debug/Xamarin.Android.Tools.AndroidSdk.dll
	csharp> Xamarin.Android.Tools.JdkInfo.GetKnownSystemJdkInfos();
	Error getting SDK info:
	System.Xml.XmlException: Data at the root level is invalid. Line 1, position 1.
	  at System.Xml.XmlTextReaderImpl.Throw (System.Exception e)
	  at System.Xml.XmlTextReaderImpl.Throw (System.String res, System.String arg)
	  at System.Xml.XmlTextReaderImpl.Throw (System.String res)
	  at System.Xml.XmlTextReaderImpl.ParseRootLevelWhitespace ()
	  at System.Xml.XmlTextReaderImpl.ParseDocumentContent ()
	  at System.Xml.XmlTextReaderImpl.Read ()
	  at System.Xml.XmlReader.MoveToContent ()
	  at System.Xml.Linq.XElement.Load (System.Xml.XmlReader reader, System.Xml.Linq.LoadOptions options)
	  at System.Xml.Linq.XElement.Parse (System.String text, System.Xml.Linq.LoadOptions options)
	  at System.Xml.Linq.XElement.Parse (System.String text)
	  at Xamarin.Android.Tools.JdkInfo+<GetLibexecJdkPaths>d__54.MoveNext ()
	  ...

Er, what?

The problem is the output of `/usr/libexec/java_home -X`:

	$ /usr/libexec/java_home -X
	Unable to find any JVMs matching version "(null)".
	<?xml version="1.0" encoding="UTF-8"?>
	<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
	<plist version="1.0">
	<array/>
	</plist>
	No Java runtime present, try --request to install.

What's happening is that `java_home` is writing XML to stdout, and an
error message to stderr.  `ProcessUtils.Exec()`, meanwhile, was
*merging **both*** `stdout` and `stderr` into *one* stream, and the
result was *not* valid XML, hence the `XmlException`.

The fix?  Allow `stderr` to be separate from `stdout`, so that
`JdkInfo.GetLibexecJdkPaths()` can get valid XML.

Additionally, because I'm finding it increasingly annoying needing to
provide the `logger` parameter to `AndroidSdkInfo`/etc., update the
`AndroidSdkInfo` constructor so that `logger` is *optional*.  If it
isn't provided, we'll write our log messages to `System.Console`.