### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Parse Properties after header

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -42,7 +42,14 @@ namespace Xamarin.Android.Tools
 		Lazy<Dictionary<string, List<string>>>      javaProperties;
 		Lazy<Version?>                              javaVersion;
 
+		Action<TraceLevel, string>                  logger;
+
 		public JdkInfo (string homePath)
+			: this (homePath, null, null)
+		{
+		}
+
+		public JdkInfo (string homePath, string? locator = null, Action<TraceLevel, string>? logger = null)
 		{
 			if (homePath == null)
 				throw new ArgumentNullException (nameof (homePath));
@@ -50,6 +57,8 @@ namespace Xamarin.Android.Tools
 				throw new ArgumentException ("Not a directory", nameof (homePath));
 
 			HomePath            = homePath;
+			Locator             = locator;
+			this.logger         = logger ?? AndroidSdkInfo.DefaultConsoleLogger;
 
 			var binPath         = Path.Combine (HomePath, "bin");
 			JarPath             = ProcessUtils.FindExecutablesInDirectory (binPath, "jar").FirstOrDefault ();
@@ -78,14 +87,15 @@ namespace Xamarin.Android.Tools
 
 			IncludePath         = new ReadOnlyCollection<string> (includes);
 
-			javaProperties      = new Lazy<Dictionary<string, List<string>>> (GetJavaProperties, LazyThreadSafetyMode.ExecutionAndPublication);
+			javaProperties      = new Lazy<Dictionary<string, List<string>>> (
+				() => GetJavaProperties (this.logger),
+				LazyThreadSafetyMode.ExecutionAndPublication);
 			javaVersion         = new Lazy<Version?> (GetJavaVersion, LazyThreadSafetyMode.ExecutionAndPublication);
 		}
 
 		public JdkInfo (string homePath, string locator)
-			: this (homePath)
+			: this (homePath, locator, null)
 		{
-			Locator             = locator;
 		}
 
 		public override string ToString()
@@ -217,9 +227,11 @@ namespace Xamarin.Android.Tools
 			return new ReadOnlyDictionary<string, string>(props);
 		}
 
-		Dictionary<string, List<string>> GetJavaProperties ()
+		Dictionary<string, List<string>> GetJavaProperties (Action<TraceLevel, string> logger)
 		{
-			return GetJavaProperties (ProcessUtils.FindExecutablesInDirectory (Path.Combine (HomePath, "bin"), "java").First ());
+			return GetJavaProperties (
+					logger,
+					ProcessUtils.FindExecutablesInDirectory (Path.Combine (HomePath, "bin"), "java").First ());
 		}
 
 		static bool AnySystemJavasInstalled ()
@@ -239,7 +251,7 @@ namespace Xamarin.Android.Tools
 			return true;
 		}
 
-		static Dictionary<string, List<string>> GetJavaProperties (string java)
+		static Dictionary<string, List<string>> GetJavaProperties (Action<TraceLevel, string> logger, string java)
 		{
 			var javaProps   = new ProcessStartInfo {
 				FileName    = java,
@@ -248,19 +260,32 @@ namespace Xamarin.Android.Tools
 
 			var     props   = new Dictionary<string, List<string>> ();
 			string? curKey  = null;
+			bool    foundPS = false;
+			var     output  = new StringBuilder ();
 
 			if (!AnySystemJavasInstalled () && (java == "/usr/bin/java" || java == "java"))
 				return props;
+
+			const string PropertySettings = "Property settings:";
 
 			ProcessUtils.Exec (javaProps, (o, e) => {
 					const string ContinuedValuePrefix   = "        ";
 					const string NewValuePrefix         = "    ";
 					const string NameValueDelim         = " = ";
+					output.AppendLine (e.Data);
 					if (string.IsNullOrEmpty (e.Data))
 						return;
+					if (e.Data.StartsWith (PropertySettings, StringComparison.Ordinal)) {
+						foundPS = true;
+						return;
+					}
+					if (!foundPS) {
+						return;
+					}
 					if (e.Data.StartsWith (ContinuedValuePrefix, StringComparison.Ordinal)) {
-						if (curKey == null)
-							throw new InvalidOperationException ($"Unknown property key for value {e.Data}!");
+						if (curKey == null) {
+							logger (TraceLevel.Error, $"No Java property previously seen for continued value `{e.Data}`.");
+						}
 						props [curKey].Add (e.Data.Substring (ContinuedValuePrefix.Length));
 						return;
 					}
@@ -276,6 +301,9 @@ namespace Xamarin.Android.Tools
 						values.Add (value);
 					}
 			});
+			if (!foundPS) {
+				logger (TraceLevel.Warning, $"No Java properties found; did not find `{PropertySettings}` in `{java} -XshowSettings:properties -version` output: ```{output.ToString ()}```");
+			}
 
 			return props;
 		}
@@ -443,16 +471,16 @@ namespace Xamarin.Android.Tools
 		// Last-ditch fallback!
 		static IEnumerable<JdkInfo> GetPathEnvironmentJdks (Action<TraceLevel, string> logger)
 		{
-			return GetPathEnvironmentJdkPaths ()
+			return GetPathEnvironmentJdkPaths (logger)
 				.Select (p => TryGetJdkInfo (p, logger, "$PATH"))
 				.Where (jdk => jdk != null)
 				.Select (jdk => jdk!);
 		}
 
-		static IEnumerable<string> GetPathEnvironmentJdkPaths ()
+		static IEnumerable<string> GetPathEnvironmentJdkPaths (Action<TraceLevel, string> logger)
 		{
 			foreach (var java in ProcessUtils.FindExecutablesInPath ("java")) {
-				var props   = GetJavaProperties (java);
+				var props   = GetJavaProperties (logger, java);
 				if (props.TryGetValue ("java.home", out var java_homes)) {
 					var java_home   = java_homes [0];
 					// `java -XshowSettings:properties -version 2>&1 | grep java.home` ends with `/jre` on macOS.

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/JdkInfoTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/JdkInfoTests.cs
@@ -79,7 +79,7 @@ namespace Xamarin.Android.Tools.Tests
 
 			string quote = OS.IsWindows ? "" : "\"";
 			string java =
-				$"echo Property settings:{Environment.NewLine}" +
+				$"echo {quote}Property settings:{quote}{Environment.NewLine}" +
 				$"echo {quote}    java.home = {dir}{quote}{Environment.NewLine}" +
 				$"echo {quote}    java.vendor = Xamarin.Android Unit Tests{quote}{Environment.NewLine}" +
 				$"echo {quote}    java.version = {javaVersion}{quote}{Environment.NewLine}" +

--- a/tools/ls-jdks/App.cs
+++ b/tools/ls-jdks/App.cs
@@ -6,9 +6,34 @@ namespace Xamarin.Android.Tools
 	{
 		static void Main(string[] args)
 		{
+			foreach (var path in args) {
+				PrintProperties (path);
+			}
+			if (args.Length != 0)
+				return;
 			foreach (var jdk in JdkInfo.GetKnownSystemJdkInfos ()) {
 				Console.WriteLine ($"Found JDK: {jdk.HomePath}");
 				Console.WriteLine ($"  Locator: {jdk.Locator}");
+				// Force parsing of java properties.
+				var keys = jdk.JavaSettingsPropertyKeys;
+			}
+		}
+
+		static void PrintProperties (string jdkPath)
+		{
+			try {
+				var jdk = new JdkInfo (jdkPath, "ls-jdks");
+				Console.WriteLine ($"Property settings for JDK Path: {jdk.HomePath}");
+				foreach (var key in jdk.JavaSettingsPropertyKeys) {
+					if (!jdk.GetJavaSettingsPropertyValues (key, out var v)) {
+						Console.Error.WriteLine ($"ls-jdks: Could not retrieve value for key {key}.");
+						continue;
+					}
+					Console.WriteLine ($"    {key} = {string.Join (Environment.NewLine + "        ", v)}");
+				}
+			}
+			catch (Exception e) {
+				Console.Error.WriteLine (e);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1397171

Context: https://www.4e00.com/blog/java/2016/12/16/java-command-line-options.html

We have a Watson report of an `InvalidOperationException` being
thrown from `JdkInfo.GetJavaProperties()`:

	Xamarin.Android.Tools.AndroidSdk!Xamarin.Android.Tools.JdkInfo
	...
	clr!IL_Throw
	Xamarin.Android.Tools.AndroidSdk!Xamarin.Android.Tools.JdkInfo.__c__DisplayClass46_0._GetJavaProperties_b__0

The dump provides an additional glimmer of information: the
`InvalidOperationException` message text:

	Unknown property key for value        (to execute a class)!

`JdkInfo.GetJavaProperties()` only contains one `throw`, for when we
think we're processing a multi-line value, but we don't have a key
for the value encountered.

Which brings us to [java-command-line-options.html][0], which isn't
English, and isn't recent, but *does* show `java` output which
contains our "offending" string "(to execute a class)":

	$ java -showversion -help
	java version "1.8.0_66"
	Java(TM) SE Runtime Environment (build 1.8.0_66-b17)
	Java HotSpot(TM) 64-Bit Server VM (build 25.66-b17, mixed mode)
	Usage: java [-options] class [args...]
	           (to execute a class)
	...

What appears to be happening is that `JdkInfo` is encountering a JDK
for which `java -XshowSettings:properties -version` shows something
resembling the above `java -showversion -help` output, and the
"           (to execute a class)" is treated as part of a multi-line
value, which it isn't.

Update `JdkInfo.GetJavaProperties()` so that we *require* that we see
"Property settings:" *before* we start looking for keys & values.
This should ensure that we appropriately ignore
"(to execute a class)".

Additionally, update `tools/ls-jdks` so that it will accept a path
to a JDK to look at, and dump out the parsed properties.

[0]: https://www.4e00.com/blog/java/2016/12/16/java-command-line-options.html