### PR TITLE
[d17-0] Allow targets override

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -13,4 +13,9 @@
       <InformationalVersion>$(Version); git-rev-head:$(GitCommit); git-branch:$(GitBranch)</InformationalVersion>
     </PropertyGroup>
   </Target>
+
+  <Import
+      Project="$([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory))).override.targets"
+      Condition=" Exists('$([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory))).override.targets') "
+  />
 </Project>


### PR DESCRIPTION
Allow a .targets.override file in the parent directory
to customize targets settings for Directory.build.targets.

This is the same change made for androidtools here
https://github.com/xamarin/androidtools/pull/307,
applied to xamarin-android-tools.