### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Probe for Zulu JDK

### DIFF
--- a/Xamarin.Android.Tools.sln
+++ b/Xamarin.Android.Tools.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30709.64
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -9,6 +9,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Android.Build.BaseTasks", "src\Microsoft.Android.Build.BaseTasks\Microsoft.Android.Build.BaseTasks.csproj", "{C8E51A26-F7A5-4B81-B0BC-F9A4BFB43D38}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Android.Build.BaseTasks-Tests", "tests\Microsoft.Android.Build.BaseTasks-Tests\Microsoft.Android.Build.BaseTasks-Tests.csproj", "{4F5FD01C-B5A6-4F9F-91CE-3E78B3F942AC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{19FE1B44-DB71-4F97-A07E-085888690DAE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ls-jdks", "tools\ls-jdks\ls-jdks.csproj", "{3D2ADF77-62C7-4E0E-AB29-BDD266B7D56D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -32,11 +36,18 @@ Global
 		{4F5FD01C-B5A6-4F9F-91CE-3E78B3F942AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4F5FD01C-B5A6-4F9F-91CE-3E78B3F942AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4F5FD01C-B5A6-4F9F-91CE-3E78B3F942AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D2ADF77-62C7-4E0E-AB29-BDD266B7D56D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D2ADF77-62C7-4E0E-AB29-BDD266B7D56D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D2ADF77-62C7-4E0E-AB29-BDD266B7D56D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D2ADF77-62C7-4E0E-AB29-BDD266B7D56D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BA1CD771-F00B-4DE8-93EE-7690D81F6A5A}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{3D2ADF77-62C7-4E0E-AB29-BDD266B7D56D} = {19FE1B44-DB71-4F97-A07E-085888690DAE}
 	EndGlobalSection
 EndGlobal

--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -185,7 +185,7 @@ namespace Xamarin.Android.Tools
 
 			logger          = logger ?? DefaultConsoleLogger;
 
-			var latestJdk   = JdkInfo.GetMicrosoftOpenJdks (logger).FirstOrDefault ();
+			var latestJdk   = MicrosoftOpenJdkLocations.GetMicrosoftOpenJdks (logger).FirstOrDefault ();
 			if (latestJdk == null)
 				throw new NotSupportedException ("No Microsoft OpenJDK could be found.  Please re-run the Visual Studio installer or manually specify the JDK path in settings.");
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/Jdks/AzulJdkLocations.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Jdks/AzulJdkLocations.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Xamarin.Android.Tools {
+
+	class AzulJdkLocations : JdkLocations {
+
+		internal static IEnumerable<JdkInfo> GetAzulJdks (Action<TraceLevel, string> logger)
+		{
+			return GetMacOSSystemJdks ("zulu-*.jdk", logger)
+				.Concat (GetWindowsFileSystemJdks (Path.Combine ("Zulu", "zulu-*"), logger))
+				.Concat (GetWindowsRegistryJdks (logger, @"SOFTWARE\Azul Systems\Zulu", "zulu-*", null, "InstallationPath"))
+				.OrderByDescending (jdk => jdk, JdkInfoVersionComparer.Default);
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Jdks/JdkLocations.MacOS.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Jdks/JdkLocations.MacOS.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace Xamarin.Android.Tools {
+
+	partial class JdkLocations {
+
+		static IEnumerable<JdkInfo> GetUnixPreferredJdks (Action<TraceLevel, string> logger)
+		{
+			return GetUnixConfiguredJdkPaths (logger)
+				.Select (p => JdkInfo.TryGetJdkInfo (p, logger, "monodroid-config.xml"))
+				.Where (jdk => jdk != null)
+				.Select (jdk => jdk!)
+				.OrderByDescending (jdk => jdk, JdkInfoVersionComparer.Default);
+		}
+
+		static IEnumerable<string> GetUnixConfiguredJdkPaths (Action<TraceLevel, string> logger)
+		{
+			var config = AndroidSdkUnix.GetUnixConfigFile (logger);
+			foreach (var java_sdk in config.Root.Elements ("java-sdk")) {
+				var path    = (string) java_sdk.Attribute ("path");
+				yield return path;
+			}
+		}
+
+		const   string  MacOSJavaVirtualMachinesRoot    = "/Library/Java/JavaVirtualMachines";
+
+		protected static IEnumerable<JdkInfo> GetMacOSSystemJdks (string pattern, Action<TraceLevel, string> logger, string? locator = null)
+		{
+			if (!OS.IsMac) {
+				return Array.Empty<JdkInfo>();
+			}
+			locator = locator ?? Path.Combine (MacOSJavaVirtualMachinesRoot, pattern);
+			return FromPaths (GetMacOSSystemJvmPaths (pattern), logger, locator);
+		}
+
+		static IEnumerable<string> GetMacOSSystemJvmPaths (string pattern)
+		{
+			var root    = MacOSJavaVirtualMachinesRoot;
+			var toHome  = Path.Combine ("Contents", "Home");
+			var jdks    = AppDomain.CurrentDomain.GetData ($"GetMacOSMicrosoftJdkPaths jdks override! {typeof (JdkInfo).AssemblyQualifiedName}")
+				?.ToString ();
+			if (jdks != null) {
+				root    = jdks;
+				toHome  = "";
+				pattern = "*";
+			}
+			if (!Directory.Exists (root)) {
+				yield break;
+			}
+			foreach (var dir in Directory.EnumerateDirectories (root, pattern)) {
+				var home = Path.Combine (dir, toHome);
+				if (!Directory.Exists (home))
+					continue;
+				yield return home;
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Jdks/JdkLocations.Windows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Jdks/JdkLocations.Windows.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Xamarin.Android.Tools {
+
+	partial class JdkLocations {
+
+		internal static string? GetWindowsPreferredJdkPath ()
+		{
+			var wow = RegistryEx.Wow64.Key32;
+			var regKey = AndroidSdkWindows.GetMDRegistryKey ();
+			if (RegistryEx.CheckRegistryKeyForExecutable (RegistryEx.CurrentUser, regKey, AndroidSdkWindows.MDREG_JAVA_SDK, wow, "bin", "java.exe"))
+				return RegistryEx.GetValueString (RegistryEx.CurrentUser, regKey, AndroidSdkWindows.MDREG_JAVA_SDK, wow);
+			return null;
+
+		}
+
+		protected static IEnumerable<JdkInfo> GetWindowsFileSystemJdks (string pattern, Action<TraceLevel, string> logger, string? locator = null)
+		{
+			if (!OS.IsWindows) {
+				yield break;
+			}
+
+			var roots = new List<string>() {
+				// "Compatibility" with existing codebases; should probably be avoided…
+				Environment.ExpandEnvironmentVariables ("%ProgramW6432%"),
+				Environment.GetFolderPath (Environment.SpecialFolder.ProgramFiles),
+				Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86),
+			};
+			foreach (var root in roots) {
+				if (!Directory.Exists (root))
+					continue;
+				IEnumerable<string> homes;
+				try {
+					homes = Directory.EnumerateDirectories (root, pattern);
+				}
+				catch (IOException e) {
+					continue;
+				}
+				foreach (var home in homes) {
+					if (!File.Exists (Path.Combine (home, "bin", "java.exe")))
+						continue;
+					var loc = locator ?? $"{pattern} via {root}";
+					var jdk = JdkInfo.TryGetJdkInfo (home, logger, loc);
+					if (jdk == null)
+						continue;
+					yield return jdk;
+				}
+			}
+		}
+
+		protected static IEnumerable<JdkInfo> GetWindowsRegistryJdks (
+				Action<TraceLevel, string> logger,
+				string  parentKey,
+				string  childKeyGlob,
+				string? grandChildKey,
+				string  valueName,
+				string? locator = null)
+		{
+			if (!OS.IsWindows) {
+				yield break;
+			}
+
+			var regex   = ToRegex (childKeyGlob);
+			var paths   = new List<(Version version, string path)> ();
+			var roots   = new[] { RegistryEx.CurrentUser, RegistryEx.LocalMachine };
+			var wows    = new[] { RegistryEx.Wow64.Key32, RegistryEx.Wow64.Key64 };
+			foreach (var root in roots)
+			foreach (var wow in wows) {
+				foreach (var subkeyName in RegistryEx.EnumerateSubkeys (root, parentKey, wow)) {
+					if (!regex.Match (subkeyName).Success) {
+						continue;
+					}
+					var key	    = $@"{parentKey}\{subkeyName}" +
+						(grandChildKey == null ? "" : "\\" + grandChildKey);
+					var path    = RegistryEx.GetValueString (root, key, valueName, wow);
+					if (path == null) {
+						continue;
+					}
+					var jdk     = JdkInfo.TryGetJdkInfo (path, logger, locator ?? $"Windows Registry @ {parentKey}");
+					if (jdk == null) {
+						continue;
+					}
+					yield return jdk;
+				}
+			}
+		}
+
+		static Regex ToRegex (string glob)
+		{
+			var r   = new StringBuilder ();
+			foreach (char c in glob) {
+				switch (c) {
+					case '*':
+						r.Append (".*");
+						break;
+					case '?':
+						r.Append (".");
+						break;
+					default:
+						r.Append (Regex.Escape (c.ToString ()));
+						break;
+				}
+			}
+			return new Regex (r.ToString (), RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Jdks/JdkLocations.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Jdks/JdkLocations.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace Xamarin.Android.Tools {
+
+	partial class JdkLocations {
+
+		internal static IEnumerable<JdkInfo> GetPreferredJdks (Action<TraceLevel, string> logger)
+		{
+			if (OS.IsWindows) {
+				var path    = GetWindowsPreferredJdkPath ();
+				var jdk     = path == null ? null : JdkInfo.TryGetJdkInfo (path, logger, "Windows Registry");
+				if (jdk != null)
+					yield return jdk;
+			}
+			foreach (var jdk in GetUnixPreferredJdks (logger)) {
+				yield return jdk;
+			}
+		}
+
+		protected static IEnumerable<JdkInfo> FromPaths (IEnumerable<string> paths, Action<TraceLevel, string> logger, string locator)
+		{
+			return paths
+				.Select (p => JdkInfo.TryGetJdkInfo (p, logger, locator))
+				.Where (jdk => jdk != null)
+				.Select (jdk => jdk!);
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Jdks/MicrosoftOpenJdkLocations.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Jdks/MicrosoftOpenJdkLocations.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Xamarin.Android.Tools {
+
+	class MicrosoftOpenJdkLocations : JdkLocations {
+
+		internal static IEnumerable<JdkInfo> GetMicrosoftOpenJdks (Action<TraceLevel, string> logger)
+		{
+			return GetMacOSSystemJdks ("microsoft-*.jdk", logger)
+				.Concat (GetWindowsFileSystemJdks (Path.Combine ("Microsoft", "jdk-*"), logger))
+				.Concat (GetWindowsRegistryJdks (logger, @"SOFTWARE\Microsoft\JDK", "*", @"hotspot\MSI", "Path"))
+				.OrderByDescending (jdk => jdk, JdkInfoVersionComparer.Default);
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Jdks/OracleJdkLocations.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Jdks/OracleJdkLocations.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Xamarin.Android.Tools {
+
+	class OracleJdkLocations : JdkLocations {
+
+		internal static IEnumerable<JdkInfo> GetOracleJdks (Action<TraceLevel, string> logger)
+		{
+			if (!OS.IsWindows) {
+				yield break;
+			}
+			foreach (var path in GetOracleJdkPaths ()) {
+				var jdk = JdkInfo.TryGetJdkInfo (path, logger, "Oracle Registry");
+				if (jdk == null) {
+					continue;
+				}
+				yield return jdk;
+			}
+		}
+
+		static IEnumerable<string> GetOracleJdkPaths ()
+		{
+			string subkey = @"SOFTWARE\JavaSoft\Java Development Kit";
+
+			foreach (var wow64 in new[] { RegistryEx.Wow64.Key32, RegistryEx.Wow64.Key64 }) {
+				string key_name = string.Format (@"{0}\{1}\{2}", "HKLM", subkey, "CurrentVersion");
+				var currentVersion = RegistryEx.GetValueString (RegistryEx.LocalMachine, subkey, "CurrentVersion", wow64);
+
+				if (!string.IsNullOrEmpty (currentVersion)) {
+
+					if (RegistryEx.CheckRegistryKeyForExecutable (RegistryEx.LocalMachine, subkey + "\\" + "1.8", "JavaHome", wow64, "bin", "java.exe"))
+						yield return RegistryEx.GetValueString (RegistryEx.LocalMachine, subkey + "\\" + "1.8", "JavaHome", wow64) ?? "";
+				}
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Jdks/VSAndroidJdkLocations.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Jdks/VSAndroidJdkLocations.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Xamarin.Android.Tools {
+
+	class VSAndroidJdkLocations : JdkLocations {
+
+		internal static IEnumerable<JdkInfo> GetVSAndroidJdks (Action<TraceLevel, string> logger)
+		{
+			if (!OS.IsWindows) {
+				yield break;
+			}
+			var root        = RegistryEx.LocalMachine;
+			var wows        = new[] { RegistryEx.Wow64.Key32, RegistryEx.Wow64.Key64 };
+			var subKey      = @"SOFTWARE\Microsoft\VisualStudio\Android";
+			var valueName   = "JavaHome";
+
+			foreach (var wow in wows) {
+				if (!RegistryEx.CheckRegistryKeyForExecutable (root, subKey, valueName, wow, "bin", "java.exe")) {
+					continue;
+				}
+				var path    = RegistryEx.GetValueString (root, subKey, valueName, wow) ?? "";
+				if (string.IsNullOrEmpty (path)) {
+					continue;
+				}
+				var jdk     = JdkInfo.TryGetJdkInfo (path, logger, subKey);
+				if (jdk == null) {
+					continue;
+				}
+				yield return jdk;
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Jdks/XAPrepareJdkLocations.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Jdks/XAPrepareJdkLocations.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Xamarin.Android.Tools {
+
+	class XAPrepareJdkLocations : JdkLocations {
+
+		internal static IEnumerable<JdkInfo> GetXAPrepareJdks (Action<TraceLevel, string> logger)
+		{
+			return FromPaths (GetXAPrepareJdkPaths (), logger, "android-toolchain");
+		}
+
+		static IEnumerable<string> GetXAPrepareJdkPaths ()
+		{
+			var androidToolchainDir = Path.Combine (Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "android-toolchain");
+			if (!Directory.Exists (androidToolchainDir)) {
+				return Array.Empty<string> ();
+			}
+			return Directory.EnumerateDirectories (androidToolchainDir, "jdk*");
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
@@ -279,7 +279,7 @@ namespace Xamarin.Android.Tools
 			return result;
 		}
 
-		protected static string? NullIfEmpty (string? s)
+		internal static string? NullIfEmpty (string? s)
 		{
 			if (s == null || s.Length != 0)
 				return s;

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -8,12 +8,14 @@ using Xamarin.Android.Tools.AndroidSdk.Properties;
 
 namespace Xamarin.Android.Tools
 {
+	using static RegistryEx;
+
 	class AndroidSdkWindows : AndroidSdkBase
 	{
 		const string MDREG_KEY = @"SOFTWARE\Novell\Mono for Android";
 		const string MDREG_ANDROID_SDK = "AndroidSdkDirectory";
 		const string MDREG_ANDROID_NDK = "AndroidNdkDirectory";
-		const string MDREG_JAVA_SDK = "JavaSdkDirectory";
+		internal const string MDREG_JAVA_SDK = "JavaSdkDirectory";
 		const string ANDROID_INSTALLER_PATH = @"SOFTWARE\Android SDK Tools";
 		const string ANDROID_INSTALLER_KEY = "Path";
 		const string XAMARIN_ANDROID_INSTALLER_PATH = @"SOFTWARE\Xamarin\MonoAndroid";
@@ -63,7 +65,7 @@ namespace Xamarin.Android.Tools
 			}
 		}
 
-		static string GetMDRegistryKey ()
+		internal static string GetMDRegistryKey ()
 		{
 			var regKey = Environment.GetEnvironmentVariable ("XAMARIN_ANDROID_REGKEY");
 			return string.IsNullOrWhiteSpace (regKey) ? MDREG_KEY : regKey;
@@ -106,165 +108,6 @@ namespace Xamarin.Android.Tools
 			foreach (var basePath in paths)
 				if (Directory.Exists (basePath))
 					yield return basePath;
-		}
-
-		internal static IEnumerable<JdkInfo> GetJdkInfos (Action<TraceLevel, string> logger)
-		{
-			JdkInfo? TryGetJdkInfo (string path, string locator)
-			{
-				JdkInfo? jdk = null;
-				try {
-					jdk = new JdkInfo (path, locator);
-				}
-				catch (Exception e) {
-					logger (TraceLevel.Warning, string.Format (Resources.InvalidJdkDirectory_path_locator_message, path, locator, e.Message));
-					logger (TraceLevel.Verbose, e.ToString ());
-				}
-				return jdk;
-			}
-
-			IEnumerable<JdkInfo> ToJdkInfos (IEnumerable<string> paths, string locator)
-			{
-				return paths.Select (p => TryGetJdkInfo (p, locator))
-					.Where (jdk => jdk != null)
-					.Select(jdk => jdk!)
-					.OrderByDescending (jdk => jdk, JdkInfoVersionComparer.Default);
-			}
-
-			return ToJdkInfos (GetPreferredJdkPaths (), "Preferred Registry")
-				.Concat (ToJdkInfos (GetMicrosoftOpenJdkFilesystemPaths (), "Microsoft OpenJDK Filesystem"))
-				.Concat (ToJdkInfos (GetMicrosoftOpenJdkRegistryPaths (), "Microsoft OpenJDK Registry"))
-				.Concat (ToJdkInfos (GetVSAndroidJdkPaths (), @"HKLM\SOFTWARE\Microsoft\VisualStudio\Android@JavaHome"))
-				.Concat (ToJdkInfos (GetOracleJdkPaths (), "Oracle JDK"))
-				;
-		}
-
-		private static IEnumerable<string> GetPreferredJdkPaths ()
-		{
-			// check the user specified path
-			var roots = new[] { RegistryEx.CurrentUser, RegistryEx.LocalMachine };
-			const RegistryEx.Wow64 wow = RegistryEx.Wow64.Key32;
-			var regKey = GetMDRegistryKey ();
-
-			foreach (var root in roots) {
-				if (CheckRegistryKeyForExecutable (root, regKey, MDREG_JAVA_SDK, wow, "bin", _JarSigner))
-					yield return RegistryEx.GetValueString (root, regKey, MDREG_JAVA_SDK, wow) ?? "";
-			}
-		}
-
-		private static IEnumerable<string> GetVSAndroidJdkPaths ()
-		{
-			var root = RegistryEx.LocalMachine;
-			var wows = new[] { RegistryEx.Wow64.Key32, RegistryEx.Wow64.Key64 };
-			var subKey = @"SOFTWARE\Microsoft\VisualStudio\Android";
-			var valueName = "JavaHome";
-
-			foreach (var wow in wows) {
-				if (CheckRegistryKeyForExecutable (root, subKey, valueName, wow, "bin", _JarSigner))
-					yield return RegistryEx.GetValueString (root, subKey, valueName, wow) ?? "";
-			}
-		}
-
-		static IEnumerable<string> GetMicrosoftOpenJdkFilesystemPaths ()
-		{
-			const string JdkFolderNamePrefix = "jdk-";
-
-			var paths = new List<Tuple<string, Version>> ();
-			var rootPaths = new List<string> {
-				Path.Combine (Environment.ExpandEnvironmentVariables ("%ProgramW6432%"), "Microsoft"),
-				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86), "Android", "jdk"),
-			};
-
-			foreach (var rootPath in rootPaths) {
-				if (!Directory.Exists (rootPath))
-					continue;
-				foreach (var directoryName in Directory.EnumerateDirectories (rootPath, $"{JdkFolderNamePrefix}*")) {
-					var version = ExtractVersion (directoryName, JdkFolderNamePrefix);
-					if (version == null)
-						continue;
-					paths.Add (Tuple.Create (directoryName, version));
-				}
-			}
-
-			return paths.OrderByDescending (v => v.Item2)
-				.Where (openJdk => ProcessUtils.FindExecutablesInDirectory (Path.Combine (openJdk.Item1, "bin"), _JarSigner).Any ())
-				.Select (openJdk => openJdk.Item1);
-		}
-
-		static IEnumerable<string> GetMicrosoftOpenJdkRegistryPaths ()
-		{
-			var paths   = new List<(Version version, string path)> ();
-			var roots   = new[] { RegistryEx.CurrentUser, RegistryEx.LocalMachine };
-			var wows    = new[] { RegistryEx.Wow64.Key32, RegistryEx.Wow64.Key64 };
-			foreach (var root in roots)
-			foreach (var wow in wows) {
-				foreach (var subkeyName in RegistryEx.EnumerateSubkeys (root, MICROSOFT_OPENJDK_PATH, wow)) {
-					if (!Version.TryParse (subkeyName, out var version))
-						continue;
-					var msiKey  = $@"{MICROSOFT_OPENJDK_PATH}\{subkeyName}\hotspot\MSI";
-					var path    = RegistryEx.GetValueString (root, msiKey, "Path", wow);
-					if (path == null)
-						continue;
-					paths.Add ((version, path));
-				}
-			}
-
-			return paths.OrderByDescending (e => e.version)
-				.Select (e => e.path);
-		}
-
-		internal static Version? ExtractVersion (string path, string prefix)
-		{
-			var name = Path.GetFileName (path);
-			if (name.Length <= prefix.Length)
-				return null;
-			if (!name.StartsWith (prefix, StringComparison.OrdinalIgnoreCase))
-				return null;
-
-			var start   = prefix.Length;
-			while (start < name.Length && !char.IsDigit (name, start)) {
-				++start;
-			}
-			if (start == name.Length)
-				return null;
-
-			name    = name.Substring (start);
-			int end = 0;
-			while (end < name.Length &&
-					(char.IsDigit (name [end]) || name [end] == '.')) {
-				end++;
-			}
-
-			do {
-				if (Version.TryParse (name.Substring (0, end), out var v))
-					return v;
-				end = name.LastIndexOf ('.', end-1);
-			} while (end > 0);
-
-			return null;
-		}
-
-		private static IEnumerable<string> GetOracleJdkPaths ()
-		{ 
-			string subkey = @"SOFTWARE\JavaSoft\Java Development Kit";
-
-			foreach (var wow64 in new[] { RegistryEx.Wow64.Key32, RegistryEx.Wow64.Key64 }) {
-				string key_name = string.Format (@"{0}\{1}\{2}", "HKLM", subkey, "CurrentVersion");
-				var currentVersion = RegistryEx.GetValueString (RegistryEx.LocalMachine, subkey, "CurrentVersion", wow64);
-
-				if (!string.IsNullOrEmpty (currentVersion)) {
-
-					// No matter what the CurrentVersion is, look for 1.6 or 1.7 or 1.8
-					if (CheckRegistryKeyForExecutable (RegistryEx.LocalMachine, subkey + "\\" + "1.8", "JavaHome", wow64, "bin", _JarSigner))
-						yield return RegistryEx.GetValueString (RegistryEx.LocalMachine, subkey + "\\" + "1.8", "JavaHome", wow64) ?? "";
-
-					if (CheckRegistryKeyForExecutable (RegistryEx.LocalMachine, subkey + "\\" + "1.7", "JavaHome", wow64, "bin", _JarSigner))
-						yield return RegistryEx.GetValueString (RegistryEx.LocalMachine, subkey + "\\" + "1.7", "JavaHome", wow64) ?? "";
-
-					if (CheckRegistryKeyForExecutable (RegistryEx.LocalMachine, subkey + "\\" + "1.6", "JavaHome", wow64, "bin", _JarSigner))
-						yield return RegistryEx.GetValueString (RegistryEx.LocalMachine, subkey + "\\" + "1.6", "JavaHome", wow64) ?? "";
-				}
-			}
 		}
 
 		protected override IEnumerable<string> GetAllAvailableAndroidNdks ()
@@ -332,29 +175,6 @@ namespace Xamarin.Android.Tools
 			var regKey = GetMDRegistryKey ();
 			RegistryEx.SetValueString (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_NDK, path ?? "", RegistryEx.Wow64.Key32);
 		}
-
-		#region Helper Methods
-		private static bool CheckRegistryKeyForExecutable (UIntPtr key, string subkey, string valueName, RegistryEx.Wow64 wow64, string subdir, string exe)
-		{
-			try {
-				string key_name = string.Format (@"{0}\{1}\{2}", key == RegistryEx.CurrentUser ? "HKCU" : "HKLM", subkey, valueName);
-
-				var path = NullIfEmpty (RegistryEx.GetValueString (key, subkey, valueName, wow64));
-
-				if (path == null) {
-					return false;
-				}
-
-				if (!ProcessUtils.FindExecutablesInDirectory (Path.Combine (path, subdir), exe).Any ()) {
-					return false;
-				}
-
-				return true;
-			} catch (Exception) {
-				return false;
-			}
-		}
-		#endregion
 
 		public override void Initialize (string? androidSdkPath = null, string? androidNdkPath = null, string? javaSdkPath = null)
 		{

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkWindowsTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkWindowsTests.cs
@@ -13,56 +13,5 @@ namespace Xamarin.Android.Tools.Tests
 	[TestFixture]
 	public class AndroidSdkWindowsTests
 	{
-		[Test]
-		public void ExtractVersion ()
-		{
-			var sep = Path.DirectorySeparatorChar;
-
-			var tests = new[]{
-				new {
-					Path        = $"foo{sep}",
-					Prefix      = "",
-					Expected    = (Version) null,
-				},
-				new {
-					Path        = $"foo{sep}bar-1-extra",
-					Prefix      = "bar-",
-					Expected    = (Version) null,
-				},
-				new {
-					Path        = $"foo{sep}abcdef",
-					Prefix      = "a",
-					Expected    = (Version) null,
-				},
-				new {
-					Path        = $"foo{sep}a{sep}b.c.d",
-					Prefix      = "none-of-the-above",
-					Expected    = (Version) null,
-				},
-				new {
-					Path        = $"jdks{sep}jdk-1.2.3-hotspot-extra",
-					Prefix      = "jdk-",
-					Expected    = new Version (1, 2, 3),
-				},
-				new {
-					Path        = $"jdks{sep}jdk-1.2.3-hotspot-extra",
-					Prefix      = "jdk",
-					Expected    = new Version (1, 2, 3),
-				},
-				new {
-					Path        = $"jdks{sep}jdk-1.2.3.4.5.6-extra",
-					Prefix      = "jdk-",
-					Expected    = new Version (1, 2, 3, 4),
-				},
-			};
-
-			foreach (var test in tests) {
-				Assert.AreEqual (
-						test.Expected,
-						AndroidSdkWindows.ExtractVersion (test.Path, test.Prefix),
-						$"Version couldn't be extracted from Path=`{test.Path}` Prefix=`{test.Prefix}`!"
-				);
-			}
-		}
 	}
 }

--- a/tools/ls-jdks/App.cs
+++ b/tools/ls-jdks/App.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Xamarin.Android.Tools
+{
+	class App
+	{
+		static void Main(string[] args)
+		{
+			foreach (var jdk in JdkInfo.GetKnownSystemJdkInfos ()) {
+				Console.WriteLine ($"Found JDK: {jdk.HomePath}");
+				Console.WriteLine ($"  Locator: {jdk.Locator}");
+			}
+		}
+	}
+}

--- a/tools/ls-jdks/ls-jdks.csproj
+++ b/tools/ls-jdks/ls-jdks.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <RootNamespace>Xamarin.Android.Tools</RootNamespace>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>$(ToolOutputFullPath)</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Context: https://www.azul.com/downloads/zulu-community/

Commit 237642ce removed support for the ancient
`microsoft_dist_openjdk_*` versions, replacing it with the newer
[Microsoft OpenJDK][0].

One problem with this change is one of *compatibility*:
`microsoft_dist_openjdk_` was a build of JDK 1.8, while
Microsoft OpenJDK only provides builds for JDK 11 and later.
This is a problem, as the [Visual Studio Android Designer][1]
currently requires JDK 1.8, and is not yet compatible with JDK 11.

Add support to probe for for [Azul Zulu OpenJDK][2] installation
directories, as Zulu provides updated JDK 1.8 installers.

Additionally, refactor and centralize the JDK Location logic.
Previously, `JdkInfo.GetKnownSystemJdkInfos()` would return all of
the Windows installation locations before the macOS/Linux/etc.
locations, which made it possible for Windows and non-Windows
platforms to return paths in an inconsistent order.  Introduce a new
`JdkLocations` helper, and add new subclasses for each specific JDK
location, so that `JdkInfo.GetKnownSystemJdkInfos()` can be *unified*
across macOS/Linux & Windows, increasing consistency.

Add a new `tools/ls-jdks` tool, to make it easier to print all probed
JDK locations.

[0]: https://www.microsoft.com/openjdk
[1]: https://docs.microsoft.com/en-us/xamarin/android/user-interface/android-designer/designer-walkthrough?tabs=windows
[2]: https://www.azul.com/downloads/zulu-community/?package=jdk