### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Fix CS0168 warning

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Jdks/JdkLocations.Windows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Jdks/JdkLocations.Windows.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Android.Tools {
 				try {
 					homes = Directory.EnumerateDirectories (root, pattern);
 				}
-				catch (IOException e) {
+				catch (IOException) {
 					continue;
 				}
 				foreach (var home in homes) {


### PR DESCRIPTION
Fix CS0168 warning in `JdkLocations.Windows.cs`:

	Jdks/JdkLocations.Windows.cs(42,24): warning CS0168: The variable 'e' is declared but never used