### PR TITLE
Adding condition to GetFilesToSign

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="XliffTasks" Version="1.0.0-beta.20420.1" PrivateAssets="all" />
   </ItemGroup>
 
-  <Target Name="GetFilesToSign" BeforeTargets="SignFiles">
+  <Target Name="GetFilesToSign" BeforeTargets="SignFiles" Condition=" '$(Configuration)' == 'Release' Or '$(Configuration)' == 'ReleaseWindows'">
     <ItemGroup>
       <FilesToSign Include="$(OutDir)\$(AssemblyName).dll">
         <Authenticode>Microsoft400</Authenticode>


### PR DESCRIPTION
Adding condition to GetFilesToSign to only include files if build configuration is Release.

This change is to support signing in the [Android.SDK.Manager](https://dev.azure.com/devdiv/DevDiv/_build?definitionId=13502&_a=summary) build pipeline. A condition was added for the signing ItemGroup to only create it if the `$(Configuration)` is a Release configuration. This is to handle the case where a solution file might build a debug configuration in a real sign build. The debug configuration will ignore the signing ItemGroup.