### PR TITLE
expose the api to get preferred jdk infos

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -185,7 +185,7 @@ namespace Xamarin.Android.Tools
 
 			logger          = logger ?? DefaultConsoleLogger;
 
-			var latestJdk   = JdkInfo.GetPreferredJdkInfos (logger).FirstOrDefault ();
+			var latestJdk   = JdkInfo.GetSupportedJdkInfos (logger).FirstOrDefault ();
 			if (latestJdk == null)
 				throw new NotSupportedException ("No Microsoft OpenJDK could be found.  Please re-run the Visual Studio installer or manually specify the JDK path in settings.");
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -280,7 +280,7 @@ namespace Xamarin.Android.Tools
 			return props;
 		}
 
-		// Keep ordering in sync w/ GetPreferredJdkInfos
+		// Keep ordering in sync w/ GetSupportedJdkInfos
 		public static IEnumerable<JdkInfo> GetKnownSystemJdkInfos (Action<TraceLevel, string>? logger = null)
 		{
 			logger  = logger ?? AndroidSdkInfo.DefaultConsoleLogger;
@@ -302,8 +302,10 @@ namespace Xamarin.Android.Tools
 		}
 
 		// Keep ordering in sync w/ GetKnownSystemJdkInfos
-		internal static IEnumerable<JdkInfo> GetPreferredJdkInfos (Action<TraceLevel, string> logger)
+		public static IEnumerable<JdkInfo> GetSupportedJdkInfos (Action<TraceLevel, string>? logger = null)
 		{
+			logger = logger ?? AndroidSdkInfo.DefaultConsoleLogger;
+
 			return MicrosoftOpenJdkLocations.GetMicrosoftOpenJdks (logger)
 				.Concat (EclipseAdoptiumJdkLocations.GetEclipseAdoptiumJdks (logger))
 				.Concat (MicrosoftDistJdkLocations.GetMicrosoftDistJdks (logger))


### PR DESCRIPTION
- VisualStudio needs to know the list of preferred jdk infos to set the default jdk on the android settings property page