### PR TITLE
[tests] Use dotnet test to run AndroidSdk-Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@ bin
 **/obj
 packages/
 TestResult-*.xml
-TestResults/*
+**/TestResults/*.trx
 .vs/

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ bin
 **/obj
 packages/
 TestResult-*.xml
+TestResults/*
 .vs/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,8 @@
     "recommendations": [
       "ms-vscode.csharp",
       "ms-vscode.mono-debug",
-      "wghats.vscode-nxunit-test-adapter",
+      "hbenl.vscode-test-explorer",
+      "derivitec-ltd.vscode-dotnet-adapter",
       "visualstudioexptteam.vscodeintellicode",
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "nxunitExplorer.nunit": "packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe",
-    "nxunitExplorer.modules": [
-        "bin/TestDebug/Xamarin.Android.Tools.AndroidSdk-Tests.dll"
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnetCoreExplorer.searchpatterns": "bin/Test*/**/*-Tests.dll",
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "dotnetCoreExplorer.searchpatterns": "bin/Test*/**/*-Tests.dll",
+    "dotnetCoreExplorer.searchpatterns": "bin/Test*net*/**/*-Tests.dll",
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -30,7 +30,11 @@
         {
             "label": "Run Unit Tests",
             "type": "shell",
-            "command": "make run-all-tests",
+            "command": "dotnet",
+            "args": [
+                "test",
+                "${workspaceFolder}/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj"
+            ],
             "group": {
                 "kind": "test",
                 "isDefault": true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,10 +14,12 @@
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)-$(TargetFramework.ToLowerInvariant())</IntermediateOutputPath>
     <BuildToolOutputFullPath>$(MSBuildThisFileDirectory)bin\Build$(Configuration)\$(TargetFramework.ToLowerInvariant())\</BuildToolOutputFullPath>
     <ToolOutputFullPath>$(MSBuildThisFileDirectory)bin\$(Configuration)\$(TargetFramework.ToLowerInvariant())\</ToolOutputFullPath>
+    <TestOutputFullPath>$(MSBuildThisFileDirectory)bin\Test$(Configuration)-$(TargetFramework.ToLowerInvariant())\</TestOutputFullPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(XATBuildingForNetCoreApp)' != 'True' ">
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)</IntermediateOutputPath>
     <BuildToolOutputFullPath>$(MSBuildThisFileDirectory)bin\Build$(Configuration)\</BuildToolOutputFullPath>
     <ToolOutputFullPath>$(MSBuildThisFileDirectory)bin\$(Configuration)\</ToolOutputFullPath>
+    <TestOutputFullPath>$(MSBuildThisFileDirectory)bin\Test$(Configuration)\</TestOutputFullPath>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,12 +14,10 @@
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)-$(TargetFramework.ToLowerInvariant())</IntermediateOutputPath>
     <BuildToolOutputFullPath>$(MSBuildThisFileDirectory)bin\Build$(Configuration)\$(TargetFramework.ToLowerInvariant())\</BuildToolOutputFullPath>
     <ToolOutputFullPath>$(MSBuildThisFileDirectory)bin\$(Configuration)\$(TargetFramework.ToLowerInvariant())\</ToolOutputFullPath>
-    <TestOutputFullPath>$(MSBuildThisFileDirectory)bin\Test$(Configuration)-$(TargetFramework.ToLowerInvariant())\</TestOutputFullPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(XATBuildingForNetCoreApp)' != 'True' ">
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)</IntermediateOutputPath>
     <BuildToolOutputFullPath>$(MSBuildThisFileDirectory)bin\Build$(Configuration)\</BuildToolOutputFullPath>
     <ToolOutputFullPath>$(MSBuildThisFileDirectory)bin\$(Configuration)\</ToolOutputFullPath>
-    <TestOutputFullPath>$(MSBuildThisFileDirectory)bin\Test$(Configuration)\</TestOutputFullPath>
   </PropertyGroup>
 </Project>

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,7 @@ clean:
 
 prepare:
 	nuget restore Xamarin.Android.Tools.sln
+
+run-all-tests:
+	dotnet test -l "console;verbosity=detailed" -l trx \
+		tests/Xamarin.Android.Tools.AndroidSdk-Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj

--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,3 @@ clean:
 
 prepare:
 	nuget restore Xamarin.Android.Tools.sln
-
-run-all-tests: run-nunit-tests
-
-# $(call RUN_NUNIT_TEST,filename,log-lref?)
-define RUN_NUNIT_TEST
-	dotnet test $(1) -l "console;verbosity=detailed" \
-		-l "trx;LogFileName=bin/Test$(CONFIGURATION)/TestOutput-$(basename $(notdir $(1))).trx"
-endef
-
-NUNIT_TESTS = \
-	bin/Test$(CONFIGURATION)/Xamarin.Android.Tools.AndroidSdk-Tests.dll
-
-run-nunit-tests: $(NUNIT_TESTS)
-	$(foreach t,$(NUNIT_TESTS), $(call RUN_NUNIT_TEST,$(t),1))

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ run-all-tests: run-nunit-tests
 # $(call RUN_NUNIT_TEST,filename,log-lref?)
 define RUN_NUNIT_TEST
 	dotnet test $(1) -l "console;verbosity=detailed" \
-		-l "trx;LogFileName=bin/Test$(CONFIGURATION)/TestOutput-$(basename $(notdir $(1))).txt"
+		-l "trx;LogFileName=bin/Test$(CONFIGURATION)/TestOutput-$(basename $(notdir $(1))).trx"
 endef
 
 NUNIT_TESTS = \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 CONFIGURATION   := Debug
-NUNIT_CONSOLE   := packages/nunit.consolerunner/3.9.0/tools/nunit3-console.exe
 OS              := $(shell uname)
-RUNTIME         := mono --debug=casts
 V               ?= 0
 
 include build-tools/scripts/msbuild.mk
@@ -19,22 +17,11 @@ run-all-tests: run-nunit-tests
 
 # $(call RUN_NUNIT_TEST,filename,log-lref?)
 define RUN_NUNIT_TEST
-	MONO_TRACE_LISTENER=Console.Out \
-	$(RUNTIME) \
-		$(NUNIT_CONSOLE) $(NUNIT_EXTRA) $(1) \
-		$(if $(RUN),-run:$(RUN)) \
-		--result="TestResult-$(basename $(notdir $(1))).xml" \
-		-output=bin/Test$(CONFIGURATION)/TestOutput-$(basename $(notdir $(1))).txt \
-	|| true ; \
-	if [ -f "bin/Test$(CONFIGURATION)/TestOutput-$(basename $(notdir $(1))).txt" ] ; then \
-		cat bin/Test$(CONFIGURATION)/TestOutput-$(basename $(notdir $(1))).txt ; \
-	fi
+	dotnet test $(1) -l "console;verbosity=detailed"
 endef
 
-$(NUNIT_CONSOLE): prepare
-
 NUNIT_TESTS = \
-	bin/Test$(CONFIGURATION)/Xamarin.Android.Tools.AndroidSdk-Tests.dll
+	bin/Test$(CONFIGURATION)/netcoreapp3.1/Xamarin.Android.Tools.AndroidSdk-Tests.dll
 
 run-nunit-tests: $(NUNIT_TESTS)
 	$(foreach t,$(NUNIT_TESTS), $(call RUN_NUNIT_TEST,$(t),1))

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,12 @@ run-all-tests: run-nunit-tests
 
 # $(call RUN_NUNIT_TEST,filename,log-lref?)
 define RUN_NUNIT_TEST
-	dotnet test $(1) -l "console;verbosity=detailed"
+	dotnet test $(1) -l "console;verbosity=detailed" \
+		-l "trx;LogFileName=bin/Test$(CONFIGURATION)/TestOutput-$(basename $(notdir $(1))).txt"
 endef
 
 NUNIT_TESTS = \
-	bin/Test$(CONFIGURATION)/netcoreapp3.1/Xamarin.Android.Tools.AndroidSdk-Tests.dll
+	bin/Test$(CONFIGURATION)/Xamarin.Android.Tools.AndroidSdk-Tests.dll
 
 run-nunit-tests: $(NUNIT_TESTS)
 	$(foreach t,$(NUNIT_TESTS), $(call RUN_NUNIT_TEST,$(t),1))

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-     Our testing infrastructure depends on a known location for:
-     - nunit3-console.exe
--->
 <configuration>
   <packageSources>
     <clear />
@@ -15,7 +11,4 @@
      <!-- Android binary, to support delta APK install -->
      <add key="xamarin.android util" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/Xamarin.Android/nuget/v3/index.json" />
   </packageSources>
-  <config>
-    <add key="globalPackagesFolder" value="packages" />
-  </config>
 </configuration>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ The default `make all` target accepts the following optional
 
 # Build
 
-To build **xamarin-android-tools**, first prepare the project:
+To build **xamarin-android-tools**:
+
+	msbuild /restore Xamarin.Android.Tools.sln
+
+Alternatively, first prepare the project:
 
 	make prepare
 
@@ -53,7 +57,7 @@ Next, run `make`:
 
 To run the unit tests:
 
-	make run-all-tests
+	dotnet test tests/Xamarin.Android.Tools.AndroidSdk-Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj -l "console;verbosity=detailed"
 
 # Build Output Directory Structure
 

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -67,7 +67,7 @@ jobs:
     displayName: 'Run Tests'
     inputs:
       command: test
-      projects: bin/TestDebug/**/*-Tests.dll
+      projects: bin/TestDebug-net*/**/*-Tests.dll
       testRunTitle: Xamarin.Android.Tools Tests - $(vmImage)
 
   - powershell: |

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -11,77 +11,81 @@ pr:
 # Global variables
 variables:
   DotNetCoreVersion: 3.1.100
-  HostedMac: Hosted Mac Internal
-  HostedWinVS2019: Hosted Windows 2019 with VS2019
 
 jobs:
-- job: windows
-  displayName: windows
-  pool: $(HostedWinVS2019)
+- job: build
+  displayName: Build and Test
+  timeoutInMinutes: 60
+  cancelTimeoutInMinutes: 2
+
+  strategy:
+    matrix:
+      macOS:
+        vmImage: macOS-10.15
+      win2019:
+        vmImage: windows-2019
+
+  pool:
+    vmImage: $(vmImage)
+
+  workspace:
+    clean: all
+
   steps:
+  - checkout: self
+    clean: true
+
   - task: UseDotNet@2
     displayName: Use .NET Core $(DotNetCoreVersion)
     inputs:
       version: $(DotNetCoreVersion)
+
   - task: NuGetToolInstaller@0
     displayName: 'Install NuGet'
     inputs:
       versionSpec: 5.x
+
+  - script: |
+      dotnet tool install --global boots
+      boots https://download.mono-project.com/archive/6.12.0/macos-10-universal/MonoFramework-MDK-6.12.0.107.macos10.xamarin.universal.pkg
+    displayName: Install Mono 6.12
+    condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
+
   - task: NuGetCommand@2
     displayName: 'NuGet Restore'
     inputs:
       restoreSolution: Xamarin.Android.Tools.sln
       feedsToUse: config
       nugetConfigPath: NuGet.config
+
   - task: MSBuild@1
     displayName: 'Build solution Xamarin.Android.Tools.sln'
     inputs:
       solution: Xamarin.Android.Tools.sln
-  - task: VSTest@2
+
+  - task: DotNetCoreCLI@2
     displayName: 'Run Tests'
     inputs:
-      testAssemblyVer2: 'bin\TestDebug\*-Tests.dll'
-      testRunTitle: windows-tests
+      command: test
+      projects: bin/TestDebug/*-Tests.dll
+
   - powershell: |
       $hashOfLastVersionChange = & "git" "log" "--follow" "-1" "--pretty=%H" "nuget.version"
       $commitsSinceVersionChange = & "git" "rev-list" "--count" "$hashOfLastVersionChange..HEAD"
       $majorMinor = Get-Content "nuget.version"
       $version = "$majorMinor.$commitsSinceVersionChange"
       Write-Host "##vso[task.setvariable variable=xat.nuget.version]$version"
+    condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
+
   - task: MSBuild@1
     displayName: 'Build NuGet'
     inputs:
       solution: 'src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj'
       msbuildArguments: '/t:pack /p:Version=$(xat.nuget.version) /p:OutputPath=$(Build.ArtifactStagingDirectory)'
+    condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
+
   - task: PublishBuildArtifacts@1
     displayName: Upload Artifacts
     inputs:
       pathtoPublish: $(Build.ArtifactStagingDirectory)
-- job: mac
-  displayName: mac
-  pool: $(HostedMac)
-  steps:
-  - task: UseDotNet@2
-    displayName: Use .NET Core $(DotNetCoreVersion)
-    inputs:
-      version: $(DotNetCoreVersion)
-  - script: |
-      dotnet tool install --global boots
-      boots https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.198.macos10.xamarin.universal.pkg
-    displayName: Install Mono 6.4
-  - script: make prepare CONFIGURATION=$(Build.Configuration)
-    displayName: make prepare
-
-  - script: make all CONFIGURATION=$(Build.Configuration)
-    displayName: make all
-
-  - script: make run-all-tests CONFIGURATION=$(Build.Configuration)
-    displayName: make run-all-tests
-
-  - task: PublishTestResults@2
-    condition: always()
-    inputs:
-      testResultsFormat: NUnit
-      testResultsFiles: TestResult*.xml
-      testRunTitle: mac-tests
-      failTaskOnFailedTests: true
+    condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -67,7 +67,7 @@ jobs:
     displayName: 'Run Tests'
     inputs:
       command: test
-      projects: bin/TestDebug/*-Tests.dll
+      projects: bin/TestDebug/**/*-Tests.dll
 
   - powershell: |
       $hashOfLastVersionChange = & "git" "log" "--follow" "-1" "--pretty=%H" "nuget.version"

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -68,6 +68,7 @@ jobs:
     inputs:
       command: test
       projects: bin/TestDebug/**/*-Tests.dll
+      testRunTitle: Xamarin.Android.Tools Tests - $(vmImage)
 
   - powershell: |
       $hashOfLastVersionChange = & "git" "log" "--follow" "-1" "--pretty=%H" "nuget.version"

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <OutputPath>..\..\bin\Test$(Configuration)\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj
@@ -1,9 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <!-- $(TargetFrameworks) is used to allow the $(TargetFramework) check in Directory.Build.props to work.
+        If $(TargetFramework) is declared here instead, it will not be evaluated before Directory.Build.props
+        is loaded and the wrong $(TestOutputFullPath) will be used. -->
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <OutputPath>..\..\bin\Test$(Configuration)\</OutputPath>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj
@@ -1,20 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <OutputPath>$(TestOutputFullPath)</OutputPath>
+    <OutputPath>..\..\bin\Test$(Configuration)\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.11.0" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates `Xamarin.Android.Tools.AndroidSdk-Tests.csproj` to target only
`netcoreapp3.1`, and updates all test running logic to use dotnet test.
This will allow us to remove the `globalPackagesFolder` override from
NuGet.config as NUnit.ConsoleRunner is no longer referenced or used.

The YAML pipeline has also been consolidated a bit to reduce step
duplication.  A matrix strategy is now used to run the same steps in
parallel on both macOS and Windows.  OS-specific steps are now hidden
behind a condition so that we don't duplicate artifact uploading and
publishing.