### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Provide more logging

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Android.Tools
 				if (androidEl != null) {
 					var path = (string?)androidEl.Attribute ("path");
 
-					if (ValidateAndroidSdkLocation (path))
+					if (ValidateAndroidSdkLocation ("preferred path", path))
 						return path;
 				}
 				return null;
@@ -66,7 +66,7 @@ namespace Xamarin.Android.Tools
 				if (androidEl != null) {
 					var path = (string?)androidEl.Attribute ("path");
 
-					if (ValidateAndroidNdkLocation (path))
+					if (ValidateAndroidNdkLocation ("preferred path", path))
 						return path;
 				}
 				return null;
@@ -81,7 +81,7 @@ namespace Xamarin.Android.Tools
 				if (javaEl != null) {
 					var path = (string?)javaEl.Attribute ("path");
 
-					if (ValidateJavaSdkLocation (path))
+					if (ValidateJavaSdkLocation ("preferred path", path))
 						return path;
 				}
 				return null;

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -145,7 +145,7 @@ namespace Xamarin.Android.Tools
 			foreach (var basePath in new string [] {xamarin_private, android_default, vs_default, vs_default32bit, vs_2017_default, cdrive_default})
 				if (Directory.Exists (basePath))
 					foreach (var dir in Directory.GetDirectories (basePath, "android-ndk-r*"))
-						if (ValidateAndroidNdkLocation (dir))
+						if (ValidateAndroidNdkLocation ("Windows known NDK path", dir))
 							yield return dir;
 
 			foreach (var dir in base.GetAllAvailableAndroidNdks ()) {


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/7073
Context: https://github.com/xamarin/xamarin-android/blob/fdfc4c44ba65fcff9caf809bcf2d1f1a6837b1e3/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs#L19-L50

Trying to figure out how xamarin-android's
`AndroidDependenciesTests.InstallAndroidDependenciesTest()` *passes*;
it creates an empty "SDK" directory, then builds with the
`InstallAndroidDependencies` target, and on main this works,
*even though* it implies that it's creating an `AndroidSdkInfo`
instance with an *empty* SDK directory:

	if (Directory.Exists (sdkPath))
		Directory.Delete (sdkPath, true);
	Directory.CreateDirectory (sdkPath);
	// `sdkPath` is not otherwise populated

Yet it *passes* `ValidateAndroidSdkLocation()`:

	  ValidateAndroidSdkLocation: `/Users/runner/work/1/a/TestRelease/06-09_22.00.22/temp/InstallAndroidDependenciesTest/android-sdk`, result=True

I do not understand *how* this can be the case, as
`ValidateAndroidSdkLocation()` wants a `platform-tools/adb` program,
*which should not exist*, yet it validates

I am thus very confused.

Expand the log messages provided by `AndroidSdkBase` & co. so that
we also log "where" the `loc` parameter is coming from, via a new
`locator` parameter (similar to the `locator` parameter in `JdkInfo`),
and update the "file check" logic so that we log the path of the
detected files.

This way, hopefully, I can verify that it *is* finding an `adb`,
and *where that file is located*.