### PR TITLE
Bump to xamarin/LibZipSharp/main@86f8ae57 [1.0.24]

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <MSBuildReferenceVersion>15.1.0.0</MSBuildReferenceVersion>
     <MSBuildPackageReferenceVersion>16.5</MSBuildPackageReferenceVersion>
-    <LibZipSharpVersion>1.0.23</LibZipSharpVersion>
+    <LibZipSharpVersion>1.0.24</LibZipSharpVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('windows'))" >


### PR DESCRIPTION
    Changes: https://github.com/xamarin/LibZipSharp/compare/1.0.23...1.0.24

      * xamarin/LibZipSharp@86f8ae57: Bump to 1.0.24
      * xamarin/LibZipSharp@582eb2c1: Include the Pdb when using 'LibZipSharpBundleAllNativeLibraries'