### PR TITLE
[ci] Use Microsoft.SourceLink.GitHub

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -18,4 +18,9 @@
       Project="$([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory))).override.targets"
       Condition=" Exists('$([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory))).override.targets') "
   />
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj
+++ b/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj
@@ -23,4 +23,8 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+  </ItemGroup>
+
 </Project>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
@@ -30,6 +30,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 
   <Target Name="GetFilesToSign" BeforeTargets="SignFiles" Condition=" '$(Configuration)' == 'Release' Or '$(Configuration)' == 'ReleaseWindows'">


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/7b4d4b8c235b22b688db13e59771722da89f37cb
Context: https://github.com/dotnet/sourcelink#githubcom-and-github-enterprise
Context: https://www.hanselman.com/blog/exploring-net-cores-sourcelink-stepping-into-the-source-code-of-nuget-packages-you-dont-own

Add a reference to the [Microsoft.SourceLink.GitHub NuGet package][0]
so that `Microsoft.Android.Build.BaseTasks.pdb` and
`Xamarin.Android.Tools.AndroidSdk.pdb` contain URLs to facilitate
debugging into their corresponding assemblies without needing to
checkout and build the `xamarin-android-tools` repo locally:

	% $HOME/.dotnet/tools/sourcelink print-urls src/Microsoft.Android.Build.BaseTasks/bin/Debug/netstandard2.0/Microsoft.Android.Build.BaseTasks.pdb
	ced7dccec3e466c9a37e0af78cccae49f3a5e50071988e03b90427ebc5ce8461 sha256 csharp …/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidAsyncTask.cs
	https://raw.githubusercontent.com/xamarin/xamarin-android-tools/01a0dde4859d126b01f9b4b479b23dd791ed6315/src/Microsoft.Android.Build.BaseTasks/AndroidAsyncTask.cs
	…

	% $HOME/.dotnet/tools/sourcelink test src/Microsoft.Android.Build.BaseTasks/bin/Debug/netstandard2.0/Microsoft.Android.Build.BaseTasks.pdb
	2 Documents with errors:
	74a35b2e0310ee692c4338531afedfe18376f44d57ebf83466e7e6a5b80e2d14 sha256 csharp /Volumes/Xamarin-Work/src/xamarin/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/obj/Debug/netstandard2.0/.NETStandard,Version=v2.0.AssemblyAttributes.cs
	https://raw.githubusercontent.com/xamarin/xamarin-android-tools/01a0dde4859d126b01f9b4b479b23dd791ed6315/src/Microsoft.Android.Build.BaseTasks/obj/Debug/netstandard2.0/.NETStandard,Version=v2.0.AssemblyAttributes.cs
	error: url failed NotFound: Not Found
	79807509946ed38a1ca2faf491c7259a0fee80fab1cc86b3e6750608b4a6d065 sha256 csharp /Volumes/Xamarin-Work/src/xamarin/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/obj/Debug/netstandard2.0/Microsoft.Android.Build.BaseTasks.AssemblyInfo.cs
	https://raw.githubusercontent.com/xamarin/xamarin-android-tools/01a0dde4859d126b01f9b4b479b23dd791ed6315/src/Microsoft.Android.Build.BaseTasks/obj/Debug/netstandard2.0/Microsoft.Android.Build.BaseTasks.AssemblyInfo.cs
	error: url failed NotFound: Not Found
	sourcelink test failed

These errors are expected, as they are generated files.

[0]: https://www.nuget.org/packages/Microsoft.SourceLink.GitHub