### PR TITLE
[d16-11] Backport[Xamarin.Android.Tools.AndroidSdk] Parse Properties after header (#143)

### DIFF
--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/JdkInfoTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/JdkInfoTests.cs
@@ -79,7 +79,7 @@ namespace Xamarin.Android.Tools.Tests
 
 			string quote = OS.IsWindows ? "" : "\"";
 			string java =
-				$"echo Property settings:{Environment.NewLine}" +
+				$"echo {quote}Property settings:{quote}{Environment.NewLine}" +
 				$"echo {quote}    java.home = {dir}{quote}{Environment.NewLine}" +
 				$"echo {quote}    java.vendor = Xamarin.Android Unit Tests{quote}{Environment.NewLine}" +
 				$"echo {quote}    java.version = {javaVersion}{quote}{Environment.NewLine}" +

--- a/tools/ls-jdks/App.cs
+++ b/tools/ls-jdks/App.cs
@@ -6,9 +6,34 @@ namespace Xamarin.Android.Tools
 	{
 		static void Main(string[] args)
 		{
+			foreach (var path in args) {
+				PrintProperties (path);
+			}
+			if (args.Length != 0)
+				return;
 			foreach (var jdk in JdkInfo.GetKnownSystemJdkInfos ()) {
 				Console.WriteLine ($"Found JDK: {jdk.HomePath}");
 				Console.WriteLine ($"  Locator: {jdk.Locator}");
+				// Force parsing of java properties.
+				var keys = jdk.JavaSettingsPropertyKeys;
+			}
+		}
+
+		static void PrintProperties (string jdkPath)
+		{
+			try {
+				var jdk = new JdkInfo (jdkPath, "ls-jdks");
+				Console.WriteLine ($"Property settings for JDK Path: {jdk.HomePath}");
+				foreach (var key in jdk.JavaSettingsPropertyKeys) {
+					if (!jdk.GetJavaSettingsPropertyValues (key, out var v)) {
+						Console.Error.WriteLine ($"ls-jdks: Could not retrieve value for key {key}.");
+						continue;
+					}
+					Console.WriteLine ($"    {key} = {string.Join (Environment.NewLine + "        ", v)}");
+				}
+			}
+			catch (Exception e) {
+				Console.Error.WriteLine (e);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1397171

Context: https://www.4e00.com/blog/java/2016/12/16/java-command-line-options.html

We have a Watson report of an `InvalidOperationException` being
thrown from `JdkInfo.GetJavaProperties()`:

	Xamarin.Android.Tools.AndroidSdk!Xamarin.Android.Tools.JdkInfo
	...
	clr!IL_Throw
	Xamarin.Android.Tools.AndroidSdk!Xamarin.Android.Tools.JdkInfo.__c__DisplayClass46_0._GetJavaProperties_b__0

The dump provides an additional glimmer of information: the
`InvalidOperationException` message text:

	Unknown property key for value        (to execute a class)!

`JdkInfo.GetJavaProperties()` only contains one `throw`, for when we
think we're processing a multi-line value, but we don't have a key
for the value encountered.

Which brings us to [java-command-line-options.html][0], which isn't
English, and isn't recent, but *does* show `java` output which
contains our "offending" string of "(to execute a class)":

	$ java -showversion -help
	java version "1.8.0_66"
	Java(TM) SE Runtime Environment (build 1.8.0_66-b17)
	Java HotSpot(TM) 64-Bit Server VM (build 25.66-b17, mixed mode)
	Usage: java [-options] class [args...]
	           (to execute a class)
	...

What appears to be happening is that `JdkInfo` is encountering a JDK
for which `java -XshowSettings:properties -version` shows something
resembling the above `java -showversion -help` output, and the
"           (to execute a class)" is treated as part of a multi-line
value, which it isn't.

Update `JdkInfo.GetJavaProperties()` so that we *require* that we see
"Property settings:" *before* we start looking for keys & values.
This should ensure that we appropriately ignore
"           (to execute a class)".

Additionally, add a `JdkInfo` constructor overload which takes an
`Action<TraceLevel, string>? logger` parameter, a'la `AndroidSdkInfo`,
so that `JdkInfo` can provide additional "contextual" logging without
requiring the use of exceptions.  Turn the lack of a key for a multi-
line value into a warning, instead of an exception.

Finally, update `tools/ls-jdks` so that it will accept a path
to a JDK to look at, and dump out the parsed properties.

[0]: https://www.4e00.com/blog/java/2016/12/16/java-command-line-options.html