### PR TITLE
Return a default for unknown API levels

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
@@ -92,7 +92,8 @@ namespace Xamarin.Android.Tools
 		public int? GetApiLevelFromId (string id)
 		{
 			return installedVersions.FirstOrDefault (v => MatchesId (v, id))?.ApiLevel ??
-				KnownVersions.FirstOrDefault (v => MatchesId (v, id))?.ApiLevel;
+				KnownVersions.FirstOrDefault (v => MatchesId (v, id))?.ApiLevel ??
+				(int.TryParse (id, out int apiLevel) ? apiLevel : default (int?));
 		}
 
 		static bool MatchesId (AndroidVersion version, string id)
@@ -105,7 +106,8 @@ namespace Xamarin.Android.Tools
 		public string? GetIdFromApiLevel (int apiLevel)
 		{
 			return installedVersions.FirstOrDefault (v => v.ApiLevel == apiLevel)?.Id ??
-				KnownVersions.FirstOrDefault (v => v.ApiLevel == apiLevel)?.Id;
+				KnownVersions.FirstOrDefault (v => v.ApiLevel == apiLevel)?.Id ??
+				apiLevel.ToString ();
 		}
 
 		// Sometimes, e.g. when new API levels are introduced, the "API level" is a letter, not a number,
@@ -115,7 +117,8 @@ namespace Xamarin.Android.Tools
 			if (int.TryParse (apiLevel, out var platform))
 				return GetIdFromApiLevel (platform);
 			return installedVersions.FirstOrDefault (v => MatchesId (v, apiLevel))?.Id ??
-				KnownVersions.FirstOrDefault (v => MatchesId (v, apiLevel))?.Id;
+				KnownVersions.FirstOrDefault (v => MatchesId (v, apiLevel))?.Id ??
+				apiLevel;
 		}
 
 		public string? GetIdFromFrameworkVersion (string frameworkVersion)

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidVersionsTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidVersionsTests.cs
@@ -202,9 +202,9 @@ namespace Xamarin.Android.Tools.Tests
 			Assert.AreEqual ("II",  versions.GetIdFromApiLevel ("14"));
 			Assert.AreEqual ("II",  versions.GetIdFromApiLevel ("II"));
 
-			Assert.AreEqual (null,  versions.GetIdFromApiLevel (-1));
-			Assert.AreEqual (null,  versions.GetIdFromApiLevel ("-1"));
-			Assert.AreEqual (null,  versions.GetIdFromApiLevel ("D"));
+			Assert.AreEqual ("-1",  versions.GetIdFromApiLevel (-1));
+			Assert.AreEqual ("-1",  versions.GetIdFromApiLevel ("-1"));
+			Assert.AreEqual ("D",  versions.GetIdFromApiLevel ("D"));
 
 			// via KnownVersions
 			Assert.AreEqual ("11",  versions.GetIdFromApiLevel (11));


### PR DESCRIPTION
In .NET 5, there is a single `AndroidApiInfo.xml` file:

    <AndroidApiInfo>
      <Id>30</Id>
      <Level>30</Level>
      <Name>R</Name>
      <Version>v11.0</Version>
      <Stable>True</Stable>
    </AndroidApiInfo>

And so if you call `AndroidVersions.GetApiLevelFromId(29)` you would
always get `null` returned. This is because `KnownVersions` does not
have API 29 or 30 listed.

To fix this and *not* update `KnownVersions`, we can make the various
`GetApiLevelFromId` methods return the incoming API level as a last
resort.

So if 29 comes in, 29 can be returned and assumed to be a valid API
level.