### PR TITLE
[905583]Fix to catch unauthorized exception when config file is created while setting sdkpath

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -159,9 +159,9 @@ namespace Xamarin.Android.Tools
 		{
 			logger  = logger ?? DefaultConsoleLogger;
 
-			var sdk = CreateSdk (logger);
-            bool setSDKPath = sdk.SetPreferredAndroidSdkPath(path);
-            return setSDKPath;
+                        var sdk = CreateSdk(logger); 
+                        bool setSDKPath = sdk.SetPreferredAndroidSdkPath(path);
+                        return setSDKPath;
 		}
 
 		public static void SetPreferredJavaSdkPath (string path, Action<TraceLevel, string> logger = null)

--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -160,8 +160,7 @@ namespace Xamarin.Android.Tools
 			logger  = logger ?? DefaultConsoleLogger;
 
                         var sdk = CreateSdk(logger); 
-                        bool setSDKPath = sdk.SetPreferredAndroidSdkPath(path);
-                        return setSDKPath;
+                        return sdk.SetPreferredAndroidSdkPath(path);
 		}
 
 		public static void SetPreferredJavaSdkPath (string path, Action<TraceLevel, string> logger = null)

--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -155,12 +155,13 @@ namespace Xamarin.Android.Tools
 			}
 		}
 
-		public static void SetPreferredAndroidSdkPath (string path, Action<TraceLevel, string> logger = null)
+		public static bool SetPreferredAndroidSdkPath (string path, Action<TraceLevel, string> logger = null)
 		{
 			logger  = logger ?? DefaultConsoleLogger;
 
 			var sdk = CreateSdk (logger);
-			sdk.SetPreferredAndroidSdkPath (path);
+            bool setSDKPath = sdk.SetPreferredAndroidSdkPath(path);
+            return setSDKPath;
 		}
 
 		public static void SetPreferredJavaSdkPath (string path, Action<TraceLevel, string> logger = null)

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
@@ -109,7 +109,7 @@ namespace Xamarin.Android.Tools
 		protected abstract string GetJavaSdkPath ();
 		protected abstract string GetShortFormPath (string path);
 
-		public abstract void SetPreferredAndroidSdkPath (string path);
+		public abstract bool SetPreferredAndroidSdkPath (string path);
 		public abstract void SetPreferredJavaSdkPath (string path);
 		public abstract void SetPreferredAndroidNdkPath (string path);
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -133,7 +133,7 @@ namespace Xamarin.Android.Tools
 			return path;
 		}
 
-		public override void SetPreferredAndroidSdkPath (string path)
+		public override bool SetPreferredAndroidSdkPath (string path)
 		{
 			path = NullIfEmpty (path);
 
@@ -145,8 +145,9 @@ namespace Xamarin.Android.Tools
 				doc.Root.Add (androidEl);
 			}
 
-			androidEl.SetAttributeValue ("path", path);
-			SaveConfig (doc, Logger);
+                       androidEl.SetAttributeValue("path", path);
+                       bool setConfig = SaveConfig(doc, Logger);
+                       return setConfig;
 		}
 
 		public override void SetPreferredJavaSdkPath (string path)
@@ -181,7 +182,7 @@ namespace Xamarin.Android.Tools
 			SaveConfig (doc, Logger);
 		}
 
-		void SaveConfig (XDocument doc, Action<TraceLevel, string> logger)
+		bool SaveConfig (XDocument doc, Action<TraceLevel, string> logger)
 		{
 			string cfg = UnixConfigPath;
 			List <string> created = null;
@@ -196,6 +197,7 @@ namespace Xamarin.Android.Tools
                                 catch (Exception ex)
                                 {
                                     logger(TraceLevel.Error, $"Unable to create directory {dir}, user do not have the right permissions, {ex.Message}.");
+                                    return false;
                                 }
                                     AddToList(dir);
                         }   
@@ -210,6 +212,7 @@ namespace Xamarin.Android.Tools
 					created = new List <string> ();
 				created.Add (path);
 			}
+                return true;
 		}
 
 		static  readonly    string  GetUnixConfigDirOverrideName            = $"UnixConfigPath directory override! {typeof (AndroidSdkInfo).AssemblyQualifiedName}";

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -146,7 +146,7 @@ namespace Xamarin.Android.Tools
 			}
 
 			androidEl.SetAttributeValue ("path", path);
-			SaveConfig (doc);
+			SaveConfig (doc, Logger);
 		}
 
 		public override void SetPreferredJavaSdkPath (string path)
@@ -162,7 +162,7 @@ namespace Xamarin.Android.Tools
 			}
 
 			javaEl.SetAttributeValue ("path", path);
-			SaveConfig (doc);
+			SaveConfig (doc, Logger);
 		}
 
 		public override void SetPreferredAndroidNdkPath (string path)
@@ -178,10 +178,10 @@ namespace Xamarin.Android.Tools
 			}
 
 			androidEl.SetAttributeValue ("path", path);
-			SaveConfig (doc);
+			SaveConfig (doc, Logger);
 		}
 
-		void SaveConfig (XDocument doc)
+		void SaveConfig (XDocument doc, Action<TraceLevel, string> logger)
 		{
 			string cfg = UnixConfigPath;
 			List <string> created = null;
@@ -189,11 +189,18 @@ namespace Xamarin.Android.Tools
 			if (!File.Exists (cfg)) {
 				string dir = Path.GetDirectoryName (cfg);
 				if (!Directory.Exists (dir)) {
-					Directory.CreateDirectory (dir);
-					AddToList (dir);
-				}
-				AddToList (cfg);
-			}
+                                try
+                                {
+                                    Directory.CreateDirectory(dir);
+                                }
+                                catch (Exception ex)
+                                {
+                                    logger(TraceLevel.Error, $"Unable to create directory {dir}, user do not have the right permissions, {ex.Message}.");
+                                }
+                                    AddToList(dir);
+                        }   
+        	   	AddToList (cfg);
+    		}
 			doc.Save (cfg);
 			FixOwnership (created);
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -236,10 +236,11 @@ namespace Xamarin.Android.Tools
 			return KernelEx.GetShortPathName (path);
 		}
 
-		public override void SetPreferredAndroidSdkPath (string path)
+		public override bool SetPreferredAndroidSdkPath (string path)
 		{
 			var regKey = GetMDRegistryKey ();
 			RegistryEx.SetValueString (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_SDK, path ?? "", RegistryEx.Wow64.Key32);
+                return true;
 		}
 
 		public override void SetPreferredJavaSdkPath (string path)

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -237,10 +237,10 @@ namespace Xamarin.Android.Tools
 		}
 
 		public override bool SetPreferredAndroidSdkPath (string path)
-		{
-			var regKey = GetMDRegistryKey ();
-			RegistryEx.SetValueString (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_SDK, path ?? "", RegistryEx.Wow64.Key32);
-                return true;
+		{               
+                        var regKey = GetMDRegistryKey();
+                        RegistryEx.SetValueString(RegistryEx.CurrentUser, regKey, MDREG_ANDROID_SDK, path ?? "", RegistryEx.Wow64.Key32);
+                        return true;
 		}
 
 		public override void SetPreferredJavaSdkPath (string path)


### PR DESCRIPTION
Partially Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/905583, Need change in installer code, once this is fixed in xamarin-android-tools.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/905583, VS for Mac installer throws an unauthorized exception, while creating ~/.config files to set sdk path. This PR catches the unhandled exception. 
VS for Mac installer needs a return value to check if the SetPreferredAndroidSDKPath was successful, I changed the  return value of "SetPreferredAndroidSDKPath" to bool to get a return value. I am not sure the impact of this change in other parts of IDE. Let me know if there are other ways to solve this issue. 

A fix for this issue is required, since there are a couple of reports of this unauthorized exception while running installer.