### PR TITLE
Add API 29 and 30 to KnownVersions

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
@@ -176,6 +176,12 @@ namespace Xamarin.Android.Tools
 			new AndroidVersion (28, "9.0",   "Pie") {
 				AlternateIds = new[]{ "P" },
 			},
+			new AndroidVersion (29, "10.0",  "Android10") {
+				AlternateIds = new[]{ "Q" },
+			},
+			new AndroidVersion (30, "11.0") {
+				AlternateIds = new[]{ "R" },
+			},
 		};
 	}
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4873

Although this is related to https://github.com/xamarin/xamarin-android/pull/4873, it is not the full fix. We probably should list the missing versions here anyway, though.