### PR TITLE
[XAT.AndroidSdk] Fix a few nullability warnings.

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
@@ -184,26 +184,4 @@ namespace Xamarin.Android.Tools
 			},
 		};
 	}
-
-	class EqualityComparer<T> : IEqualityComparer<T>
-	{
-		Func<T, T, bool>    equals;
-		Func<T, int>        getHashCode;
-
-		public EqualityComparer (Func<T, T, bool> equals, Func<T, int>? getHashCode = null)
-		{
-			this.equals         = equals;
-			this.getHashCode    = getHashCode ?? (v => v?.GetHashCode () ?? 0);
-		}
-
-		public bool Equals (T x, T y)
-		{
-			return equals (x, y);
-		}
-
-		public int GetHashCode (T obj)
-		{
-			return getHashCode (obj);
-		}
-	}
 }

--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -492,9 +492,9 @@ namespace Xamarin.Android.Tools
 	{
 		public  static  readonly    IComparer<JdkInfo> Default = new JdkInfoVersionComparer ();
 
-		public int Compare (JdkInfo x, JdkInfo y)
+		public int Compare ([AllowNull]JdkInfo x, [AllowNull]JdkInfo y)
 		{
-			if (x.Version != null && y.Version != null)
+			if (x?.Version != null && y?.Version != null)
 				return x.Version.CompareTo (y.Version);
 			return 0;
 		}


### PR DESCRIPTION
Fixes a few NRT warnings in `JdkInfoVersionComparer`.

There are also some NRT warnings in `EqualityComparer<T>`, but this class is `private` and not used anywhere, so we're removing it instead.