### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Add API-S as a known version.

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
@@ -182,6 +182,9 @@ namespace Xamarin.Android.Tools
 			new AndroidVersion (30, "11.0") {
 				AlternateIds = new[]{ "R" },
 			},
+			new AndroidVersion (31, "12.0") {
+				AlternateIds = new[]{ "S" },
+			},
 		};
 	}
 }


### PR DESCRIPTION
Add support for API-S to fix CI error:
```
 /Users/runner/Library/Android/dotnet/packs/Microsoft.Android.Sdk.osx-x64/11.0.200-ci.pr.gh5653.119/tools
/Xamarin.Android.Common.targets(517,2): error XA5207: Could not find android.jar for API level 31. This means
 the Android SDK platform for API level 31 is not installed. Either install it in the Android SDK Manager (Tools >
 Open Android SDK Manager...), or change the Xamarin.Android project to target an API version that is
 installed. (/Users/runner/Library/Android/sdk/platforms/android-31/android.jar missing.) [/Users/runner
/work/1/s/bin/TestRelease/temp/CheckLintErrorsAndWarnings/UnnamedProject.csproj]
```
when running One .NET tests.