### PR TITLE
Added ndk-bundle directories to ndk search in Windows

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -194,6 +194,17 @@ namespace Xamarin.Android.Tools
 
 			Logger (TraceLevel.Info, "Looking for Android NDK...");
 
+			// Check for the "ndk-bundle" directory inside the SDK directories
+			string ndk;
+
+			var sdks = GetAllAvailableAndroidSdks().ToList();
+			sdks.Add(AndroidSdkPath);
+	
+			foreach(var sdk in sdks.Distinct())
+				if (Directory.Exists(ndk = Path.Combine(sdk, "ndk-bundle")))
+					if (ValidateAndroidNdkLocation(ndk))
+						yield return ndk;
+
 			// Check for the key the user gave us in the VS/addin options
 			foreach (var root in roots)
 				if (CheckRegistryKeyForExecutable (root, regKey, MDREG_ANDROID_NDK, wow, ".", NdkStack))

--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidSdkInfoTests.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidSdkInfoTests.cs
@@ -65,6 +65,36 @@ namespace Xamarin.Android.Tools.Tests
 		}
 
 		[Test]
+		public void Ndk_PathInSdk()
+		{
+			if (!OS.IsWindows)
+				Assert.Ignore("This only works in Windows");
+
+			CreateSdks(out string root, out string jdk, out string ndk, out string sdk);
+
+			var logs = new StringWriter();
+			Action<TraceLevel, string> logger = (level, message) => {
+				logs.WriteLine($"[{level}] {message}");
+			};
+
+			try
+			{
+				var ndkPath = Path.Combine(sdk, "ndk-bundle");
+				Directory.CreateDirectory(ndkPath);
+				Directory.CreateDirectory(Path.Combine(ndkPath, "toolchains"));
+				File.WriteAllText(Path.Combine(ndkPath, "ndk-stack.cmd"), "");
+
+				var info = new AndroidSdkInfo(logger, androidSdkPath: sdk, androidNdkPath: null, javaSdkPath: jdk);
+				
+				Assert.AreEqual(ndkPath, info.AndroidNdkPath, "AndroidNdkPath not found inside sdk!");
+			}
+			finally
+			{
+				Directory.Delete(root, recursive: true);
+			}
+		}
+
+		[Test]
 		public void Constructor_SetValuesFromPath ()
 		{
 			if (OS.IsWindows)


### PR DESCRIPTION
A few versions ago, the ndk started shipping inside the sdk path. In VS
we are now checking this directories, and only using the registry keys
as fallbacks (meaning, if the ndk exists in the sdk it takes priority
over anything else). According to our telemetry, 100% of the users are
using the ndk this way. This commit adds that check so we can have
parity between what Android does and what VS does. Also, it serves as
preparation for VS removing that option (meaning, it will not be
configurable and _always_ work in the way described in this commit).