### PR TITLE
[ci] Run OneLocBuild on a schedule

### DIFF
--- a/Localize/onelocbuild.yaml
+++ b/Localize/onelocbuild.yaml
@@ -2,10 +2,16 @@
 
 name: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
 
-trigger:
-- main
+trigger: none
 
 pr: none
+
+schedules:
+- cron: "0 6 * * *"
+  displayName: Run daily at 6:00 UTC
+  branches:
+    include:
+    - main
 
 jobs:
 - job: OneLocBuild


### PR DESCRIPTION
The xamarin-android-tools repo now builds in both the xamarin/public and
devdiv/DevDiv Azure DevOps orgs, and unfortunately CI triggers only work
for [one organization at a time][0]:

    "However, if you create pipelines for a single repository in multiple
    Azure DevOps organizations, only the first organization's pipelines
    can be automatically triggered by GitHub commits or pull requests."

Since the OneLocBuild job can't run against every commit automatically,
the job has been updated to run on a daily schedule so that we can still
get continuous builds.

[0]: https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#create-pipelines-in-multiple-azure-devops-organizations-and-projects