### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Permit NDK r24

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Android.Tools
 	{
 		// When this changes, update the test: Xamarin.Android.Tools.Tests.AndroidSdkInfoTests.Ndk_MultipleNdkVersionsInSdk
 		const int MinimumCompatibleNDKMajorVersion = 16;
-		const int MaximumCompatibleNDKMajorVersion = 23;
+		const int MaximumCompatibleNDKMajorVersion = 24;
 
 		static readonly char[] SourcePropertiesKeyValueSplit = new char[] { '=' };
 


### PR DESCRIPTION
Update `AndroidSdkBase.MaximumCompatibleNDKMajorVersion` to 24, so
that NDK r24 is considered as a valid version.