### PR TITLE
[AndroidSdkWindows] Guard against exception checking registry.

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -303,19 +303,23 @@ namespace Xamarin.Android.Tools
 		#region Helper Methods
 		private static bool CheckRegistryKeyForExecutable (UIntPtr key, string subkey, string valueName, RegistryEx.Wow64 wow64, string subdir, string exe)
 		{
-			string key_name = string.Format (@"{0}\{1}\{2}", key == RegistryEx.CurrentUser ? "HKCU" : "HKLM", subkey, valueName);
+			try {
+				string key_name = string.Format (@"{0}\{1}\{2}", key == RegistryEx.CurrentUser ? "HKCU" : "HKLM", subkey, valueName);
 
-			var path = NullIfEmpty (RegistryEx.GetValueString (key, subkey, valueName, wow64));
+				var path = NullIfEmpty (RegistryEx.GetValueString (key, subkey, valueName, wow64));
 
-			if (path == null) {
+				if (path == null) {
+					return false;
+				}
+
+				if (!ProcessUtils.FindExecutablesInDirectory (Path.Combine (path, subdir), exe).Any ()) {
+					return false;
+				}
+
+				return true;
+			} catch (Exception) {
 				return false;
 			}
-
-			if (!ProcessUtils.FindExecutablesInDirectory (Path.Combine (path, subdir), exe).Any ()) {
-				return false;
-			}
-
-			return true;
 		}
 		#endregion
 


### PR DESCRIPTION
In https://developercommunity.visualstudio.com/content/problem/883179/ilegal-characters-in-path-after-fresh-install.html, the user is hitting an exception when checking for an executable from paths found in their registry.

If we hit an error we should just return `false` as there obviously isn't a valid install located there.