### PR TITLE
[Microsoft.Android.Build] Use MSBuild NuGets

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -10,12 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('windows'))" >
-    <!-- Compile against Microsoft.Build* NuGet refs, but do not copy to OutputDir. -->
     <!-- Only use these on Windows as it causes problems with running unit tests in the IDE's on MacOS -->
-    <PackageReference Include="Microsoft.Build"                Version="$(MSBuildPackageReferenceVersion)" IncludeAssets="compile" />
-    <PackageReference Include="Microsoft.Build.Framework"      Version="$(MSBuildPackageReferenceVersion)" IncludeAssets="compile" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core"     Version="$(MSBuildPackageReferenceVersion)" IncludeAssets="compile" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageReferenceVersion)" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build"                Version="$(MSBuildPackageReferenceVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework"      Version="$(MSBuildPackageReferenceVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core"     Version="$(MSBuildPackageReferenceVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageReferenceVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsOSPlatform('windows'))">
@@ -47,14 +46,6 @@
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('windows'))" >
-    <!-- Copy system Microsoft.Build*.dll and dependencies for tests to run against. We can remove this
-          and rely entirely on NuGet assets when mono/msbuild is merged into microsoft/msbuild. -->
-    <None Include="$(MSBuildToolsPath)\Microsoft.Build*.dll" >
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I've been hitting errors running tests locally on Windows after building
with .NET 6 Preview 3:

    Error Message:
     System.IO.FileNotFoundException : Could not load file or assembly 'System.Runtime, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.
    Stack Trace:
       at Xamarin.ProjectTools.DotNetXamarinProject.SaveProject()
     at Xamarin.ProjectTools.XamarinProject.Save(Boolean saveProject) in C:\Users\Peter\source\xamarin-android\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Common\XamarinProject.cs:line 241
     at Xamarin.ProjectTools.ProjectBuilder.Save(XamarinProject project, Boolean doNotCleanupOnUpdate, Boolean saveProject) in C:\Users\Peter\source\xamarin-android\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Common\ProjectBuilder.cs:line 43
     at Xamarin.ProjectTools.ProjectBuilder.Build(XamarinProject project, Boolean doNotCleanupOnUpdate, String[] parameters, Boolean saveProject, Dictionary`2 environmentVariables) in C:\Users\Peter\source\xamarin-android\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Common\ProjectBuilder.cs:line 67
     at Xamarin.Android.Build.Tests.WearTests.ResolveLibraryImportsWithReadonlyFiles() in C:\Users\Peter\source\xamarin-android\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\WearTests.cs:line 28

Rather than copying the version of the MSBuild assemblies used to build
our test projects to the output directory, we should be able to use the
NuGet package content directly.  These files should only be used by our
project creation APIs and as a result their version shouldn't matter.