### PR TITLE
Move from `netcoreapp3.1` to `net6.0`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
   <PropertyGroup>
     <BaseIntermediateOutputPath Condition=" '$(BaseIntermediateOutputPath)' == '' ">obj\</BaseIntermediateOutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' != '' And $(TargetFramework.StartsWith ('netcoreapp')) ">
+  <PropertyGroup Condition=" '$(TargetFramework)' != '' and '$(TargetFramework)' != 'net472' and '$(TargetFramework)' != 'netstandard2.0' ">
     <XATBuildingForNetCoreApp>True</XATBuildingForNetCoreApp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(XATBuildingForNetCoreApp)' == 'True' ">

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -12,7 +12,7 @@ pr:
 
 # Global variables
 variables:
-  DotNetCoreVersion: 3.1.100
+  DotNetCoreVersion: 6.0.x
 
 jobs:
 - job: build
@@ -42,22 +42,8 @@ jobs:
     inputs:
       version: $(DotNetCoreVersion)
 
-  - task: NuGetToolInstaller@0
-    displayName: 'Install NuGet'
-    inputs:
-      versionSpec: 5.x
-
-  - task: NuGetCommand@2
-    displayName: 'NuGet Restore'
-    inputs:
-      restoreSolution: Xamarin.Android.Tools.sln
-      feedsToUse: config
-      nugetConfigPath: NuGet.config
-
-  - task: MSBuild@1
+  - script: dotnet build Xamarin.Android.Tools.sln -bl:$(Build.ArtifactStagingDirectory)/build.binlog
     displayName: 'Build solution Xamarin.Android.Tools.sln'
-    inputs:
-      solution: Xamarin.Android.Tools.sln
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Tests'
@@ -73,15 +59,13 @@ jobs:
       Write-Host "##vso[task.setvariable variable=xat.nuget.version]$version"
     condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
-  - task: MSBuild@1
+  - script: dotnet pack src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj -p:Version=$(xat.nuget.version) -p:PackageOutputPath=$(Build.ArtifactStagingDirectory) -bl:$(Build.ArtifactStagingDirectory)/pack.binlog
     displayName: 'Build NuGet'
-    inputs:
-      solution: 'src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj'
-      msbuildArguments: '/t:pack /p:Version=$(xat.nuget.version) /p:OutputPath=$(Build.ArtifactStagingDirectory)'
     condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     displayName: Upload Artifacts
     inputs:
-      pathtoPublish: $(Build.ArtifactStagingDirectory)
-    condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
+      path: $(Build.ArtifactStagingDirectory)
+      artifactName: $(vmImage)
+    condition: always()

--- a/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj
+++ b/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj
@@ -3,7 +3,7 @@
   <Import Project="MSBuildReferences.projitems" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>Microsoft.Android.Build.Tasks</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SignAssembly>true</SignAssembly>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <DefineConstants>INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/Microsoft.Android.Build.BaseTasks-Tests.csproj
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/Microsoft.Android.Build.BaseTasks-Tests.csproj
@@ -4,7 +4,7 @@
     <!-- $(TargetFrameworks) is used to allow the $(TargetFramework) check in Directory.Build.props to work.
         If $(TargetFramework) is declared here instead, it will not be evaluated before Directory.Build.props
         is loaded and the wrong $(TestOutputFullPath) will be used. -->
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <RootNamespace>Microsoft.Android.Build.BaseTasks.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <OutputPath>$(TestOutputFullPath)</OutputPath>

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj
@@ -4,7 +4,7 @@
     <!-- $(TargetFrameworks) is used to allow the $(TargetFramework) check in Directory.Build.props to work.
         If $(TargetFramework) is declared here instead, it will not be evaluated before Directory.Build.props
         is loaded and the wrong $(TestOutputFullPath) will be used. -->
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>

--- a/tools/ls-jdks/ls-jdks.csproj
+++ b/tools/ls-jdks/ls-jdks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <RootNamespace>Xamarin.Android.Tools</RootNamespace>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>$(ToolOutputFullPath)</OutputPath>


### PR DESCRIPTION
I believe this is a good idea anyway, but this should assist with:

https://github.com/xamarin/xamarin-android/pull/7451

Which is hitting the error:

    error NU1102: Unable to find package Microsoft.NETCore.App.Host.osx-x64 with version (= 3.1.31)

.NET Core 3.1.31 is not released yet and is likely on a private feed.

Also pass `6.0.x` to the [`UseDotNet`][0] yaml task.

After these changes, the build failed with:

    error MSB3971: The reference assemblies for ".NETFramework,Version=v6.0" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.

Mono MSBuild probably can't build .NET 6 projects?

So I fixed various things in the build:

* Use `dotnet build` instead of MSBuild, remove NuGet commands
* No tests were running:
```
[warning] Project file(s) matching the specified pattern were not found.
```
* Fixed the `$(XATBuildingForNetCoreApp)` property
* Upload artifacts based on the pool name: `$(vmImage)`
* Use `$(PackageOutputPath)` instead of `$(OutputPath)`
* `PublishBuildArtifacts` is deprecated use `PublishPipelineArtifact`
* Save `.binlog` files as artifacts

[0]: https://learn.microsoft.com/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer