### PR TITLE
Check if system Java is installed

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -200,6 +200,23 @@ namespace Xamarin.Android.Tools
 			return GetJavaProperties (ProcessUtils.FindExecutablesInDirectory (Path.Combine (HomePath, "bin"), "java").First ());
 		}
 
+		static bool AnySystemJavasInstalled ()
+		{
+			if (OS.IsMac) {
+				string path = Path.Combine (Path.DirectorySeparatorChar + "System", "Library", "Java", "JavaVirtualMachines");
+				if (!Directory.Exists (path)) {
+					return false;
+				}
+
+				string[] dirs = Directory.GetDirectories (path);
+				if (dirs == null || dirs.Length == 0) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+
 		static Dictionary<string, List<string>> GetJavaProperties (string java)
 		{
 			var javaProps   = new ProcessStartInfo {
@@ -209,6 +226,10 @@ namespace Xamarin.Android.Tools
 
 			var     props   = new Dictionary<string, List<string>> ();
 			string  curKey  = null;
+
+			if (!AnySystemJavasInstalled () && (java == "/usr/bin/java" || java == "java"))
+				return props;
+
 			ProcessUtils.Exec (javaProps, (o, e) => {
 					const string ContinuedValuePrefix   = "        ";
 					const string NewValuePrefix         = "    ";


### PR DESCRIPTION
This checks for /System/Library/Java/JavaVirtualMachines if we're
trying to use the system java. If there is no system Java installed
then calling /usr/bin/java has the unfortunate effect of popping up
a dialog telling the user to install a JDK.

Fixes VSTS #735545

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/735545