### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] More Microsoft Dist JDK Support

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -185,7 +185,7 @@ namespace Xamarin.Android.Tools
 
 			logger          = logger ?? DefaultConsoleLogger;
 
-			var latestJdk   = MicrosoftOpenJdkLocations.GetMicrosoftOpenJdks (logger).FirstOrDefault ();
+			var latestJdk   = JdkInfo.GetPreferredJdkInfos (logger).FirstOrDefault ();
 			if (latestJdk == null)
 				throw new NotSupportedException ("No Microsoft OpenJDK could be found.  Please re-run the Visual Studio installer or manually specify the JDK path in settings.");
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -280,6 +280,7 @@ namespace Xamarin.Android.Tools
 			return props;
 		}
 
+		// Keep ordering in sync w/ GetPreferredJdkInfos
 		public static IEnumerable<JdkInfo> GetKnownSystemJdkInfos (Action<TraceLevel, string>? logger = null)
 		{
 			logger  = logger ?? AndroidSdkInfo.DefaultConsoleLogger;
@@ -297,6 +298,14 @@ namespace Xamarin.Android.Tools
 				.Concat (GetPathEnvironmentJdks (logger))
 				.Concat (GetLibexecJdks (logger))
 				.Concat (GetJavaAlternativesJdks (logger))
+				;
+		}
+
+		// Keep ordering in sync w/ GetKnownSystemJdkInfos
+		internal static IEnumerable<JdkInfo> GetPreferredJdkInfos (Action<TraceLevel, string> logger)
+		{
+			return MicrosoftOpenJdkLocations.GetMicrosoftOpenJdks (logger)
+				.Concat (MicrosoftDistJdkLocations.GetMicrosoftDistJdks (logger))
 				;
 		}
 


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1314263

Remember `AndroidSdkInfo.DetectAndSetPreferredJavaSdkPathToLatest()`
(commit a4aad186)?  It's supposed to "detect" the latest installed
"preferred" JDK installation location, and set configuration values
so that subsequent `new AndroidSdkInfo()` expressions will use that
JDK location, instead of some other JDK location.

The "preferred" JDK was a JDK that was "known good" for Xamarin.Android
use, i.e. one that Visual Studio installed.  In a4aad186, this was the
`microsoft_dist_openjdk_*` version.

When we (prematurely) removed support for the `microsoft_dist_openjdk_`
build in commits 237642ce and dca30d9d, we updated
`AndroidSdkInfo.DetectAndSetPreferredJavaSdkPathToLatest()` to instead
prefer the [Microsoft OpenJDK][0] build, but this migration needed to
be delayed until Visual Studio 17.0.

Which means that the "current world order" is *wrong*:
`AndroidSdkInfo.DetectAndSetPreferredJavaSdkPathToLatest()` tries to
detect a JDK that is not currently installed by anything.

Futhermore, Visual Studio for Mac will call
`AndroidSdkInfo.DetectAndSetPreferredJavaSdkPathToLatest()` if no JDK
is currently configured.

The result is that on "clean" systems, Visual Studio for Mac can
crash with a `NotSupportedException` because it's looking for a
Microsoft OpenJDK installation, but only a `microsoft_dist_openjdk_`
installation is available.  Thus, no preferred JDK is found, and the
IDE crashes.

Fix this by adding a new (`internal`) `JdkInfo.GetPreferredJdkInfos()`
method, which appropriately checks *both* Microsoft OpenJDK *and*
`microsoft_dist_openjdk_` installation locations, and update
`AndroidSdkInfo.DetectAndSetPreferredJavaSdkPathToLatest()` to now
use `JdkInfo.GetPreferredJdkInfos()`.

(We add the method to `JdkInfo` so that it is easier to keep
`GetPreferredJdkInfos()` and `GetKnownSystemJdkInfos()` consistent
with each other.)

[0]: https://www.microsoft.com/openjdk