### PR TITLE
Support side by side NDK installations in SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ src/*.dll
 bin
 **/obj
 packages/
-TestResult-*.xml
+TestResult*.xml
 .vs/

--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -46,32 +46,18 @@ namespace Xamarin.Android.Tools
 			var buildTools  = Path.Combine (AndroidSdkPath, "build-tools");
 			if (Directory.Exists (buildTools)) {
 				var preview = Directory.EnumerateDirectories (buildTools)
-					.Where(x => TryParseVersion (Path.GetFileName (x)) == null)
+					.Where(x => sdk.TryParseVersion (Path.GetFileName (x)) == null)
 					.Select(x => x);
 
 				foreach (var d in preview)
 					yield return d;
 
-				var sorted = from p in Directory.EnumerateDirectories (buildTools)
-					let version = TryParseVersion (Path.GetFileName (p))
-						where version != null
-					orderby version descending
-					select p;
-
-				foreach (var d in sorted)
+				foreach (var d in sdk.GetSortedToolDirectoryPaths (buildTools))
 					yield return d;
 			}
 			var ptPath  = Path.Combine (AndroidSdkPath, "platform-tools");
 			if (Directory.Exists (ptPath))
 				yield return ptPath;
-		}
-
-		static Version TryParseVersion (string v)
-		{
-			Version version;
-			if (Version.TryParse (v, out version))
-				return version;
-			return null;
 		}
 
 		public IEnumerable<AndroidVersion> GetInstalledPlatformVersions (AndroidVersions versions)

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
@@ -199,10 +199,8 @@ namespace Xamarin.Android.Tools
 
 		public Version TryParseVersion (string v)
 		{
-			Version version;
-			if (Version.TryParse (v, out version))
-				return version;
-			return null;
+			Version.TryParse (v, out Version version);
+			return version;
 		}
 
 		public IEnumerable<string> GetSortedToolDirectoryPaths (string topToolDirectory)

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -125,6 +125,10 @@ namespace Xamarin.Android.Tools
 				if (ValidateAndroidNdkLocation (ndkDir))
 					yield return ndkDir;
 			}
+
+			// Check for NDK directories inside the SDK directories
+			foreach (var ndk in FindNdkPathsInAndroidSdkPaths ())
+				yield return ndk;
 		}
 
 		protected override string GetShortFormPath (string path)

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -237,17 +237,9 @@ namespace Xamarin.Android.Tools
 
 			Logger (TraceLevel.Info, "Looking for Android NDK...");
 
-			// Check for the "ndk-bundle" directory inside the SDK directories
-			string ndk;
-
-			var sdks = GetAllAvailableAndroidSdks().ToList();
-			if (!string.IsNullOrEmpty(AndroidSdkPath))
-				sdks.Add(AndroidSdkPath);
-	
-			foreach(var sdk in sdks.Distinct())
-				if (Directory.Exists(ndk = Path.Combine(sdk, "ndk-bundle")))
-					if (ValidateAndroidNdkLocation(ndk))
-						yield return ndk;
+			// Check for NDK directories inside the SDK directories
+			foreach (var ndk in FindNdkPathsInAndroidSdkPaths ())
+				yield return ndk;
 
 			// Check for the key the user gave us in the VS/addin options
 			foreach (var root in roots)

--- a/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidSdkInfoTests.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Tests/AndroidSdkInfoTests.cs
@@ -113,7 +113,8 @@ namespace Xamarin.Android.Tools.Tests
 					Environment.SetEnvironmentVariable ("PATH", "dummypath");
 
 				var ndkPath = Path.Combine (sdk, "ndk", "20.0.5594570");
-				Directory.CreateDirectory(ndkPath);
+				Directory.CreateDirectory (ndkPath);
+				Directory.CreateDirectory (Path.Combine (sdk, "ndk", "noversion"));
 				CreateFauxAndroidNdkDirectory (ndkPath);
 				var info = new AndroidSdkInfo (logger, androidSdkPath: sdk, androidNdkPath: null, javaSdkPath: jdk);
 				Assert.AreEqual (ndkPath, info.AndroidNdkPath, "Versioned AndroidNdkPath not found inside sdk!");


### PR DESCRIPTION
The NDK can now be installed by the sdkmanager tool in a side by side
fashion inside the Android SDK. Currently only the `ndk;20.0.5594570`
package exists, and it installs into `$(AndroidSdk)/ndk/20.0.5594570`.

We should re-use the logic used to look up and sort `build-tools` folders
to locate these new NDK installation locations. Additionally, we should
check both the `ndk-bundle` and new `ndk/$(VERSION)` paths on macOS if
we are otherwise unable to locate an NDK installation there.