### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Remove net461

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <Title>Xamarin.Android.Tools</Title>


### PR DESCRIPTION
@DmitriyKirakosyan ran into a build failure when attempting to bump
xamarin/android-sdk-installer to use commit bfb66f38:

	external\androidtools\external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj(0,0):
	Error MSB4057: The target "BuiltProjectOutputGroupDependencies" does not exist in the project.

[Further investigation][0] showed that the MSB4057 occurs because
`Xamarin.Android.Tools.AndroidSdk.csproj` uses the `$(TargetFrameworks)`
property (plural), and to avoid the MSB4057 the `$(TargetFramework)`
property (singular) should instead be used.

As `Xamarin.Android.Tools.AndroidSdk.csproj` also targets
.NET Standard 2.0, and [.NET Standard 2.0 supports .NET 4.6][1],
we can fix the MSB4057 by dropping the build of `net461`.

[0]: https://stackoverflow.com/a/43481827
[1]: https://docs.microsoft.com/en-us/dotnet/standard/net-standard