### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Prefer API-28 Component Versions

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
@@ -11,10 +11,10 @@
     -->
     <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">29.0.2</AndroidSdkBuildToolsVersion>
     <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">1.0</AndroidCommandLineToolsVersion>
-    <AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">29.0.5</AndroidSdkPlatformToolsVersion>
+    <AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">30.0.4</AndroidSdkPlatformToolsVersion>
     <AndroidSdkToolsVersion Condition="'$(AndroidSdkToolsVersion)' == ''">26.1.1</AndroidSdkToolsVersion>
     <AndroidSdkEmulatorVersion Condition="'$(AndroidSdkEmulatorVersion)' == ''"></AndroidSdkEmulatorVersion>
-    <AndroidSdkPlatformVersion Condition="'$(AndroidSdkPlatformVersion)' == ''">android-29</AndroidSdkPlatformVersion>
+    <AndroidSdkPlatformVersion Condition="'$(AndroidSdkPlatformVersion)' == ''">android-28</AndroidSdkPlatformVersion>
     <AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">16.1</AndroidNdkVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
We were late in attempting to update dependencies, resulting in an
"undesirable" first run experience on macOS+Visual Studio for Mac, in
which creating a new Xamarin.Forms project would elicit a dialog to
the user:

> **Android SDK components needed**
>
> The project … requires the following Android SDK
> components that are not currently installed:
>
> -- Android SDK Platform 28 v6
>
> The download will take a few minutes…
>
> [Cancel] [Download and Install]

…because the default template would be using Xamarin.Android
`$(TargetFrameworkVersion)`=v9.0 (API-28), which wasn't installed.

"Revert" MSBuild properties so that API-28 -related packages are
referenced, which will allow them to be installed on macOS, which will
thus prevent the above dialog from being shown:

  * `$(AndroidSdkBuildToolsVersion)`=28.0.3
  * `$(AndroidSdkPlatformToolsVersion)`=28.0.2
  * `$(AndroidSdkPlatformVersion)`=android-28