### PR TITLE
Add support for new 'cmdline-tools'

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -185,5 +185,18 @@ namespace Xamarin.Android.Tools
 			var sdk = CreateSdk (logger);
 			sdk.SetPreferredJavaSdkPath (latestJdk.HomePath);
 		}
+
+		public static string GetPreferredAndroidToolsPath(string androidSdkPath)
+		{
+			var toolsDir = Path.Combine (androidSdkPath, "cmdline-tools");
+			if (!Directory.Exists (toolsDir))
+				return toolsDir;
+
+			if (Directory.Exists (Path.Combine (toolsDir, "latest")))
+				return Path.Combine (toolsDir, "latest");
+
+			var latestToolsDir = Directory.GetDirectories (toolsDir).Max ();
+			return Path.Combine (toolsDir, latestToolsDir);
+		}
 	}
 }

--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -189,8 +189,14 @@ namespace Xamarin.Android.Tools
 		public static string GetPreferredAndroidToolsPath(string androidSdkPath)
 		{
 			var toolsDir = Path.Combine (androidSdkPath, "cmdline-tools");
-			if (!Directory.Exists (toolsDir))
+			if (!Directory.Exists (toolsDir)) {
+				// Trying to fallback to "tools"
+				var oldToolsDir = Path.Combine (androidSdkPath, "tools");
+				if (Directory.Exists (oldToolsDir))
+					return oldToolsDir;
+
 				return toolsDir;
+			}
 
 			if (Directory.Exists (Path.Combine (toolsDir, "latest")))
 				return Path.Combine (toolsDir, "latest");

--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -195,7 +195,7 @@ namespace Xamarin.Android.Tools
 				if (Directory.Exists (oldToolsDir))
 					return oldToolsDir;
 
-				return toolsDir;
+				return Path.Combine(toolsDir, "latest");
 			}
 
 			if (Directory.Exists (Path.Combine (toolsDir, "latest")))

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
@@ -37,9 +37,7 @@ namespace Xamarin.Android.Tools
 		public string AndroidNdkPath { get; private set; }
 		public string JavaSdkPath { get; private set; }
 		public string JavaBinPath { get; private set; }
-		public string AndroidToolsPath { get; private set; }
 		public string AndroidPlatformToolsPath { get; private set; }
-		public string AndroidToolsPathShort { get; private set; }
 		public string AndroidPlatformToolsPathShort { get; private set; }
 
 		public virtual string Adb { get; protected set; } = "adb";
@@ -76,13 +74,9 @@ namespace Xamarin.Android.Tools
 			}
 
 			if (!string.IsNullOrEmpty (AndroidSdkPath)) {
-				AndroidToolsPath = AndroidSdkInfo.GetPreferredAndroidToolsPath(AndroidSdkPath);
-				AndroidToolsPathShort = GetShortFormPath (AndroidToolsPath);
 				AndroidPlatformToolsPath = Path.Combine (AndroidSdkPath, "platform-tools");
 				AndroidPlatformToolsPathShort = GetShortFormPath (AndroidPlatformToolsPath);
 			} else {
-				AndroidToolsPath = null;
-				AndroidToolsPathShort = null;
 				AndroidPlatformToolsPath = null;
 				AndroidPlatformToolsPathShort = null;
 			}
@@ -98,9 +92,7 @@ namespace Xamarin.Android.Tools
 			// we need to look for extensions other than the default .exe|.bat
 			// google have a habbit of changing them.
 			Adb = GetExecutablePath (AndroidPlatformToolsPath, Adb);
-			Android = GetExecutablePath (AndroidToolsPath, Android);
 			Emulator = GetExecutablePath (Path.Combine (AndroidSdkPath, "emulator"), Emulator);
-			Monitor = GetExecutablePath (AndroidToolsPath, Monitor);
 			NdkStack = GetExecutablePath (AndroidNdkPath, NdkStack);
 		}
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
@@ -41,9 +41,6 @@ namespace Xamarin.Android.Tools
 		public string AndroidPlatformToolsPathShort { get; private set; }
 
 		public virtual string Adb { get; protected set; } = "adb";
-		public virtual string Android { get; protected set; } = "android";
-		public virtual string Emulator { get; protected set; } = "emulator";
-		public virtual string Monitor { get; protected set; } = "monitor";
 		public virtual string ZipAlign { get; protected set; } = "zipalign";
 		public virtual string JarSigner { get; protected set; } = "jarsigner";
 		public virtual string KeyTool { get; protected set; } = "keytool";
@@ -92,7 +89,6 @@ namespace Xamarin.Android.Tools
 			// we need to look for extensions other than the default .exe|.bat
 			// google have a habbit of changing them.
 			Adb = GetExecutablePath (AndroidPlatformToolsPath, Adb);
-			Emulator = GetExecutablePath (Path.Combine (AndroidSdkPath, "emulator"), Emulator);
 			NdkStack = GetExecutablePath (AndroidNdkPath, NdkStack);
 		}
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Android.Tools
 			}
 
 			if (!string.IsNullOrEmpty (AndroidSdkPath)) {
-				AndroidToolsPath = Path.Combine (AndroidSdkPath, "tools");
+				AndroidToolsPath = AndroidSdkInfo.GetPreferredAndroidToolsPath(AndroidSdkPath);
 				AndroidToolsPathShort = GetShortFormPath (AndroidToolsPath);
 				AndroidPlatformToolsPath = Path.Combine (AndroidSdkPath, "platform-tools");
 				AndroidPlatformToolsPathShort = GetShortFormPath (AndroidPlatformToolsPath);
@@ -99,7 +99,7 @@ namespace Xamarin.Android.Tools
 			// google have a habbit of changing them.
 			Adb = GetExecutablePath (AndroidPlatformToolsPath, Adb);
 			Android = GetExecutablePath (AndroidToolsPath, Android);
-			Emulator = GetExecutablePath (AndroidToolsPath, Emulator);
+			Emulator = GetExecutablePath (Path.Combine (AndroidSdkPath, "emulator"), Emulator);
 			Monitor = GetExecutablePath (AndroidToolsPath, Monitor);
 			NdkStack = GetExecutablePath (AndroidNdkPath, NdkStack);
 		}

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
@@ -167,20 +167,20 @@ namespace Xamarin.Android.Tools.Tests
 		[Test]
 		public void Sdk_PreferredToolsPath ()
 		{
-			var root = CreateRoot ();
-			var sdk = Path.Combine (root, "sdk");
-			var latestToolsVersion = "latest";
-			var toolsVersion = "1.1";
-			var higherToolsVersion = "1.2";
+			var root                = CreateRoot ();
+			var sdk                 = Path.Combine (root, "sdk");
+			var latestToolsVersion  = "latest";
+			var toolsVersion        = "1.1";
+			var higherToolsVersion  = "1.2";
 			
 			Directory.CreateDirectory (sdk);
 			void recreateSdkDirectory () {
-				Directory.Delete (sdk, true);
+				Directory.Delete (sdk, recursive: true);
 				Directory.CreateDirectory (sdk);
 			}
 			
 			var failureMessage = "GetPreferredAndroidToolsPath should return \"cmdline-tools\" if it is installed";
-			CreateFauxAndroidSdkToolsDirectory (sdk, true, toolsVersion, false);
+			CreateFauxAndroidSdkToolsDirectory (sdk, createToolsDir: true, toolsVersion: toolsVersion, createOldToolsDir: false);
 
 			var toolsPath = AndroidSdkInfo.GetPreferredAndroidToolsPath (sdk);
 			Assert.AreEqual (toolsPath, Path.Combine (sdk, "cmdline-tools", toolsVersion), failureMessage);
@@ -188,7 +188,7 @@ namespace Xamarin.Android.Tools.Tests
 			
 			failureMessage = "GetPreferredAndroidToolsPath should return \"cmdline-tools\", if both \"tools\" and \"cmdline-tools\" are installed";
 			recreateSdkDirectory ();
-			CreateFauxAndroidSdkToolsDirectory (sdk, true, latestToolsVersion, true);
+			CreateFauxAndroidSdkToolsDirectory (sdk, createToolsDir: true, toolsVersion: latestToolsVersion, createOldToolsDir: true);
 
 			toolsPath = AndroidSdkInfo.GetPreferredAndroidToolsPath (sdk);
 			Assert.AreEqual (toolsPath, Path.Combine (sdk, "cmdline-tools", latestToolsVersion), failureMessage);
@@ -196,9 +196,9 @@ namespace Xamarin.Android.Tools.Tests
 
 			failureMessage = "GetPreferredAndroidToolsPath should return \"<sdk>/cmdline-tools/latest\", if multiple versions are installed, including \"latest\"";
 			recreateSdkDirectory ();
-			CreateFauxAndroidSdkToolsDirectory (sdk, true, latestToolsVersion, false);
-			CreateFauxAndroidSdkToolsDirectory (sdk, true, toolsVersion, false);
-			CreateFauxAndroidSdkToolsDirectory (sdk, true, higherToolsVersion, false);
+			CreateFauxAndroidSdkToolsDirectory (sdk, createToolsDir: true,  toolsVersion: latestToolsVersion,   createOldToolsDir: false);
+			CreateFauxAndroidSdkToolsDirectory (sdk, createToolsDir: true,  toolsVersion: toolsVersion,         createOldToolsDir: false);
+			CreateFauxAndroidSdkToolsDirectory (sdk, createToolsDir: true,  toolsVersion: higherToolsVersion,   createOldToolsDir: false);
 
 			toolsPath = AndroidSdkInfo.GetPreferredAndroidToolsPath (sdk);
 			Assert.AreEqual (toolsPath, Path.Combine (sdk, "cmdline-tools", latestToolsVersion), failureMessage);
@@ -206,16 +206,16 @@ namespace Xamarin.Android.Tools.Tests
 
 			failureMessage = "GetPreferredAndroidToolsPath should return \"<sdk>/cmdline-tools/<max-version>\", if multiple versions are installed";
 			recreateSdkDirectory ();
-			CreateFauxAndroidSdkToolsDirectory (sdk, true, toolsVersion, false);
-			CreateFauxAndroidSdkToolsDirectory (sdk, true, higherToolsVersion, false);
+			CreateFauxAndroidSdkToolsDirectory (sdk, createToolsDir: true, toolsVersion: toolsVersion,          createOldToolsDir: false);
+			CreateFauxAndroidSdkToolsDirectory (sdk, createToolsDir: true, toolsVersion: higherToolsVersion,    createOldToolsDir: false);
 
 			toolsPath = AndroidSdkInfo.GetPreferredAndroidToolsPath (sdk);
-			Assert.AreEqual (toolsPath, Path.Combine (sdk, "cmdline-tools", higherToolsVersion), failureMessage);
+			Assert.AreEqual (toolsPath, Path.Combine (sdk, "cmdline-tools", toolsVersion: higherToolsVersion), failureMessage);
 
 
 			failureMessage = "GetPreferredAndroidToolsPath should return \"tools\" if it is installed and \"cmdline-tools\" isn't";
 			recreateSdkDirectory ();
-			CreateFauxAndroidSdkToolsDirectory (sdk, false, toolsVersion, true);
+			CreateFauxAndroidSdkToolsDirectory (sdk, createToolsDir: false, toolsVersion: toolsVersion,     createOldToolsDir: true);
 
 			toolsPath = AndroidSdkInfo.GetPreferredAndroidToolsPath (sdk);
 			Assert.AreEqual (toolsPath, Path.Combine (sdk, "tools"), failureMessage);
@@ -260,34 +260,34 @@ namespace Xamarin.Android.Tools.Tests
 		static void CreateFauxAndroidSdkToolsDirectory (string androidSdkDirectory, bool createToolsDir, string toolsVersion, bool createOldToolsDir)
 		{
 			if (createToolsDir) {
-				string androidSdkToolsPath = Path.Combine (androidSdkDirectory, "cmdline-tools", toolsVersion ?? "1.0");
-				var androidSDdkToolsBinPath = Path.Combine (androidSdkToolsPath, "bin");
+				string androidSdkToolsPath    = Path.Combine (androidSdkDirectory, "cmdline-tools", toolsVersion ?? "1.0");
+				string androidSdkToolsBinPath = Path.Combine (androidSdkToolsPath, "bin");
 				
 				Directory.CreateDirectory (androidSdkToolsPath);
-				Directory.CreateDirectory (androidSDdkToolsBinPath);
+				Directory.CreateDirectory (androidSdkToolsBinPath);
 				
-				File.WriteAllText (Path.Combine (androidSdkToolsPath, IsWindows ? "lint.bat" : "lint"), "");
+				File.WriteAllText (Path.Combine (androidSdkToolsBinPath, IsWindows ? "lint.bat" : "lint"), "");
 			}
 
 			if (createOldToolsDir) {
-				string androidSdkToolsPath = Path.Combine (androidSdkDirectory, "tools");
-				var androidSDdkToolsBinPath = Path.Combine (androidSdkToolsPath, "bin");
+				string androidSdkToolsPath    = Path.Combine (androidSdkDirectory, "tools");
+				string androidSDdkToolsBinPath = Path.Combine (androidSdkToolsPath, "bin");
 
 				Directory.CreateDirectory (androidSdkToolsPath);
-				Directory.CreateDirectory (androidSDdkToolsBinPath);
+				Directory.CreateDirectory (androidSdkToolsBinPath);
 			
-				File.WriteAllText (Path.Combine (androidSdkToolsPath, IsWindows ? "lint.bat" : "lint"), "");
+				File.WriteAllText (Path.Combine (androidSdkToolsBinPath, IsWindows ? "lint.bat" : "lint"), "");
 			}
 
 		}
 
 		static void CreateFauxAndroidSdkDirectory (
-			string androidSdkDirectory,
-			string buildToolsVersion,
-			bool createToolsDir = true,
-			string toolsVersion = null,
-			bool createOldToolsDir = false,
-			ApiInfo [] apiLevels = null)
+				string  androidSdkDirectory,
+				string  buildToolsVersion,
+				bool    createToolsDir = true,
+				string  toolsVersion = null,
+				bool    createOldToolsDir = false,
+				ApiInfo[]   apiLevels = null)
 		{
 			CreateFauxAndroidSdkToolsDirectory (androidSdkDirectory, createToolsDir, toolsVersion, createOldToolsDir);
 			

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
@@ -170,8 +170,8 @@ namespace Xamarin.Android.Tools.Tests
 			var root                = CreateRoot ();
 			var sdk                 = Path.Combine (root, "sdk");
 			var latestToolsVersion  = "latest";
-			var toolsVersion        = "1.1";
-			var higherToolsVersion  = "1.2";
+			var toolsVersion        = "2.1";
+			var higherToolsVersion  = "11.2";
 			
 			Directory.CreateDirectory (sdk);
 			void recreateSdkDirectory () {

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
@@ -180,14 +180,14 @@ namespace Xamarin.Android.Tools.Tests
 			Directory.CreateDirectory (ndk);
 			Directory.CreateDirectory (jdk);
 
-			CreateFauxAndroidSdkDirectory (sdk, "26.0.0");
+			CreateFauxAndroidSdkDirectory (sdk, "26.0.0", "1.0");
 			CreateFauxAndroidNdkDirectory (ndk);
 			CreateFauxJavaSdkDirectory (jdk, "1.8.0", out var _, out var _);
 		}
 
-		static void CreateFauxAndroidSdkDirectory (string androidSdkDirectory, string buildToolsVersion, ApiInfo [] apiLevels = null)
+		static void CreateFauxAndroidSdkDirectory (string androidSdkDirectory, string buildToolsVersion, string toolsVersion, ApiInfo [] apiLevels = null)
 		{
-			var androidSdkToolsPath             = Path.Combine (androidSdkDirectory, "tools");
+			var androidSdkToolsPath             = Path.Combine (androidSdkDirectory, "cmdline-tools", toolsVersion);
 			var androidSdkBinPath               = Path.Combine (androidSdkToolsPath, "bin");
 			var androidSdkPlatformToolsPath     = Path.Combine (androidSdkDirectory, "platform-tools");
 			var androidSdkPlatformsPath         = Path.Combine (androidSdkDirectory, "platforms");

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
@@ -210,7 +210,7 @@ namespace Xamarin.Android.Tools.Tests
 			CreateFauxAndroidSdkToolsDirectory (sdk, createToolsDir: true, toolsVersion: higherToolsVersion,    createOldToolsDir: false);
 
 			toolsPath = AndroidSdkInfo.GetPreferredAndroidToolsPath (sdk);
-			Assert.AreEqual (toolsPath, Path.Combine (sdk, "cmdline-tools", toolsVersion: higherToolsVersion), failureMessage);
+			Assert.AreEqual (toolsPath, Path.Combine (sdk, "cmdline-tools", higherToolsVersion), failureMessage);
 
 
 			failureMessage = "GetPreferredAndroidToolsPath should return \"tools\" if it is installed and \"cmdline-tools\" isn't";
@@ -271,7 +271,7 @@ namespace Xamarin.Android.Tools.Tests
 
 			if (createOldToolsDir) {
 				string androidSdkToolsPath    = Path.Combine (androidSdkDirectory, "tools");
-				string androidSDdkToolsBinPath = Path.Combine (androidSdkToolsPath, "bin");
+				string androidSdkToolsBinPath = Path.Combine (androidSdkToolsPath, "bin");
 
 				Directory.CreateDirectory (androidSdkToolsPath);
 				Directory.CreateDirectory (androidSdkToolsBinPath);


### PR DESCRIPTION
Google replaced 'tools' with 'cmdline-tools'
Android sdk now supports multiple 'cmdline-tools' versions installed SxS

For the sake of simplicity, using latest installed version for now.

Since new 'cmdline-tools' doesnt contain Emulator executable, replaced the searching path with `Path.Combine (AndroidSdkPath, "emulator")`

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1109288