### PR TITLE
Fixed programfiles64 path for 32-bit apps

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -93,7 +93,9 @@ namespace Xamarin.Android.Tools
 				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), "Xamarin", "MonoAndroid", "android-sdk-windows"),
 				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86), "Android", "android-sdk"),
 				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86), "Android", "android-sdk-windows"),
-				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ProgramFiles), "Android", "android-sdk"),
+				!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("ProgramW6432"))
+					? Path.Combine (Environment.GetEnvironmentVariable ("ProgramW6432"), "Android", "android-sdk")
+					: Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ProgramFiles), "Android", "android-sdk"),
 				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), "Android", "android-sdk"),
 				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.CommonApplicationData), "Android", "android-sdk"),
 				@"C:\android-sdk-windows"


### PR DESCRIPTION
Use new ProgramW6432 envar if available so that both Prefer32Bit=false and Prefer32Bit=true apps
could get the path.
Otherwise Environment.SpecialFolder.ProgramFiles returns `"C:\\Program Files (x86)"` for 32-bit apps on 64-bit OS.