### PR TITLE
Fallback to well known config file place

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -221,10 +221,10 @@ namespace Xamarin.Android.Tools
 		//
 		private static string UnixConfigPath {
 			get {
-				var p   = AppDomain.CurrentDomain.GetData (GetUnixConfigDirOverrideName)?.ToString ();
+				var p = AppDomain.CurrentDomain.GetData (GetUnixConfigDirOverrideName)?.ToString ();
 				if (string.IsNullOrEmpty (p)) {
-					p   = Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData);
-					p   = Path.Combine (p, "xbuild");
+					p = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), ".config");
+					p = Path.Combine (p, "xbuild");
 				}
 				return Path.Combine (p, "monodroid-config.xml");
 			}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -221,10 +221,10 @@ namespace Xamarin.Android.Tools
 		//
 		private static string UnixConfigPath {
 			get {
-				var p = AppDomain.CurrentDomain.GetData (GetUnixConfigDirOverrideName)?.ToString ();
+				var p   = AppDomain.CurrentDomain.GetData (GetUnixConfigDirOverrideName)?.ToString ();
 				if (string.IsNullOrEmpty (p)) {
-					p = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), ".config");
-					p = Path.Combine (p, "xbuild");
+					p   = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), ".config");
+					p   = Path.Combine (p, "xbuild");
 				}
 				return Path.Combine (p, "monodroid-config.xml");
 			}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -223,8 +223,7 @@ namespace Xamarin.Android.Tools
 			get {
 				var p   = AppDomain.CurrentDomain.GetData (GetUnixConfigDirOverrideName)?.ToString ();
 				if (string.IsNullOrEmpty (p)) {
-					p   = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), ".config");
-					p   = Path.Combine (p, "xbuild");
+					p   = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), ".config", "xbuild");
 				}
 				return Path.Combine (p, "monodroid-config.xml");
 			}


### PR DESCRIPTION
When running on NET6 (VSMac installer), SpecialFolder.ApplicationData
returns nothing, resulting in a relative path being used for the config
file. In those cases, check that's the case and fallback to well known
~/.config folder, which is, from what it seems, the default.