### PR TITLE
Update Mono.Unix and LibZipSharp

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -5,7 +5,7 @@
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
     <MSBuildPackageReferenceVersion>16.10.0</MSBuildPackageReferenceVersion>
-    <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >2.0.4</LibZipSharpVersion>
+    <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >2.0.5</LibZipSharpVersion>
     <MonoUnixVersion>7.1.0-final.1.21458.1</MonoUnixVersion>
   </PropertyGroup>
 

--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <MSBuildPackageReferenceVersion>16.10.0</MSBuildPackageReferenceVersion>
     <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >2.0.4</LibZipSharpVersion>
-    <MonoUnixVersion>7.0.0-final.1.21369.2</MonoUnixVersion>
+    <MonoUnixVersion>7.1.0-final.1.21458.1</MonoUnixVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -5,7 +5,7 @@
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
     <MSBuildPackageReferenceVersion>16.10.0</MSBuildPackageReferenceVersion>
-    <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >2.0.5</LibZipSharpVersion>
+    <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >2.0.7</LibZipSharpVersion>
     <MonoUnixVersion>7.1.0-final.1.21458.1</MonoUnixVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Update Mono.Unix to a version which correctly p/invokes into `libc` on Unix, 
instead of into `msvcrt`.

Update `LibZipSharp` to a version which includes a fix for a buffer overflow in 
zlib as well as bumps `libzip` native library version to the latest 1.9.2.

The new version of `LibZipSharp` also includes localization changes.