### PR TITLE
[d17-0][build] Allow Assembly "vendorization" (#136)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,14 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
   </PropertyGroup>
+  <Import
+      Project="$(MSBuildThisFileDirectory)Configuration.Override.props"
+      Condition=" Exists('$(MSBuildThisFileDirectory)Configuration.Override.props') "
+  />
+  <Import
+      Project="$([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory))).override.props"
+      Condition=" Exists('$([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory))).override.props') "
+  />
   <PropertyGroup>
     <BaseIntermediateOutputPath Condition=" '$(BaseIntermediateOutputPath)' == '' ">obj\</BaseIntermediateOutputPath>
   </PropertyGroup>

--- a/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj
+++ b/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj
@@ -11,6 +11,7 @@
     <UpdateXlfOnBuild Condition=" '$(RunningOnCI)' != 'true' ">true</UpdateXlfOnBuild>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
+    <AssemblyName>$(VendorPrefix)Microsoft.Android.Build.BaseTasks$(VendorSuffix)</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
@@ -14,6 +14,7 @@
     <Description>Xamarin tools for interacting with the Android SDK.</Description>
     <Copyright>Copyright © Xamarin 2011-2016</Copyright>
     <PackageTags>Xamarin;Xamarin.Android</PackageTags>
+    <AssemblyName>$(VendorPrefix)Xamarin.Android.Tools.AndroidSdk$(VendorSuffix)</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -38,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FilesToSign Include="$(OutDir)\Xamarin.Android.Tools.AndroidSdk.dll">
+    <FilesToSign Include="$(OutDir)\$(AssemblyName).dll">
       <Authenticode>Microsoft400</Authenticode>
     </FilesToSign>
   </ItemGroup>


### PR DESCRIPTION
Context: ff73f925a399df523cd89a9b8b49849e63fe0411
Context: 061bcc2eb6e81b2ef7b26ec37315c0c636cf2093
Context: https://github.com/xamarin/XamarinVS/pull/12550

Changing `$(Version)` with every commit is fun and all, but doesn't
solve all problems.  Commit ff73f925 works "nicely" for MSBuild tasks
via [`<UsingTask/>`][0].  It doesn't work as well for "normal"
assembly references in a "normal" AppDomain context, because
assemblies are [normally resolved][1] via "assembly base name", *not*
the full path name including directory.

Thus, given `Example.dll`:

	csc /out:Example.dll /r:Path/To/Xamarin.Android.Tools.AndroidSdk.dll

then when `Example.dll` is loaded, it will try to load
`Xamarin.Android.Tools.AndroidSdk` via a `Load-by-name` method, and
will load the first `Xamarin.Android.Tools.AndroidSdk.dll` loaded
into the `AppDomain`/`AssemblyLoadContext`, regardless of version.

There may not be a good way to control what that assembly *is*.

This causes grief with our peer IDE teams, as assembly versions are
still checked, but on mismatch an exception is thrown (!).

Commit 061bcc2e was an attempt to address this, but proved to be
incomplete.

Attempt to improve matters by introducing a "vendorization" protocol:

 1. Update `Directory.Build.props` to import
    "parent directory.override.props", so that a "parent checkout"
    can easily override MSBuild properties.

 2. Update the `*.csproj` files so that `$(AssemblyName)` is forced
    to start with `$(VendorPrefix)`, and end with `$(VendorSuffix)`.

This allows a parent checkout to set the `$(VendorPrefix)` and
`$(VendorSuffix)` properties, which will impact the assembly filenames
of all assemblies built in xamarin-android-tools.

[0]: https://docs.microsoft.com/en-us/visualstudio/msbuild/usingtask-element-msbuild?view=vs-2019
[1]: https://docs.microsoft.com/en-us/dotnet/core/dependency-loading/loading-managed