### PR TITLE
Bump LibZipSharp to 2.0.4

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -5,7 +5,7 @@
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
     <MSBuildPackageReferenceVersion>16.10.0</MSBuildPackageReferenceVersion>
-    <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >2.0.3</LibZipSharpVersion>
+    <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >2.0.4</LibZipSharpVersion>
     <MonoUnixVersion>7.0.0-final.1.21369.2</MonoUnixVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Changes

- Add a new more complex unit test
- [ci] Use new EO compliant build pools
- Bump vcpkg to latest version
- Use RuntimeInformation to determine the Processor architecture

https://github.com/xamarin/LibZipSharp/compare/2.0.2...2.0.4