### PR TITLE
Fix SpecialFolder.Personal usages

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Jdks/MicrosoftDistJdkLocations.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Jdks/MicrosoftDistJdkLocations.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Android.Tools {
 			var jdks    = AppDomain.CurrentDomain.GetData ($"GetMacOSMicrosoftJdkPaths jdks override! {typeof (JdkInfo).AssemblyQualifiedName}")
 				?.ToString ();
 			if (jdks == null) {
-				var home    = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
+				var home    = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
 				jdks        = Path.Combine (home, "Library", "Developer", "Xamarin", "jdk");
 			}
 			if (!Directory.Exists (jdks))

--- a/src/Xamarin.Android.Tools.AndroidSdk/OS.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/OS.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.IO;
@@ -69,15 +69,15 @@ namespace Xamarin.Android.Tools
 		internal static string GetXamarinAndroidCacheDir ()
 		{
 			if (IsMac) {
-				var home = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
+				var home = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
 				return Path.Combine (home, "Library", "Caches", "Xamarin.Android");
 			} else if (IsWindows) {
 				var localAppData = Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData);
 				return Path.Combine (localAppData, "Xamarin.Android", "Cache");
 			} else {
-				var home = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
 				var xdgCacheHome = Environment.GetEnvironmentVariable ("XDG_CACHE_HOME");
 				if (string.IsNullOrEmpty (xdgCacheHome)) {
+					var home = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
 					xdgCacheHome = Path.Combine (home, ".cache");
 				}
 				return Path.Combine (xdgCacheHome, "Xamarin.Android");

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -111,7 +111,7 @@ namespace Xamarin.Android.Tools
 			}
 
 			// Check some hardcoded paths for good measure
-			var macSdkPath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), "Library", "Android", "sdk");
+			var macSdkPath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), "Library", "Android", "sdk");
 			yield return macSdkPath;
 		}
 


### PR DESCRIPTION
All of the usages of SpecialFolder.Personal should be using UserProfile instead. SpecialFolder Personal is the same value as MyDocuments, both of which will be changed on Unix from `~` to `~/Documents` in .NET 8. See https://github.com/dotnet/runtime/pull/68610.