### PR TITLE
Bump LibZipSharp to 2.0.2

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -5,7 +5,7 @@
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
     <MSBuildPackageReferenceVersion>16.10.0</MSBuildPackageReferenceVersion>
-    <LibZipSharpVersion>2.0.0</LibZipSharpVersion>
+    <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' != ''" >2.0.2</LibZipSharpVersion>
     <MonoUnixVersion>7.0.0-final.1.21369.2</MonoUnixVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Changes

- Use a different license tag for nuget generation 
- Fix corrupt data when Deleting entries from zip files.

https://github.com/xamarin/LibZipSharp/compare/2.0.0...2.0.2