### PR TITLE
[ci] Use latest macOS and Windows images

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -23,9 +23,9 @@ jobs:
   strategy:
     matrix:
       macOS:
-        vmImage: macOS-10.15
-      win2019:
-        vmImage: windows-2019
+        vmImage: macOS-12
+      windows:
+        vmImage: windows-2022
 
   pool:
     vmImage: $(vmImage)


### PR DESCRIPTION
Updates the build to run on the latest macOS and Windows VM images, as
the macOS-10.15 Azure Pipelines agent pool is now deprecated.