### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Support Microsoft Disk JDK

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -292,6 +292,7 @@ namespace Xamarin.Android.Tools
 				.Concat (AzulJdkLocations.GetAzulJdks (logger))
 				.Concat (OracleJdkLocations.GetOracleJdks (logger))
 				.Concat (VSAndroidJdkLocations.GetVSAndroidJdks (logger))
+				.Concat (MicrosoftDistJdkLocations.GetMicrosoftDistJdks (logger))
 				.Concat (GetEnvironmentVariableJdks ("JAVA_HOME", logger))
 				.Concat (GetPathEnvironmentJdks (logger))
 				.Concat (GetLibexecJdks (logger))

--- a/src/Xamarin.Android.Tools.AndroidSdk/Jdks/MicrosoftDistJdkLocations.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Jdks/MicrosoftDistJdkLocations.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Xamarin.Android.Tools {
+
+	class MicrosoftDistJdkLocations : JdkLocations {
+
+		internal static IEnumerable<JdkInfo> GetMicrosoftDistJdks (Action<TraceLevel, string> logger)
+		{
+			return FromPaths (GetMacOSMicrosoftDistJdkPaths (), logger, "$HOME/Library/Developer/Xamarin/jdk")
+				.Concat (GetWindowsFileSystemJdks (Path.Combine ("Android", "jdk", "microsoft_dist_openjdk_*"), logger, locator: "legacy microsoft_dist_openjdk"))
+				.OrderByDescending (jdk => jdk, JdkInfoVersionComparer.Default);
+		}
+
+		static IEnumerable<string> GetMacOSMicrosoftDistJdkPaths ()
+		{
+			var jdks    = AppDomain.CurrentDomain.GetData ($"GetMacOSMicrosoftJdkPaths jdks override! {typeof (JdkInfo).AssemblyQualifiedName}")
+				?.ToString ();
+			if (jdks == null) {
+				var home    = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
+				jdks        = Path.Combine (home, "Library", "Developer", "Xamarin", "jdk");
+			}
+			if (!Directory.Exists (jdks))
+				return Enumerable.Empty <string> ();
+
+			return Directory.EnumerateDirectories (jdks);
+		}
+	}
+}


### PR DESCRIPTION
Partially reverts commit 237642ce.

The plan to remove support for the obsolete `microsoft_dist_openjdk_`
JDK distribution has hit a few "snags", and thus we cannot remove
support for the legacy `microsoft_dist_openjdk_` package as quickly
as we had hoped.

Re-introduce support for the `microsoft_dist_openjdk_` JDK
installation location.