### PR TITLE
[JdkInfo] handle invalid XML from /usr/libexec/java_home

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -350,7 +350,14 @@ namespace Xamarin.Android.Tools
 						return;
 					xml.Append (e.Data);
 			}, includeStderr: false);
-			var plist   = XElement.Parse (xml.ToString ());
+
+			XElement plist;
+			try {
+				plist = XElement.Parse (xml.ToString ());
+			} catch (XmlException e) {
+				logger (TraceLevel.Warning, string.Format (Resources.InvalidXmlLibExecJdk_path_args_message, jhp.FileName, jhp.Arguments, e.Message));
+				yield break;
+			}
 			foreach (var info in plist.Elements ("array").Elements ("dict")) {
 				var JVMHomePath = (XNode) info.Elements ("key").FirstOrDefault (e => e.Value == "JVMHomePath");
 				if (JVMHomePath == null)

--- a/src/Xamarin.Android.Tools.AndroidSdk/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Properties/Resources.Designer.cs
@@ -77,5 +77,14 @@ namespace Xamarin.Android.Tools.AndroidSdk.Properties {
                 return ResourceManager.GetString("InvalidMonodroidConfigFile_path_message", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An exception occurred while reading the output of &apos;{0} {1}&apos;. Exception: {2}.
+        /// </summary>
+        internal static string InvalidXmlLibExecJdk_path_args_message {
+            get {
+                return ResourceManager.GetString("InvalidXmlLibExecJdk_path_args_message", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Xamarin.Android.Tools.AndroidSdk/Properties/Resources.resx
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Properties/Resources.resx
@@ -130,4 +130,7 @@
 {0} - The path of the file being read.
 {1} - The exception message of the associated exception.</comment>
   </data>
+  <data name="InvalidXmlLibExecJdk_path_args_message" xml:space="preserve">
+    <value>An exception occurred while reading the output of '{0} {1}'. Exception: {2}</value>
+  </data>
 </root>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.cs.xlf
@@ -17,6 +17,11 @@
 {0} - The path of the file being read.
 {1} - The exception message of the associated exception.</note>
       </trans-unit>
+      <trans-unit id="InvalidXmlLibExecJdk_path_args_message">
+        <source>An exception occurred while reading the output of '{0} {1}'. Exception: {2}</source>
+        <target state="new">An exception occurred while reading the output of '{0} {1}'. Exception: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.de.xlf
@@ -17,6 +17,11 @@
 {0} - The path of the file being read.
 {1} - The exception message of the associated exception.</note>
       </trans-unit>
+      <trans-unit id="InvalidXmlLibExecJdk_path_args_message">
+        <source>An exception occurred while reading the output of '{0} {1}'. Exception: {2}</source>
+        <target state="new">An exception occurred while reading the output of '{0} {1}'. Exception: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.es.xlf
@@ -17,6 +17,11 @@
 {0} - The path of the file being read.
 {1} - The exception message of the associated exception.</note>
       </trans-unit>
+      <trans-unit id="InvalidXmlLibExecJdk_path_args_message">
+        <source>An exception occurred while reading the output of '{0} {1}'. Exception: {2}</source>
+        <target state="new">An exception occurred while reading the output of '{0} {1}'. Exception: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.fr.xlf
@@ -17,6 +17,11 @@
 {0} - The path of the file being read.
 {1} - The exception message of the associated exception.</note>
       </trans-unit>
+      <trans-unit id="InvalidXmlLibExecJdk_path_args_message">
+        <source>An exception occurred while reading the output of '{0} {1}'. Exception: {2}</source>
+        <target state="new">An exception occurred while reading the output of '{0} {1}'. Exception: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.it.xlf
@@ -17,6 +17,11 @@
 {0} - The path of the file being read.
 {1} - The exception message of the associated exception.</note>
       </trans-unit>
+      <trans-unit id="InvalidXmlLibExecJdk_path_args_message">
+        <source>An exception occurred while reading the output of '{0} {1}'. Exception: {2}</source>
+        <target state="new">An exception occurred while reading the output of '{0} {1}'. Exception: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.ja.xlf
@@ -17,6 +17,11 @@
 {0} - The path of the file being read.
 {1} - The exception message of the associated exception.</note>
       </trans-unit>
+      <trans-unit id="InvalidXmlLibExecJdk_path_args_message">
+        <source>An exception occurred while reading the output of '{0} {1}'. Exception: {2}</source>
+        <target state="new">An exception occurred while reading the output of '{0} {1}'. Exception: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.ko.xlf
@@ -17,6 +17,11 @@
 {0} - The path of the file being read.
 {1} - The exception message of the associated exception.</note>
       </trans-unit>
+      <trans-unit id="InvalidXmlLibExecJdk_path_args_message">
+        <source>An exception occurred while reading the output of '{0} {1}'. Exception: {2}</source>
+        <target state="new">An exception occurred while reading the output of '{0} {1}'. Exception: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.pl.xlf
@@ -17,6 +17,11 @@
 {0} - The path of the file being read.
 {1} - The exception message of the associated exception.</note>
       </trans-unit>
+      <trans-unit id="InvalidXmlLibExecJdk_path_args_message">
+        <source>An exception occurred while reading the output of '{0} {1}'. Exception: {2}</source>
+        <target state="new">An exception occurred while reading the output of '{0} {1}'. Exception: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.pt-BR.xlf
@@ -17,6 +17,11 @@
 {0} - The path of the file being read.
 {1} - The exception message of the associated exception.</note>
       </trans-unit>
+      <trans-unit id="InvalidXmlLibExecJdk_path_args_message">
+        <source>An exception occurred while reading the output of '{0} {1}'. Exception: {2}</source>
+        <target state="new">An exception occurred while reading the output of '{0} {1}'. Exception: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.ru.xlf
@@ -17,6 +17,11 @@
 {0} - The path of the file being read.
 {1} - The exception message of the associated exception.</note>
       </trans-unit>
+      <trans-unit id="InvalidXmlLibExecJdk_path_args_message">
+        <source>An exception occurred while reading the output of '{0} {1}'. Exception: {2}</source>
+        <target state="new">An exception occurred while reading the output of '{0} {1}'. Exception: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.tr.xlf
@@ -17,6 +17,11 @@
 {0} - The path of the file being read.
 {1} - The exception message of the associated exception.</note>
       </trans-unit>
+      <trans-unit id="InvalidXmlLibExecJdk_path_args_message">
+        <source>An exception occurred while reading the output of '{0} {1}'. Exception: {2}</source>
+        <target state="new">An exception occurred while reading the output of '{0} {1}'. Exception: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.zh-Hans.xlf
@@ -17,6 +17,11 @@
 {0} - The path of the file being read.
 {1} - The exception message of the associated exception.</note>
       </trans-unit>
+      <trans-unit id="InvalidXmlLibExecJdk_path_args_message">
+        <source>An exception occurred while reading the output of '{0} {1}'. Exception: {2}</source>
+        <target state="new">An exception occurred while reading the output of '{0} {1}'. Exception: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Properties/xlf/Resources.zh-Hant.xlf
@@ -17,6 +17,11 @@
 {0} - The path of the file being read.
 {1} - The exception message of the associated exception.</note>
       </trans-unit>
+      <trans-unit id="InvalidXmlLibExecJdk_path_args_message">
+        <source>An exception occurred while reading the output of '{0} {1}'. Exception: {2}</source>
+        <target state="new">An exception occurred while reading the output of '{0} {1}'. Exception: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Context: https://dev.azure.com/xamarin/public/_build/results?buildId=40929&view=logs&j=cfef19e4-4225-5e84-636a-86ba2231ac21&t=cd3bc6c3-ac29-5320-67c9-5fb59fc8e05c&l=732

dotnet/maui has hit some build failures such as:

    error XARSD7000: System.Xml.XmlException: Root element is missing.
    error XARSD7000:   at System.Xml.XmlTextReaderImpl.Throw (System.Exception e) [0x00027] in <cd2a19182af54ce694ec155c18cdf0fc>:0
    error XARSD7000:   at System.Xml.XmlTextReaderImpl.ThrowWithoutLineInfo (System.String res) [0x00017] in <cd2a19182af54ce694ec155c18cdf0fc>:0
    error XARSD7000:   at System.Xml.XmlTextReaderImpl.ParseDocumentContent () [0x0035d] in <cd2a19182af54ce694ec155c18cdf0fc>:0
    error XARSD7000:   at System.Xml.XmlTextReaderImpl.Read () [0x0008c] in <cd2a19182af54ce694ec155c18cdf0fc>:0
    error XARSD7000:   at System.Xml.XmlReader.MoveToContent () [0x0003a] in <cd2a19182af54ce694ec155c18cdf0fc>:0
    error XARSD7000:   at System.Xml.Linq.XElement.Load (System.Xml.XmlReader reader, System.Xml.Linq.LoadOptions options) [0x0000e] in <7a9b77c9c73b43f99a32b1ba98596ce4>:0
    error XARSD7000:   at System.Xml.Linq.XElement.Parse (System.String text, System.Xml.Linq.LoadOptions options) [0x00016] in <7a9b77c9c73b43f99a32b1ba98596ce4>:0
    error XARSD7000:   at System.Xml.Linq.XElement.Parse (System.String text) [0x00000] in <7a9b77c9c73b43f99a32b1ba98596ce4>:0
    error XARSD7000:   at Xamarin.Android.Tools.JdkInfo+<GetLibexecJdkPaths>d__56.MoveNext () [0x0007e] in <2f2fbe285c184b618ed10818f205c9e8>:0
    error XARSD7000:   at System.Linq.Enumerable+DistinctIterator`1[TSource].MoveNext () [0x00028] in <22add0566d954580989fae334638a101>:0
    error XARSD7000:   at System.Linq.Enumerable+SelectEnumerableIterator`2[TSource,TResult].MoveNext () [0x00029] in <22add0566d954580989fae334638a101>:0
    error XARSD7000:   at System.Linq.Enumerable+WhereSelectEnumerableIterator`2[TSource,TResult].ToArray () [0x0003e] in <22add0566d954580989fae334638a101>:0
    error XARSD7000:   at System.Linq.Buffer`1[TElement]..ctor (System.Collections.Generic.IEnumerable`1[T] source) [0x0000a] in <22add0566d954580989fae334638a101>:0
    error XARSD7000:   at System.Linq.OrderedEnumerable`1+<GetEnumerator>d__3[TElement].MoveNext () [0x0001e] in <22add0566d954580989fae334638a101>:0
    error XARSD7000:   at System.Linq.Enumerable+ConcatIterator`1[TSource].MoveNext () [0x0002b] in <22add0566d954580989fae334638a101>:0
    error XARSD7000:   at System.Linq.Enumerable+SelectEnumerableIterator`2[TSource,TResult].MoveNext () [0x00029] in <22add0566d954580989fae334638a101>:0
    error XARSD7000:   at Xamarin.Android.Tools.AndroidSdkBase.GetValidPath (System.Func`2[T,TResult] pathValidator, System.String ctorParam, System.Func`1[TResult] getPreferredPath, System.Func`1[TResult] getAllPaths) [0x00040] in <2f2fbe285c184b618ed10818f205c9e8>:0
    error XARSD7000:   at Xamarin.Android.Tools.AndroidSdkBase.Initialize (System.String androidSdkPath, System.String androidNdkPath, System.String javaSdkPath) [0x00030] in <2f2fbe285c184b618ed10818f205c9e8>:0
    error XARSD7000:   at Xamarin.Android.Tools.AndroidSdkInfo..ctor (System.Action`2[T1,T2] logger, System.String androidSdkPath, System.String androidNdkPath, System.String javaSdkPath) [0x00025] in <2f2fbe285c184b618ed10818f205c9e8>:0
    error XARSD7000:   at Xamarin.Android.Tasks.MonoAndroidHelper.RefreshAndroidSdk (System.String sdkPath, System.String ndkPath, System.String javaPath, Microsoft.Build.Utilities.TaskLoggingHelper logHelper) [0x00005] in <5a1df33220564ef787578ac3c7e67d03>:0
    error XARSD7000:   at Xamarin.Android.Tasks.ResolveSdks.RunTask () [0x000ac] in <5a1df33220564ef787578ac3c7e67d03>:0
    error XARSD7000:   at Xamarin.Android.Tasks.AndroidTask.Execute () [0x00000] in <5a1df33220564ef787578ac3c7e67d03>:0

Looking at the method in question, it doesn't handle `XmlException`
and warn appropriately.

I don't have the *actual* output of `/usr/libexec/java_home` from
these machines, but I suspect it's printing some message before the
XML or no XML at all.