### PR TITLE
Avoids NRE trying to get the list of available NDK if the AndroidSdk path is null

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -229,7 +229,8 @@ namespace Xamarin.Android.Tools
 			string ndk;
 
 			var sdks = GetAllAvailableAndroidSdks().ToList();
-			sdks.Add(AndroidSdkPath);
+			if (!string.IsNullOrEmpty(AndroidSdkPath))
+				sdks.Add(AndroidSdkPath);
 	
 			foreach(var sdk in sdks.Distinct())
 				if (Directory.Exists(ndk = Path.Combine(sdk, "ndk-bundle")))


### PR DESCRIPTION
- fixes bug 938504: AndroidSdk initialization fails with a System.ArgumentNullException when no AndroidSdk is detected on the user machine
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/938504