### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Improve utility of JDK warnings

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -340,7 +340,7 @@ namespace Xamarin.Android.Tools
 				jdk = new JdkInfo (path, locator);
 			}
 			catch (Exception e) {
-				logger (TraceLevel.Warning, $"Not a valid JDK directory: `{path}`; via locator: {locator}");
+				logger (TraceLevel.Warning, $"The directory `{path}`, via locator `{locator}`, is not a valid JDK directory: {e.Message}");
 				logger (TraceLevel.Verbose, e.ToString ());
 			}
 			return jdk;

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -121,7 +121,7 @@ namespace Xamarin.Android.Tools
 					jdk = new JdkInfo (path, locator);
 				}
 				catch (Exception e) {
-					logger (TraceLevel.Warning, $"Not a valid JDK directory: `{path}`; via category: {locator}");
+					logger (TraceLevel.Warning, $"The directory `{path}`, via locator `{locator}`, is not a valid JDK directory: {e.Message}");
 					logger (TraceLevel.Verbose, e.ToString ());
 				}
 				return jdk;


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4567
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3781637&view=logs&j=aacb7678-d5ef-5d73-dd2c-3def32e966f3&t=36563657-e889-567e-4d1d-090ca934735a

We're trying to get our CI to use JDK11 (xamarin/xamarin-android#4567),
for which we added support for a `JI_JAVA_HOME` environment variable
"override"; see 13cc497a.

However, even with `JI_JAVA_HOME` set, `nuget restore` still fails:

	…\Xamarin.Android.Tooling.targets(65,5): warning XA5300: Not a valid JDK directory: `C:\Users\dlab14\android-toolchain\jdk`; via locator: $JI_JAVA_HOME

The question is *why* it's an invalid JDK directory.  (It certainly
looks like it should be valid!)

While we *do* print out the contents of `e.ToString()`, this is only
written as "verbose" output, which isn't captured by `nuget restore`.
As such, we have no idea why the JDK directory is not considered valid.

Update the warning message that Java.Interop emits when checking JDK
locations so that it includes `Exception.Message`, e.g.

	The directory `/invalid`, via locator `$JI_JAVA_HOME`, is not a valid JDK directory: Not a directory

This will hopefully provide enough detail to let us know why it's
failing.