### PR TITLE
[NDK] Properly detect 64-bit NDK

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
@@ -87,7 +87,11 @@ namespace Xamarin.Android.Tools
 			if (!string.IsNullOrEmpty (AndroidNdkPath)) {
 				// It would be nice if .NET had real globbing support in System.IO...
 				string toolchainsDir = Path.Combine (AndroidNdkPath, "toolchains");
-				if (Directory.Exists (toolchainsDir)) {
+				string llvmNdkToolchainDir = Path.Combine (toolchainsDir, "llvm", "prebuilt", NdkHostPlatform64Bit);
+
+				if (Directory.Exists (llvmNdkToolchainDir)) {
+					IsNdk64Bit = true;
+				} else if (Directory.Exists (toolchainsDir)) {
 					IsNdk64Bit = Directory.EnumerateDirectories (toolchainsDir, "arm-linux-androideabi-*")
 						.Any (dir => Directory.Exists (Path.Combine (dir, "prebuilt", NdkHostPlatform64Bit)));
 				}


### PR DESCRIPTION
The code detecting whether an instance of NDK is a 64-bit one assumed
that the GNU binutils paths existed below the toolchains dir and used
them to check whether the 64-bit platform directory exists under them in
order to determine if the NDK is a 64-bit one.  NDK r23, however, will
remove the GNU binutils completely and those paths no longer exist.

Add a check for the `toolchains/llvm/prebuilt/[PLATFORM]` directory
existence before the older check so that detection works correctly for
NDK r23+.