### PR TITLE
[BaseTasks] fix `\`-delimited paths on macOS

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/AndroidRidAbiHelper.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/AndroidRidAbiHelper.cs
@@ -18,6 +18,10 @@ namespace Microsoft.Android.Build.Tasks
 
 		public static string GetNativeLibraryAbi (string lib)
 		{
+			if (string.IsNullOrEmpty (lib))
+				return null;
+			lib = lib.Replace ('\\', Path.DirectorySeparatorChar);
+
 			// The topmost directory the .so file is contained within
 			var dir = Directory.GetParent (lib);
 			var dirName = dir.Name.ToLowerInvariant ();

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/AndroidRidAbiHelperTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/AndroidRidAbiHelperTests.cs
@@ -160,6 +160,14 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 				/* expected */
 				"x86_64"
 			},
+			new object [] {
+				/* input */
+				new TaskItem("liblinkwin.so", new Dictionary<string,string> {
+					{ "Link", "android-arm64\\libfoo.so" },
+				}),
+				/* expected */
+				"x86_64",
+			},
 		};
 
 		[Test]

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/AndroidRidAbiHelperTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/AndroidRidAbiHelperTests.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 					{ "Link", "android-arm64\\libfoo.so" },
 				}),
 				/* expected */
-				"x86_64",
+				"arm64-v8a",
 			},
 		};
 

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/AndroidRidAbiHelperTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/AndroidRidAbiHelperTests.cs
@@ -11,6 +11,14 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 	{
 		static object [] StringValueSource = new object [] {
 			new[] {
+				/* input */    default (string),
+				/* expected */ default (string)
+			},
+			new[] {
+				/* input */    "",
+				/* expected */ default
+			},
+			new[] {
 				/* input */    "armeabi-v7a/libfoo.so",
 				/* expected */ "armeabi-v7a"
 			},
@@ -65,7 +73,15 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 			new[] {
 				/* input */    "packages/sqlitepclraw.lib.e_sqlite3.android/1.1.11/runtimes/android-arm64/native/libe_sqlite3.so",
 				/* expected */ "arm64-v8a"
-			}
+			},
+			new[] {
+				/* input */    "arm64-v8a\\libfoo.so",
+				/* expected */ "arm64-v8a"
+			},
+			new[] {
+				/* input */    "android-arm64\\libfoo.so",
+				/* expected */ "arm64-v8a"
+			},
 		};
 
 		[Test]
@@ -76,6 +92,12 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 		}
 
 		static object [] ITaskItemValueSource = new object [] {
+			new object [] {
+				/* input */
+				new TaskItem(""),
+				/* expected */
+				default (string)
+			},
 			new object [] {
 				/* input */
 				new TaskItem("armeabi-v7a/libfoo.so"),
@@ -129,6 +151,14 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 				}),
 				/* expected */
 				"armeabi-v7a"
+			},
+			new object [] {
+				/* input */
+				new TaskItem("liblinkwin.so", new Dictionary<string,string> {
+					{ "Link", "x86_64\\libfoo.so" }
+				}),
+				/* expected */
+				"x86_64"
 			},
 		};
 


### PR DESCRIPTION
Tests in xamarin-android have started failing with:

    libfoo.so : error XA4301: Cannot determine ABI of native library 'libfoo.so'.
    Move this file to a directory with a valid Android ABI name such as 'libs/armeabi-v7a/'.

Where the test in question sets `Link=x86\libfoo.so`:

https://github.com/xamarin/xamarin-android/blob/bf63c3d116b38459678cb3aefd2f5826e78c385e/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs#L115

This only fails on macOS and works fine on Windows. I didn't consider
this case in 90d76212.

I've added test cases for `\`, and added a `string.Replace()` that
should solve the problem on macOS.

I added test cases for `null` input as well.