### PR TITLE
Bump LibZipSharp to 2.0.0-alpha7

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -5,7 +5,7 @@
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
     <MSBuildPackageReferenceVersion>16.10.0</MSBuildPackageReferenceVersion>
-    <LibZipSharpVersion>2.0.0-alpha6</LibZipSharpVersion>
+    <LibZipSharpVersion>2.0.0-alpha7</LibZipSharpVersion>
     <MonoUnixVersion>7.0.0-alpha8.21302.6</MonoUnixVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Context: https://github.com/xamarin/LibZipSharp/commit/fcb9323d9d95b06051f67d8d73ba371a4029722d
Context: https://libzip.org/news/release-1.8.0.html

2.0.0-alpha7 changes:

  * bump libzip version to 1.8.0
  * add support for ZSTD compression
  * properly hide all the native library symbols except for the libzip ones