### PR TITLE
[d17-2] Add support for writing android:roundIcon to Android manifest (#162)

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidAppManifest.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidAppManifest.cs
@@ -150,6 +150,11 @@ namespace Xamarin.Android.Tools
 			set { application.SetAttributeValue (aNS + "icon", NullIfEmpty (value)); }
 		}
 
+		public string? ApplicationRoundIcon {
+			get { return (string?) application.Attribute (aNS + "roundIcon");  }
+			set { application.SetAttributeValue (aNS + "roundIcon", NullIfEmpty (value)); }
+		}
+
 		public string? ApplicationTheme {
 			get { return (string?) application.Attribute (aNS + "theme"); }
 			set { application.SetAttributeValue (aNS + "theme", NullIfEmpty (value)); }


### PR DESCRIPTION
Context: https://github.com/xamarin/XamarinVS/pull/12895

This change is necessary for enabling adaptive icon support in the Android Manifest property page.

It introduces a new attribute `android:roundIcon`.

Co-authored-by: Jonathan Peppers <jonathan.peppers@microsoft.com>