### PR TITLE
Adding resource dlls to MicroBuild signing.

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
@@ -43,7 +43,7 @@
       <FilesToSign Include="$(OutDir)\$(AssemblyName).dll">
         <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>
-      <FilesToSign Include="$(OutDir)\**\Xamarin.Android.Tools.AndroidSdk.Ide.resources.dll">
+      <FilesToSign Include="$(OutDir)\**\$(AssemblyName).resources.dll">
         <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>
     </ItemGroup>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
@@ -38,11 +38,16 @@
     <PackageReference Include="XliffTasks" Version="1.0.0-beta.20420.1" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup>
-    <FilesToSign Include="$(OutDir)\$(AssemblyName).dll">
-      <Authenticode>Microsoft400</Authenticode>
-    </FilesToSign>
-  </ItemGroup>
+  <Target Name="GetFilesToSign" BeforeTargets="SignFiles">
+    <ItemGroup>
+      <FilesToSign Include="$(OutDir)\$(AssemblyName).dll">
+        <Authenticode>Microsoft400</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="$(OutDir)\**\Xamarin.Android.Tools.AndroidSdk.Ide.resources.dll">
+        <Authenticode>Microsoft400</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">


### PR DESCRIPTION
BaRS is conducting an effort to migrate signing in Xamarin pipelines off the [external Groovy pipeline.](https://dev.azure.com/devdiv/DevDiv/_build?definitionId=13878&_a=summary) The goal is to use MicroBuild to handle all signing within the build rather than hand off files for another pipeline to sign. The [Android.SDK.Manager](https://dev.azure.com/devdiv/DevDiv/_build?definitionId=13502&_a=summary) pipeline has been chosen as the first pipeline to migrate. Project files in Android.SDK.Manager reference the [xamarin-android-tools repo](https://github.com/xamarin/android-sdk-installer/blob/684b7e1283706bef2e5c832a64ced0158abe5259/Xamarin.Installer.AndroidSDK.Manager/Xamarin.Installer.AndroidSDK.Manager.csproj#L154) as a submodule and [sign the resource dlls](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=5479174&view=logs&j=7082d35a-e46b-5a74-0b0f-e46ed113ca0e&t=9ebd6855-a6bc-5b9a-0813-711468e28365&l=91) that the Xamarin.Android.Tools.AndroidSdk project creates. This change will move the signing of these resource dlls to within the build of Xamarin.Android.Tools.AndroidSdk. The added "GetFilesToSign" target is to enable the use of wildcards in MicroBuild.

This change is not intended to impact the behavior of the AndroidTools build beyond the added signing.
