### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Permit NDK r25

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Android.Tools
 	{
 		// When this changes, update the test: Xamarin.Android.Tools.Tests.AndroidSdkInfoTests.Ndk_MultipleNdkVersionsInSdk
 		const int MinimumCompatibleNDKMajorVersion = 16;
-		const int MaximumCompatibleNDKMajorVersion = 24;
+		const int MaximumCompatibleNDKMajorVersion = 25;
 
 		static readonly char[] SourcePropertiesKeyValueSplit = new char[] { '=' };
 

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Android.Tools.Tests
 		{
 			// Must match like-named constants in AndroidSdkBase
 			const int MinimumCompatibleNDKMajorVersion = 16;
-			const int MaximumCompatibleNDKMajorVersion = 24;
+			const int MaximumCompatibleNDKMajorVersion = 25;
 
 			CreateSdks(out string root, out string jdk, out string ndk, out string sdk);
 
@@ -94,9 +94,10 @@ namespace Xamarin.Android.Tools.Tests
 				"22.1.7171670",
 				"23.1.7779620",
 				"24.0.8215888",
-				"25.0.3735928559",  // 0xdeadbeef
+				"25.0.8775105",
+				"26.0.3735928559",   // 0xdeadbeef
 			};
-			string expectedVersion = "24.0.8215888";
+			string expectedVersion = "25.0.8775105";
 			string expectedNdkPath = Path.Combine (sdk, "ndk", expectedVersion);
 
 			try {


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/7233

Update `AndroidSdkBase.MaximumCompatibleNDKMajorVersion` to 25, so
that NDK r25 is considered as a valid version.