### PR TITLE
Made KnownVersions public

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
@@ -134,7 +134,7 @@ namespace Xamarin.Android.Tools
 				KnownVersions.FirstOrDefault (v => MatchesId (v, id))?.FrameworkVersion;
 		}
 
-		static readonly AndroidVersion [] KnownVersions = new [] {
+		public static readonly AndroidVersion [] KnownVersions = new [] {
 			new AndroidVersion (4,  "1.6",   "Donut"),
 			new AndroidVersion (5,  "2.0",   "Eclair"),
 			new AndroidVersion (6,  "2.0.1", "Eclair"),


### PR DESCRIPTION
KnownVersions should be the only place we modify when new versions are
published. AndroidVersions right now provides information on what's
installed and what's supported, but not what exists. For Android
Manifest we also need to know what exists because Minimum Android
Version and Target may be anything (regardless of what the compile
version is). This is related to:
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/777180