### PR TITLE
[build] fail macOS build if tests fail

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -39,6 +39,7 @@ jobs:
     displayName: 'Run Tests'
     inputs:
       testAssemblyVer2: 'bin\TestDebug\*-Tests.dll'
+      testRunTitle: windows-tests
   - powershell: |
       $hashOfLastVersionChange = & "git" "log" "--follow" "-1" "--pretty=%H" "nuget.version"
       $commitsSinceVersionChange = & "git" "rev-list" "--count" "$hashOfLastVersionChange..HEAD"
@@ -80,3 +81,5 @@ jobs:
     inputs:
       testResultsFormat: NUnit
       testResultsFiles: TestResult*.xml
+      testRunTitle: mac-tests
+      failTaskOnFailedTests: true


### PR DESCRIPTION
Context: https://docs.microsoft.com/azure/devops/pipelines/tasks/test/publish-test-results#yaml-snippet
Context: https://dev.azure.com/xamarin/public/_build/results?buildId=21614&view=ms.vss-test-web.build-test-results-tab

Currently, if a test fails on macOS the build will still be green.

We need to set `failTaskOnFailedTests` on the `PublishTestResults` step.

I also filled out `testRunTitle`, to fix the display name shown on
test results.