### PR TITLE
Don't return null Jdk locations

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Jdks/JdkLocations.MacOS.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Jdks/JdkLocations.MacOS.cs
@@ -21,8 +21,10 @@ namespace Xamarin.Android.Tools {
 		{
 			var config = AndroidSdkUnix.GetUnixConfigFile (logger);
 			foreach (var java_sdk in config.Root.Elements ("java-sdk")) {
-				var path    = (string) java_sdk.Attribute ("path");
-				yield return path;
+				var path = (string) java_sdk.Attribute ("path");
+				if (path != null) {
+					yield return path;
+				}
 			}
 		}
 


### PR DESCRIPTION
VSMac has a first-chance exception because we're returning null here for some attributes