### PR TITLE
Add reference to System.Security.Cryptography.Xml

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Build.Framework"      Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core"     Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageReferenceVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
     <PackageReference Include="Xamarin.Build.AsyncTask" Version="0.4.0" GeneratePathProperty="true" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" GeneratePathProperty="true" />


### PR DESCRIPTION
Context: https://dev.azure.com/xamarin/public/_componentGovernance/115226/alert/8008980?typeId=5585428&pipelinesTrackingFilter=1

We've receieved an alert about our usage of the 6.0.0 version of
`System.Security.Cryptography.Xml`.  This package is brought in through
the [Microsoft.Build.Tasks.Core][0] package reference.  An explicit
reference to version 6.0.1 of `System.Security.Cryptography.Xml` should
bring in the fix for CVE-2022-34716.

[0]: https://www.nuget.org/packages/Microsoft.Build.Tasks.Core/17.3.2#dependencies-body-tab