### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Add VS 2017 v15.7 NDK fallback path

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -221,10 +221,19 @@ namespace Xamarin.Android.Tools
 			var vs_default = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.CommonApplicationData), "Microsoft", "AndroidNDK");
 			var vs_default32bit = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.CommonApplicationData), "Microsoft", "AndroidNDK32");
 			var vs_2017_default = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.CommonApplicationData), "Microsoft", "AndroidNDK64");
+			var vs2017_shared_install_dir =
+				RegistryEx.GetValueString (RegistryEx.LocalMachine, @"SOFTWARE\Policies\Microsoft\VisualStudio\Setup", "SharedInstallationPath", RegistryEx.Wow64.Key32) ??
+				RegistryEx.GetValueString (RegistryEx.LocalMachine, @"SOFTWARE\Microsoft\VisualStudio\Setup", "SharedInstallationPath", RegistryEx.Wow64.Key32) ??
+				RegistryEx.GetValueString (RegistryEx.LocalMachine, @"SOFTWARE\Policies\Microsoft\VisualStudio\Setup", "SharedInstallationPath", RegistryEx.Wow64.Key64) ??
+				RegistryEx.GetValueString (RegistryEx.LocalMachine, @"SOFTWARE\Microsoft\VisualStudio\Setup", "SharedInstallationPath", RegistryEx.Wow64.Key64) ??
+				@"C:\";
+			var vs2017_install_drive = Path.GetPathRoot (vs2017_shared_install_dir);
+			var vs_2017_new_default32bit = Path.Combine (vs2017_install_drive, "Microsoft", "AndroidNDK");
+			var vs_2017_new_default = Path.Combine (vs2017_install_drive, "Microsoft", "AndroidNDK64");
 			var android_default = Path.Combine (OS.ProgramFilesX86, "Android");
 			var cdrive_default = @"C:\";
 
-			foreach (var basePath in new string [] {xamarin_private, android_default, vs_default, vs_default32bit, vs_2017_default, cdrive_default})
+			foreach (var basePath in new string [] {xamarin_private, android_default, vs_default, vs_default32bit, vs_2017_default, vs_2017_new_default32bit, vs_2017_new_default, cdrive_default })
 				if (Directory.Exists (basePath))
 					foreach (var dir in Directory.GetDirectories (basePath, "android-ndk-r*"))
 						if (ValidateAndroidNdkLocation (dir))

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -233,7 +233,7 @@ namespace Xamarin.Android.Tools
 			var android_default = Path.Combine (OS.ProgramFilesX86, "Android");
 			var cdrive_default = @"C:\";
 
-			foreach (var basePath in new string [] {xamarin_private, android_default, vs_default, vs_default32bit, vs_2017_default, vs_2017_new_default32bit, vs_2017_new_default, cdrive_default })
+			foreach (var basePath in new string [] {xamarin_private, android_default, vs_default, vs_default32bit, vs_2017_default, vs_2017_new_default32bit, vs_2017_new_default, cdrive_default})
 				if (Directory.Exists (basePath))
 					foreach (var dir in Directory.GetDirectories (basePath, "android-ndk-r*"))
 						if (ValidateAndroidNdkLocation (dir))


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2694

Before Visual Studio 2017 version 15.7, the Visual Studio Installer
installed the default Android NDK for the **Mobile development with
C++** workload into:

    [CommonApplicationData]\Microsoft\AndroidNDK64

Starting with Visual Studio 2017 version 15.7, that location changed to:

    [SharedInstallDrive]\Microsoft\AndroidNDK64

Visual Studio 2019 Preview uses that same new location.

This commit adds the new install location to the list of hardcoded NDK
search paths.  It uses the same approach as the **Mobile development
with C++** workload MSBuild targets to get the value of
`[SharedInstallDrive]` based on the `SharedInstallationPath` registry
value.

I tested this change locally with Xamarin.Android apps configured to use
the **Bundle assemblies into native code** and **AOT Compilation
(Experimental)** features.  I verified that the apps failed to build
without this change and built successfully with it.  The builds
correctly located the default Visual Studio 2017 Android NDK
installation even when the `MDREG_ANDROID_SDK` registry value was empty.

I also looked at adding an NUnit test, but that would be tricky because
the test would ideally need to set a registry value, and the
`RegistryEx` class is not visible from the tests.  On top of that, the
`RegistryEx.SetValueString()` method can't write the necessary value in
the `LocalMachine` registry hive without elevated user permissions.