### PR TITLE
Fix sort ordering for ndk-bundle, add macOS support

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -115,6 +115,14 @@ namespace Xamarin.Android.Tools
 
 		protected override IEnumerable<string> GetAllAvailableAndroidNdks ()
 		{
+			string ndk;
+
+			if (!string.IsNullOrEmpty (AndroidSdkPath) &&
+				Directory.Exists (ndk = Path.Combine (AndroidSdkPath, "ndk-bundle"))) {
+				if (ValidateAndroidNdkLocation (ndk))
+					yield return ndk;
+			}
+
 			var preferedNdkPath = PreferedAndroidNdkPath;
 			if (!string.IsNullOrEmpty (preferedNdkPath))
 				yield return preferedNdkPath!;
@@ -124,6 +132,16 @@ namespace Xamarin.Android.Tools
 				var ndkDir  = Path.GetDirectoryName (ndkStack);
 				if (ValidateAndroidNdkLocation (ndkDir))
 					yield return ndkDir;
+			}
+
+			// Check for the "ndk-bundle" directory inside the SDK directories
+			foreach (var sdk in GetAllAvailableAndroidSdks ()) {
+				if (sdk == AndroidSdkPath)
+					continue;
+				if (Directory.Exists (ndk = Path.Combine (sdk, "ndk-bundle"))) {
+					if (ValidateAndroidNdkLocation (ndk))
+						yield return ndk;
+				}
 			}
 		}
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -98,51 +98,15 @@ namespace Xamarin.Android.Tools
 				// Strip off "platform-tools"
 				var dir = Path.GetDirectoryName (path);
 
-				if (ValidateAndroidSdkLocation (dir))
-					yield return dir;
+				if (dir == null)
+					continue;
+
+				yield return dir;
 			}
 
 			// Check some hardcoded paths for good measure
 			var macSdkPath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), "Library", "Android", "sdk");
-			if (ValidateAndroidSdkLocation (macSdkPath))
-				yield return macSdkPath;
-		}
-
-		protected override string? GetJavaSdkPath ()
-		{
-			return JdkInfo.GetKnownSystemJdkInfos (Logger).FirstOrDefault ()?.HomePath;
-		}
-
-		protected override IEnumerable<string> GetAllAvailableAndroidNdks ()
-		{
-			string ndk;
-
-			if (!string.IsNullOrEmpty (AndroidSdkPath) &&
-				Directory.Exists (ndk = Path.Combine (AndroidSdkPath, "ndk-bundle"))) {
-				if (ValidateAndroidNdkLocation (ndk))
-					yield return ndk;
-			}
-
-			var preferedNdkPath = PreferedAndroidNdkPath;
-			if (!string.IsNullOrEmpty (preferedNdkPath))
-				yield return preferedNdkPath!;
-
-			// Look in PATH
-			foreach (var ndkStack in ProcessUtils.FindExecutablesInPath (NdkStack)) {
-				var ndkDir  = Path.GetDirectoryName (ndkStack);
-				if (ValidateAndroidNdkLocation (ndkDir))
-					yield return ndkDir;
-			}
-
-			// Check for the "ndk-bundle" directory inside the SDK directories
-			foreach (var sdk in GetAllAvailableAndroidSdks ()) {
-				if (sdk == AndroidSdkPath)
-					continue;
-				if (Directory.Exists (ndk = Path.Combine (sdk, "ndk-bundle"))) {
-					if (ValidateAndroidNdkLocation (ndk))
-						yield return ndk;
-				}
-			}
+			yield return macSdkPath;
 		}
 
 		protected override string GetShortFormPath (string path)

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -232,14 +232,20 @@ namespace Xamarin.Android.Tools
 			// Check for the "ndk-bundle" directory inside the SDK directories
 			string ndk;
 
-			var sdks = GetAllAvailableAndroidSdks().ToList();
-			if (!string.IsNullOrEmpty(AndroidSdkPath))
-				sdks.Add (AndroidSdkPath!);
-	
-			foreach(var sdk in sdks.Distinct())
-				if (Directory.Exists(ndk = Path.Combine(sdk, "ndk-bundle")))
-					if (ValidateAndroidNdkLocation(ndk))
+			if (!string.IsNullOrEmpty (AndroidSdkPath) &&
+					Directory.Exists (ndk = Path.Combine (AndroidSdkPath, "ndk-bundle"))) {
+				if (ValidateAndroidNdkLocation (ndk))
+					yield return ndk;
+			}
+
+			foreach (var sdk in GetAllAvailableAndroidSdks ()) {
+				if (sdk == AndroidSdkPath)
+					continue;
+				if (Directory.Exists (ndk = Path.Combine (sdk, "ndk-bundle"))) {
+					if (ValidateAndroidNdkLocation (ndk))
 						yield return ndk;
+				}
+			}
 
 			// Check for the key the user gave us in the VS/addin options
 			foreach (var root in roots)

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -102,14 +102,7 @@ namespace Xamarin.Android.Tools
 			};
 			foreach (var basePath in paths)
 				if (Directory.Exists (basePath))
-					if (ValidateAndroidSdkLocation (basePath))
-						yield return basePath;
-		}
-
-		protected override string? GetJavaSdkPath ()
-		{
-			var jdk = JdkInfo.GetKnownSystemJdkInfos (Logger).FirstOrDefault ();
-			return jdk?.HomePath;
+					yield return basePath;
 		}
 
 		internal static IEnumerable<JdkInfo> GetJdkInfos (Action<TraceLevel, string> logger)
@@ -223,29 +216,12 @@ namespace Xamarin.Android.Tools
 
 		protected override IEnumerable<string> GetAllAvailableAndroidNdks ()
 		{
+
 			var roots = new[] { RegistryEx.CurrentUser, RegistryEx.LocalMachine };
 			var wow = RegistryEx.Wow64.Key32;
 			var regKey = GetMDRegistryKey ();
 
 			Logger (TraceLevel.Info, "Looking for Android NDK...");
-
-			// Check for the "ndk-bundle" directory inside the SDK directories
-			string ndk;
-
-			if (!string.IsNullOrEmpty (AndroidSdkPath) &&
-					Directory.Exists (ndk = Path.Combine (AndroidSdkPath, "ndk-bundle"))) {
-				if (ValidateAndroidNdkLocation (ndk))
-					yield return ndk;
-			}
-
-			foreach (var sdk in GetAllAvailableAndroidSdks ()) {
-				if (sdk == AndroidSdkPath)
-					continue;
-				if (Directory.Exists (ndk = Path.Combine (sdk, "ndk-bundle"))) {
-					if (ValidateAndroidNdkLocation (ndk))
-						yield return ndk;
-				}
-			}
 
 			// Check for the key the user gave us in the VS/addin options
 			foreach (var root in roots)
@@ -271,6 +247,10 @@ namespace Xamarin.Android.Tools
 					foreach (var dir in Directory.GetDirectories (basePath, "android-ndk-r*"))
 						if (ValidateAndroidNdkLocation (dir))
 							yield return dir;
+
+			foreach (var dir in base.GetAllAvailableAndroidNdks ()) {
+				yield return dir;
+			}
 		}
 
 		protected override string GetShortFormPath (string path)

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
@@ -74,11 +74,8 @@ namespace Xamarin.Android.Tools.Tests
 				logs.WriteLine($"[{level}] {message}");
 			};
 
-			var oldPath = Environment.GetEnvironmentVariable ("PATH", EnvironmentVariableTarget.Process);
 			try
 			{
-				Environment.SetEnvironmentVariable ("PATH", "", EnvironmentVariableTarget.Process);
-
 				var extension = OS.IsWindows ? ".cmd" : "";
 				var ndkPath = Path.Combine(sdk, "ndk-bundle");
 				Directory.CreateDirectory(ndkPath);
@@ -91,7 +88,6 @@ namespace Xamarin.Android.Tools.Tests
 			}
 			finally
 			{
-				Environment.SetEnvironmentVariable ("PATH", oldPath, EnvironmentVariableTarget.Process);
 				Directory.Delete(root, recursive: true);
 			}
 		}

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
@@ -67,9 +67,6 @@ namespace Xamarin.Android.Tools.Tests
 		[Test]
 		public void Ndk_PathInSdk()
 		{
-			if (!OS.IsWindows)
-				Assert.Ignore("This only works in Windows");
-
 			CreateSdks(out string root, out string jdk, out string ndk, out string sdk);
 
 			var logs = new StringWriter();
@@ -77,12 +74,16 @@ namespace Xamarin.Android.Tools.Tests
 				logs.WriteLine($"[{level}] {message}");
 			};
 
+			var oldPath = Environment.GetEnvironmentVariable ("PATH", EnvironmentVariableTarget.Process);
 			try
 			{
+				Environment.SetEnvironmentVariable ("PATH", "", EnvironmentVariableTarget.Process);
+
+				var extension = OS.IsWindows ? ".cmd" : "";
 				var ndkPath = Path.Combine(sdk, "ndk-bundle");
 				Directory.CreateDirectory(ndkPath);
 				Directory.CreateDirectory(Path.Combine(ndkPath, "toolchains"));
-				File.WriteAllText(Path.Combine(ndkPath, "ndk-stack.cmd"), "");
+				File.WriteAllText(Path.Combine(ndkPath, $"ndk-stack{extension}"), "");
 
 				var info = new AndroidSdkInfo(logger, androidSdkPath: sdk, androidNdkPath: null, javaSdkPath: jdk);
 				
@@ -90,6 +91,7 @@ namespace Xamarin.Android.Tools.Tests
 			}
 			finally
 			{
+				Environment.SetEnvironmentVariable ("PATH", oldPath, EnvironmentVariableTarget.Process);
 				Directory.Delete(root, recursive: true);
 			}
 		}


### PR DESCRIPTION
Context: https://build.azdo.io/xamarin/public/21545

An environment change on Azure DevOps seems to cause the test failure
on Windows:

    Ndk_PathInSdk
    AndroidNdkPath not found inside sdk!
    Expected string length 71 but was 53. Strings differ at index 3.
    Expected: "C:\Users\VssAdministrator\AppData\Local\Temp\tmpAE78.tmp\sdk\..."
    But was: "C:\Program Files (x86)\Android\android-sdk\ndk-bundle"

It appears that `xamarin-android-tools` is preferring an `ndk-bundle
found on the system instead of the value passed in for
`AndroidSdkPath`.

To make matters worse, use of `Distinct()` returns an unordered
sequence, and so the sort ordering is unknown:

https://docs.microsoft.com/dotnet/api/system.linq.enumerable.distinct

To fix this, let's not use `ToList()` or add `AndroidSdkPath` to the
list at all. We can make an explicit check for it before the `foreach`
loop. Inside the loop we should skip `AndroidSdkPath`.

I also added the same code for the macOS/linux side in
`AndroidSdkUnix`.

I updated the `Ndk_PathInSdk` test so it will run on all platforms.