### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Probe for AdoptOpenJDK Locations

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -288,6 +288,7 @@ namespace Xamarin.Android.Tools
 				.Concat (JdkLocations.GetPreferredJdks (logger))
 				.Concat (XAPrepareJdkLocations.GetXAPrepareJdks (logger))
 				.Concat (MicrosoftOpenJdkLocations.GetMicrosoftOpenJdks (logger))
+				.Concat (AdoptOpenJdkLocations.GetAdoptOpenJdks (logger))
 				.Concat (AzulJdkLocations.GetAzulJdks (logger))
 				.Concat (OracleJdkLocations.GetOracleJdks (logger))
 				.Concat (VSAndroidJdkLocations.GetVSAndroidJdks (logger))

--- a/src/Xamarin.Android.Tools.AndroidSdk/Jdks/AdoptOpenJdkLocations.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Jdks/AdoptOpenJdkLocations.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Xamarin.Android.Tools {
+
+	class AdoptOpenJdkLocations : JdkLocations {
+
+		internal static IEnumerable<JdkInfo> GetAdoptOpenJdks (Action<TraceLevel, string> logger)
+		{
+			return GetMacOSSystemJdks ("adoptopenjdk-*.jdk", logger)
+				.Concat (GetWindowsFileSystemJdks (Path.Combine ("AdoptOpenJDK", "jdk-*"), logger))
+				.Concat (GetWindowsRegistryJdks (logger, @"SOFTWARE\AdoptOpenJDK\JDK", "*", @"hotspot\MSI", "Path"))
+				.OrderByDescending (jdk => jdk, JdkInfoVersionComparer.Default);
+		}
+	}
+}


### PR DESCRIPTION
Context: https://adoptopenjdk.net

Add support to probe for the [AdoptOpenJDK][0] installation
directories.

[0]: https://adoptopenjdk.net/?variant=openjdk8&jvmVariant=hotspot