### PR TITLE
Fix for invalid values in %PATH% or %PATHEXT%

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs
@@ -173,8 +173,15 @@ namespace Xamarin.Android.Tools
 
 		internal static IEnumerable<string> FindExecutablesInDirectory (string dir, string executable)
 		{
+			if (!Directory.Exists (dir))
+				yield break;
 			foreach (var exe in ExecutableFiles (executable)) {
-				var exePath = Path.Combine (dir, exe);
+				string exePath;
+				try {
+					exePath = Path.Combine (dir, exe);
+				} catch (ArgumentException) {
+					continue;
+				}
 				if (File.Exists (exePath))
 					yield return exePath;
 			}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
@@ -292,9 +292,14 @@ namespace Xamarin.Android.Tools
 			if (string.IsNullOrEmpty (dir))
 				return exe;
 
-			foreach (var e in ProcessUtils.ExecutableFiles (exe))
-				if (File.Exists (Path.Combine (dir, e)))
-					return e;
+			foreach (var e in ProcessUtils.ExecutableFiles (exe)) {
+				try {
+					if (File.Exists (Path.Combine (dir, e)))
+						return e;
+				} catch (ArgumentException) {
+					continue;
+				}
+			}
 			return exe;
 		}
 	}

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
@@ -147,6 +147,50 @@ namespace Xamarin.Android.Tools.Tests
 		}
 
 		[Test]
+		public void Ndk_Path_InvalidChars ()
+		{
+			CreateSdks (out string root, out string jdk, out string ndk, out string sdk);
+
+			Action<TraceLevel, string> logger = (level, message) => {
+				Console.WriteLine ($"[{level}] {message}");
+				if (level == TraceLevel.Error)
+					Assert.Fail (message);
+			};
+
+			var oldPath = Environment.GetEnvironmentVariable ("PATH");
+			try {
+				Environment.SetEnvironmentVariable ("PATH", "\"C:\\IHAVEQUOTES\\\"");
+				// Check that this doesn't throw
+				new AndroidSdkInfo (logger, androidSdkPath: sdk, androidNdkPath: null, javaSdkPath: jdk);
+			} finally {
+				Environment.SetEnvironmentVariable ("PATH", oldPath);
+				Directory.Delete (root, recursive: true);
+			}
+		}
+
+		[Test]
+		public void Ndk_PathExt_InvalidChars ()
+		{
+			CreateSdks (out string root, out string jdk, out string ndk, out string sdk);
+
+			Action<TraceLevel, string> logger = (level, message) => {
+				Console.WriteLine ($"[{level}] {message}");
+				if (level == TraceLevel.Error)
+					Assert.Fail (message);
+			};
+
+			var oldPathExt = Environment.GetEnvironmentVariable ("PATHEXT");
+			try {
+				Environment.SetEnvironmentVariable ("PATHEXT", string.Join (Path.PathSeparator.ToString (), "\"", ".EXE", ".BAT"));
+				// Check that this doesn't throw
+				new AndroidSdkInfo (logger, androidSdkPath: sdk, androidNdkPath: null, javaSdkPath: jdk);
+			} finally {
+				Environment.SetEnvironmentVariable ("PATHEXT", oldPathExt);
+				Directory.Delete (root, recursive: true);
+			}
+		}
+
+		[Test]
 		public void Ndk_AndroidSdkDoesNotExist ()
 		{
 			CreateSdks (out string root, out string jdk, out string ndk, out string sdk);


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/t/illegal-character-exception-in-xamarinandroid-afte/1363149

In 16.9 we are getting some reports of:

    (_ResolveSdks target) ->
        error XARSD7004: System.ArgumentException: Illegal characters in path.
        error XARSD7004:    at System.IO.Path.CheckInvalidPathChars(String path, Boolean checkAdditional)
        error XARSD7004:    at System.IO.Path.Combine(String path1, String path2)
        error XARSD7004:    at Xamarin.Android.Tools.ProcessUtils.<FindExecutablesInDirectory>d__9.MoveNext() in /Users/builder/azdo/_work/278/s/xamarin-android/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs:line 177
        error XARSD7004:    at Xamarin.Android.Tools.ProcessUtils.<FindExecutablesInPath>d__8.MoveNext() in /Users/builder/azdo/_work/278/s/xamarin-android/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/ProcessUtils.cs:line 168
        error XARSD7004:    at Xamarin.Android.Tools.AndroidSdkBase.<GetAllAvailableAndroidNdks>d__73.MoveNext() in /Users/builder/azdo/_work/278/s/xamarin-android/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs:line 153
        error XARSD7004:    at Xamarin.Android.Tools.AndroidSdkWindows.<GetAllAvailableAndroidNdks>d__43.MoveNext() in /Users/builder/azdo/_work/278/s/xamarin-android/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs:line 257
        error XARSD7004:    at Xamarin.Android.Tools.AndroidSdkBase.GetValidNdkPath(String ctorParam) in /Users/builder/azdo/_work/278/s/xamarin-android/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs:line 128
        error XARSD7004:    at Xamarin.Android.Tools.AndroidSdkBase.Initialize(String androidSdkPath, String androidNdkPath, String javaSdkPath) in /Users/builder/azdo/_work/278/s/xamarin-android/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs:line 71
        error XARSD7004:    at Xamarin.Android.Tools.AndroidSdkWindows.Initialize(String androidSdkPath, String androidNdkPath, String javaSdkPath) in /Users/builder/azdo/_work/278/s/xamarin-android/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs:line 310
        error XARSD7004:    at Xamarin.Android.Tools.AndroidSdkInfo..ctor(Action`2 logger, String androidSdkPath, String androidNdkPath, String javaSdkPath) in /Users/builder/azdo/_work/278/s/xamarin-android/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs:line 18
        error XARSD7004:    at Xamarin.Android.Tasks.MonoAndroidHelper.RefreshAndroidSdk(String sdkPath, String ndkPath, String javaPath, TaskLoggingHelper logHelper)
        error XARSD7004:    at Xamarin.Android.Tasks.ResolveSdks.RunTask()
        error XARSD7004:    at Xamarin.Android.Tasks.AndroidTask.Execute()

It appears this is simply a call like this failing:

    Path.Combine ("foo", "\"")
    Path.Combine ("\"", "foo")

I could reproduce this in a test by setting `%PATH%` or `%PATHEXT%` to
invalid names.

For fixing `%PATH%`, I could simply add a `Directory.Exists()` check
in the place that makes sense. However, I think a `try-catch` of
`ArgumentException` is the only way to handle `%PATHEXT%`? I had to
put this in two places where the new test found an issue.

I am not exactly sure how this problem would have been introduced in
16.9, as this problem looks like it would have always been here.

Possibly 9d8924d5? Maybe the new call to
`GetSdkFromEnvironmentVariables()` is triggering this issue?