### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Update SDK component for API-31

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
@@ -9,12 +9,14 @@
     If this file is changed the submodule for androidtools should be updated, 
     along with any other repo which references androidtools. 
     -->
-    <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">30.0.2</AndroidSdkBuildToolsVersion>
-    <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">2.1</AndroidCommandLineToolsVersion>
-    <AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">30.0.4</AndroidSdkPlatformToolsVersion>
-    <AndroidSdkToolsVersion Condition="'$(AndroidSdkToolsVersion)' == ''">26.1.1</AndroidSdkToolsVersion>
+    <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">31.0.0</AndroidSdkBuildToolsVersion>
+    <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">5.0</AndroidCommandLineToolsVersion>
+    <AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">31.0.3</AndroidSdkPlatformToolsVersion>
     <AndroidSdkEmulatorVersion Condition="'$(AndroidSdkEmulatorVersion)' == ''"></AndroidSdkEmulatorVersion>
-    <AndroidSdkPlatformVersion Condition="'$(AndroidSdkPlatformVersion)' == ''">android-30</AndroidSdkPlatformVersion>
-    <AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">21.3.6528147</AndroidNdkVersion>
+    <AndroidSdkPlatformVersion Condition="'$(AndroidSdkPlatformVersion)' == ''">android-31</AndroidSdkPlatformVersion>
+    <AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">22.1.7171670</AndroidNdkVersion>
+
+    <!-- obsolete; should consider removing eventually -->
+    <AndroidSdkToolsVersion Condition="'$(AndroidSdkToolsVersion)' == ''">26.1.1</AndroidSdkToolsVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Context: https://dl-ssl.google.com/android/repository/repository2-1.xml

Update the preferred Android SDK component versions to the current latest
versions listed in the [Android Repository file][0]:

  * `$(AndroidSdkBuildToolsVersion)`/build-tools to 31.0.0
  * `$(AndroidCommandLineToolsVersion)`/cmdline-tools to 5.0
  * `$(AndroidSdkPlatformToolsVersion)`/platform-tools to 31.0.3
  * `$(AndroidSdkPlatformVersion)`/platform to android-31
  * `$(AndroidNdkVersion)`/ndk-bundle to 22.1.7171670

    Note: there is an NDK r23 package in `ndk;23.0.7599858`, and
    xamarin-android supports NDK r23 as of
    [xamarin/xamarin-android@f361d997][2], but that is installed into
    a *versioned* directory, a'la `$ANDROID_SDK_ROOT/ndk/23.0.7599858`,
    which (1) may not be fully supported, and (2) *isn't* supported
    by the Android SDK Manager.

    The latest `ndk-bundle` package is 22.1.7171670.

Additionally, the Android SDK `tools` component has been
[deprecated since 2017-Sep][1].  Add a comment noting that
`$(AndroidSdkToolsVersion)` should be considered obsolete, and that
we should eventually remove it.

[0]: https://dl-ssl.google.com/android/repository/repository2-1.xml
[1]: https://developer.android.com/studio/releases/sdk-tools
[2]: http://github.com/xamarin/xamarin-android/commit/f361d997807504a69c29163811f362da701410b6