### PR TITLE
[Xamarin.Android.Tools.AndroidSdk][Windows] Allow preferred Android SDK path be empty.

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Android.Tools
 			androidNdkPath  = androidNdkPath ?? PreferedAndroidNdkPath;
 			javaSdkPath     = javaSdkPath ?? PreferedJavaSdkPath;
 
-			AndroidSdkPath  = ValidateAndroidSdkLocation (androidSdkPath) ? androidSdkPath : AllAndroidSdks.FirstOrDefault ();
+			AndroidSdkPath  = androidSdkPath ?? AllAndroidSdks.FirstOrDefault ();
 			AndroidNdkPath  = ValidateAndroidNdkLocation (androidNdkPath) ? androidNdkPath : AllAndroidNdks.FirstOrDefault ();
 			JavaSdkPath     = ValidateJavaSdkLocation (javaSdkPath) ? javaSdkPath : GetJavaSdkPath ();
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -36,9 +36,7 @@ namespace Xamarin.Android.Tools
 			get {
 				var wow = RegistryEx.Wow64.Key32;
 				var regKey = GetMDRegistryKey ();
-				if (CheckRegistryKeyForExecutable (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_SDK, wow, "platform-tools", Adb))
-					return RegistryEx.GetValueString (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_SDK, wow);
-				return null;
+				return NullIfEmpty (RegistryEx.GetValueString (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_SDK, wow));
 			}
 		}
 		public override string PreferedAndroidNdkPath {


### PR DESCRIPTION
Use Android SDK path from Windows registry as preferred even if the path doesn't exist in system. The idea is to make Android SDK Installer able to install SDK tools if it wasn't installed within the Xamarin extension, as it is now optional in Willow.

Task #718086