### PR TITLE
Fix Warning CS8600: Converting null literal or possible null value to non-nullable type.

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
@@ -138,7 +138,7 @@ namespace Xamarin.Android.Tools
 		protected IEnumerable<string> GetSdkFromEnvironmentVariables ()
 		{
 			foreach (string envVar in AndroidSdkEnvVars) {
-				string ev = Environment.GetEnvironmentVariable (envVar);
+				var ev = Environment.GetEnvironmentVariable (envVar);
 				if (String.IsNullOrEmpty (ev)) {
 					continue;
 				}


### PR DESCRIPTION
In #103 this line was added:
```
string ev = Environment.GetEnvironmentVariable (envVar);
```

With NRT, `Environment.GetEnvironmentVariable` returns `string?` instead of `string`, causing the warning:

```
Warning CS8600: Converting null literal or possible null value to non-nullable type.
```

We can avoid it by using `var` instead of `string`.