### PR TITLE
Bump LibZipSharp to 2.0.3

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -5,7 +5,7 @@
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
     <MSBuildPackageReferenceVersion>16.10.0</MSBuildPackageReferenceVersion>
-    <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >2.0.2</LibZipSharpVersion>
+    <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >2.0.3</LibZipSharpVersion>
     <MonoUnixVersion>7.0.0-final.1.21369.2</MonoUnixVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
    Changes

    - Don't rewind the temporary stream on write to the main one

    https://github.com/xamarin/LibZipSharp/compare/2.0.2...2.0.3