### PR TITLE
Add a .props file which contains the Android SDK Tools versions.

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
@@ -37,4 +37,9 @@
     </FilesToSign>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Xamarin.Android.Tools.Versions.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!--
+    This file contains the versions of the tooling which will be installed
+    by default on a users machine. They should be the latest stable versions
+    which xamarin.android works with. 
+    
+    If this file is changed the submodule for androidtools should be updated, 
+    along with any other repo which references androidtools. 
+    -->
+    <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">29.0.2</AndroidSdkBuildToolsVersion>
+    <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">1.0</AndroidCommandLineToolsVersion>
+    <AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">29.0.5</AndroidSdkPlatformToolsVersion>
+    <AndroidSdkToolsVersion Condition="'$(AndroidSdkToolsVersion)' == ''">26.1.1</AndroidSdkToolsVersion>
+    <AndroidSdkEmulatorVersion Condition="'$(AndroidSdkEmulatorVersion)' == ''"></AndroidSdkEmulatorVersion>
+    <AndroidSdkPlatformVersion Condition="'$(AndroidSdkPlatformVersion)' == ''">android-29</AndroidSdkPlatformVersion>
+    <AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">16.1</AndroidNdkVersion>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This commit is part of an effort to make sure all of our tooling uses
the same android sdk versions. It adds a MSbuild `.props` file
which contains the versions of parts of the Android Sdk. It is
these versions which will be installed/used by default when a
user first installs the product, or if they do not specify
other versions in their `csproj`.

If the new file is changed ALL repos referencing this one
will need to be updated. This includes all repos which pull
in this one via `androidtools`.