### PR TITLE
Downgrade to net46 for compatibility with VS2017+

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Xamarin.Android.Tools.Tests</RootNamespace>
     <AssemblyName>Xamarin.Android.Tools.AndroidSdk-Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Android.Tools</RootNamespace>
     <AssemblyName>Xamarin.Android.Tools.AndroidSdk</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Under VS2017+, code must either target net46 or net472 and nothing in between.
Otherwise, run-time errors might happen if the wrong assemblies (facades for NS2 support)
are inadvertently bound at compile time and loaded at run-time.

(d16-2 backport)