### PR TITLE
Backport MicroBuild Signing Changes to d17-0

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
@@ -38,11 +38,16 @@
     <PackageReference Include="XliffTasks" Version="1.0.0-beta.20420.1" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup>
-    <FilesToSign Include="$(OutDir)\$(AssemblyName).dll">
-      <Authenticode>Microsoft400</Authenticode>
-    </FilesToSign>
-  </ItemGroup>
+  <Target Name="GetFilesToSign" BeforeTargets="SignFiles">
+    <ItemGroup>
+      <FilesToSign Include="$(OutDir)\$(AssemblyName).dll">
+        <Authenticode>Microsoft400</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="$(OutDir)\**\$(AssemblyName).resources.dll">
+        <Authenticode>Microsoft400</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="XliffTasks" Version="1.0.0-beta.20420.1" PrivateAssets="all" />
   </ItemGroup>
 
-  <Target Name="GetFilesToSign" BeforeTargets="SignFiles">
+  <Target Name="GetFilesToSign" BeforeTargets="SignFiles" Condition=" '$(Configuration)' == 'Release' Or '$(Configuration)' == 'ReleaseWindows'">
     <ItemGroup>
       <FilesToSign Include="$(OutDir)\$(AssemblyName).dll">
         <Authenticode>Microsoft400</Authenticode>


### PR DESCRIPTION
With the move away from the "sign-from-github-esrp" ("Groovy") pipeline, we need to shift our assembly signing to happen alongside the build itself, which is more secure. Without these changes, we will not be able to push new, signed assemblies from this branch.