### PR TITLE
Add support for Project Specific RegisterTaskObject.

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildExtensions.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildExtensions.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Android.Build.Tasks
 		/// </summary>
 		[Obsolete ("Use RegisterTaskObjectAssemblyLocal (engine, key, value, allowEarlyCollection, lifetime, flags) instead.")]
 		public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection = false) =>
-			RegisterTaskObjectAssemblyLocal (engine, key, value, lifetime, allowEarlyCollection: false, flags: RegisterTaskObjectKeyFlags.None);
+			RegisterTaskObjectAssemblyLocal (engine, key, value, lifetime, allowEarlyCollection: false, flags: RegisterTaskObjectKeyFlags.IncludeProjectFile);
 
 		/// <summary>
 		/// IBuildEngine4.RegisterTaskObject, but adds the current assembly path into the key

--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildExtensions.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildExtensions.cs
@@ -13,6 +13,12 @@ using Xamarin.Build;
 
 namespace Microsoft.Android.Build.Tasks
 {
+	[Flags]
+	public enum RegisterTaskObjectKeyFlags {
+		None = 0,
+		IncludeProjectFile = 1 << 0,
+	}
+
 	public static class MSBuildExtensions
 	{
 		public static void LogDebugMessage (this TaskLoggingHelper log, string message, params object[] messageArgs)
@@ -252,69 +258,80 @@ namespace Microsoft.Android.Build.Tasks
 		/// <summary>
 		/// IBuildEngine4.RegisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		[Obsolete ("Use RegisterTaskObjectAssemblyLocal (engine, key, value, allowEarlyCollection, lifetime, projectSpecific) instead.")]
+		[Obsolete ("Use RegisterTaskObjectAssemblyLocal (engine, key, value, allowEarlyCollection, lifetime, flags) instead.")]
 		public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection = false) =>
-			RegisterTaskObjectAssemblyLocal (engine, key, value, lifetime, allowEarlyCollection: false, projectSpecific: true);
+			RegisterTaskObjectAssemblyLocal (engine, key, value, lifetime, allowEarlyCollection: false, flags: RegisterTaskObjectKeyFlags.None);
 
 		/// <summary>
 		/// IBuildEngine4.RegisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection = false, bool projectSpecific = true) =>
-			engine.RegisterTaskObject ((AssemblyLocation, key, (projectSpecific ? engine.ProjectFileOfTaskNode : string.Empty)), value, lifetime, allowEarlyCollection);
+		public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection = false, RegisterTaskObjectKeyFlags flags = RegisterTaskObjectKeyFlags.IncludeProjectFile) =>
+			engine.RegisterTaskObject (engine.GetKey (AssemblyLocation, key, flags), value, lifetime, allowEarlyCollection);
 
 		/// <summary>
 		/// IBuildEngine4.GetRegisteredTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		[Obsolete ("Use GetRegisteredTaskObjectAssemblyLocal (engine, key, lifetime, projectSpecific) instead.")]
+		[Obsolete ("Use GetRegisteredTaskObjectAssemblyLocal (engine, key, lifetime, flags) instead.")]
 		public static object GetRegisteredTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime) =>
-			GetRegisteredTaskObjectAssemblyLocal (engine, key, lifetime, projectSpecific: true);
+			GetRegisteredTaskObjectAssemblyLocal (engine, key, lifetime, flags: RegisterTaskObjectKeyFlags.IncludeProjectFile);
 
 		/// <summary>
 		/// IBuildEngine4.GetRegisteredTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		public static object GetRegisteredTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, bool projectSpecific = true) =>
-			engine.GetRegisteredTaskObject ((AssemblyLocation, key, (projectSpecific ? engine.ProjectFileOfTaskNode : string.Empty)), lifetime);
+		public static object GetRegisteredTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, RegisterTaskObjectKeyFlags flags = RegisterTaskObjectKeyFlags.IncludeProjectFile) =>
+			engine.GetRegisteredTaskObject (engine.GetKey (AssemblyLocation, key, flags), lifetime);
 
 
 		/// <summary>
 		/// Generic version of IBuildEngine4.GetRegisteredTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		[Obsolete ("Use GetRegisteredTaskObjectAssemblyLocal<T> (engine, key, lifetime, projectSpecific) instead.")]
+		[Obsolete ("Use GetRegisteredTaskObjectAssemblyLocal<T> (engine, key, lifetime, flags) instead.")]
 		public static T GetRegisteredTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime)
-			where T : class => GetRegisteredTaskObjectAssemblyLocal<T> (engine, key, lifetime, projectSpecific: true);
+			where T : class => GetRegisteredTaskObjectAssemblyLocal<T> (engine, key, lifetime, flags: RegisterTaskObjectKeyFlags.IncludeProjectFile);
 
 		/// <summary>
 		/// Generic version of IBuildEngine4.GetRegisteredTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		public static T GetRegisteredTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, bool projectSpecific = true)
+		public static T GetRegisteredTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, RegisterTaskObjectKeyFlags flags = RegisterTaskObjectKeyFlags.IncludeProjectFile)
 			where T : class =>
-			engine.GetRegisteredTaskObject ((AssemblyLocation, key, (projectSpecific ? engine.ProjectFileOfTaskNode : string.Empty)), lifetime) as T;
+			engine.GetRegisteredTaskObject (engine.GetKey (AssemblyLocation, key, flags), lifetime) as T;
 
 		/// <summary>
 		/// IBuildEngine4.UnregisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		[Obsolete ("Use UnregisterTaskObjectAssemblyLocal (engine, key, lifetime, projectSpecific) instead.")]
+		[Obsolete ("Use UnregisterTaskObjectAssemblyLocal (engine, key, lifetime, flags) instead.")]
 		public static object UnregisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime) =>
-			UnregisterTaskObjectAssemblyLocal (engine, key, lifetime, projectSpecific: true);
+			UnregisterTaskObjectAssemblyLocal (engine, key, lifetime, flags: RegisterTaskObjectKeyFlags.IncludeProjectFile);
 
 		/// <summary>
 		/// IBuildEngine4.UnregisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		public static object UnregisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, bool projectSpecific = true) =>
-			engine.UnregisterTaskObject ((AssemblyLocation, key, (projectSpecific ? engine.ProjectFileOfTaskNode : string.Empty)), lifetime);
+		public static object UnregisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, RegisterTaskObjectKeyFlags flags = RegisterTaskObjectKeyFlags.IncludeProjectFile) =>
+			engine.UnregisterTaskObject (engine.GetKey (AssemblyLocation, key, flags), lifetime);
 
 		/// <summary>
 		/// Generic version of IBuildEngine4.UnregisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		[Obsolete ("Use UnregisterTaskObjectAssemblyLocal<T> (engine, key, lifetime, projectSpecific) instead.")]
+		[Obsolete ("Use UnregisterTaskObjectAssemblyLocal<T> (engine, key, lifetime, flags) instead.")]
 		public static T UnregisterTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime)
-			where T : class => UnregisterTaskObjectAssemblyLocal<T> (engine, key, lifetime, projectSpecific: true);
+			where T : class => UnregisterTaskObjectAssemblyLocal<T> (engine, key, lifetime, flags: RegisterTaskObjectKeyFlags.IncludeProjectFile);
 
 		/// <summary>
 		/// Generic version of IBuildEngine4.UnregisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		public static T UnregisterTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, bool projectSpecific = true)
+		public static T UnregisterTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, RegisterTaskObjectKeyFlags flags = RegisterTaskObjectKeyFlags.IncludeProjectFile)
 			where T : class =>
-			engine.UnregisterTaskObject ((AssemblyLocation, key, (projectSpecific ? engine.ProjectFileOfTaskNode : string.Empty)), lifetime) as T;
+			engine.UnregisterTaskObject (engine.GetKey (AssemblyLocation, key, flags), lifetime) as T;
+
+		/// <summary>
+		/// Method to calculate the key for the RegisterTaskObject. This is based on the
+		/// RegisterTaskObjectKeyFlags which are passed.
+		/// </summary>
+		static object GetKey (this IBuildEngine4 engine, string location, object key, RegisterTaskObjectKeyFlags flags)
+		{
+			return ((flags & RegisterTaskObjectKeyFlags.IncludeProjectFile) != 0)
+				? (location, key, engine.ProjectFileOfTaskNode)
+				: (location, key, string.Empty);
+		}
 	}
 }

--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildExtensions.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildExtensions.cs
@@ -252,34 +252,34 @@ namespace Microsoft.Android.Build.Tasks
 		/// <summary>
 		/// IBuildEngine4.RegisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection = false) =>
-			engine.RegisterTaskObject ((AssemblyLocation, key), value, lifetime, allowEarlyCollection);
+		public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection = false, bool projectSpecific = true) =>
+			engine.RegisterTaskObject ((AssemblyLocation, key, (projectSpecific ? engine.ProjectFileOfTaskNode : string.Empty)), value, lifetime, allowEarlyCollection);
 
 		/// <summary>
 		/// IBuildEngine4.GetRegisteredTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		public static object GetRegisteredTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime) =>
-			engine.GetRegisteredTaskObject ((AssemblyLocation, key), lifetime);
+		public static object GetRegisteredTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, bool projectSpecific = true) =>
+			engine.GetRegisteredTaskObject ((AssemblyLocation, key, (projectSpecific ? engine.ProjectFileOfTaskNode : string.Empty)), lifetime);
 
 		/// <summary>
 		/// Generic version of IBuildEngine4.GetRegisteredTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		public static T GetRegisteredTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime)
+		public static T GetRegisteredTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, bool projectSpecific = true)
 			where T : class =>
-			engine.GetRegisteredTaskObject ((AssemblyLocation, key), lifetime) as T;
+			engine.GetRegisteredTaskObject ((AssemblyLocation, key, (projectSpecific ? engine.ProjectFileOfTaskNode : string.Empty)), lifetime) as T;
 
 
 		/// <summary>
 		/// IBuildEngine4.UnregisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		public static object UnregisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime) =>
-			engine.UnregisterTaskObject ((AssemblyLocation, key), lifetime);
+		public static object UnregisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, bool projectSpecific = true) =>
+			engine.UnregisterTaskObject ((AssemblyLocation, key, (projectSpecific ? engine.ProjectFileOfTaskNode : string.Empty)), lifetime);
 
 		/// <summary>
 		/// Generic version of IBuildEngine4.UnregisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		public static T UnregisterTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime)
+		public static T UnregisterTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, bool projectSpecific = true)
 			where T : class =>
-			engine.UnregisterTaskObject ((AssemblyLocation, key), lifetime) as T;
+			engine.UnregisterTaskObject ((AssemblyLocation, key, (projectSpecific ? engine.ProjectFileOfTaskNode : string.Empty)), lifetime) as T;
 	}
 }

--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildExtensions.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildExtensions.cs
@@ -252,14 +252,36 @@ namespace Microsoft.Android.Build.Tasks
 		/// <summary>
 		/// IBuildEngine4.RegisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
+		[Obsolete ("Use RegisterTaskObjectAssemblyLocal (engine, key, value, allowEarlyCollection, lifetime, projectSpecific) instead.")]
+		public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection = false) =>
+			RegisterTaskObjectAssemblyLocal (engine, key, value, lifetime, allowEarlyCollection: false, projectSpecific: true);
+
+		/// <summary>
+		/// IBuildEngine4.RegisterTaskObject, but adds the current assembly path into the key
+		/// </summary>
 		public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection = false, bool projectSpecific = true) =>
 			engine.RegisterTaskObject ((AssemblyLocation, key, (projectSpecific ? engine.ProjectFileOfTaskNode : string.Empty)), value, lifetime, allowEarlyCollection);
 
 		/// <summary>
 		/// IBuildEngine4.GetRegisteredTaskObject, but adds the current assembly path into the key
 		/// </summary>
+		[Obsolete ("Use GetRegisteredTaskObjectAssemblyLocal (engine, key, lifetime, projectSpecific) instead.")]
+		public static object GetRegisteredTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime) =>
+			GetRegisteredTaskObjectAssemblyLocal (engine, key, lifetime, projectSpecific: true);
+
+		/// <summary>
+		/// IBuildEngine4.GetRegisteredTaskObject, but adds the current assembly path into the key
+		/// </summary>
 		public static object GetRegisteredTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, bool projectSpecific = true) =>
 			engine.GetRegisteredTaskObject ((AssemblyLocation, key, (projectSpecific ? engine.ProjectFileOfTaskNode : string.Empty)), lifetime);
+
+
+		/// <summary>
+		/// Generic version of IBuildEngine4.GetRegisteredTaskObject, but adds the current assembly path into the key
+		/// </summary>
+		[Obsolete ("Use GetRegisteredTaskObjectAssemblyLocal<T> (engine, key, lifetime, projectSpecific) instead.")]
+		public static T GetRegisteredTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime)
+			where T : class => GetRegisteredTaskObjectAssemblyLocal<T> (engine, key, lifetime, projectSpecific: true);
 
 		/// <summary>
 		/// Generic version of IBuildEngine4.GetRegisteredTaskObject, but adds the current assembly path into the key
@@ -268,12 +290,25 @@ namespace Microsoft.Android.Build.Tasks
 			where T : class =>
 			engine.GetRegisteredTaskObject ((AssemblyLocation, key, (projectSpecific ? engine.ProjectFileOfTaskNode : string.Empty)), lifetime) as T;
 
+		/// <summary>
+		/// IBuildEngine4.UnregisterTaskObject, but adds the current assembly path into the key
+		/// </summary>
+		[Obsolete ("Use UnregisterTaskObjectAssemblyLocal (engine, key, lifetime, projectSpecific) instead.")]
+		public static object UnregisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime) =>
+			UnregisterTaskObjectAssemblyLocal (engine, key, lifetime, projectSpecific: true);
 
 		/// <summary>
 		/// IBuildEngine4.UnregisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
 		public static object UnregisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, bool projectSpecific = true) =>
 			engine.UnregisterTaskObject ((AssemblyLocation, key, (projectSpecific ? engine.ProjectFileOfTaskNode : string.Empty)), lifetime);
+
+		/// <summary>
+		/// Generic version of IBuildEngine4.UnregisterTaskObject, but adds the current assembly path into the key
+		/// </summary>
+		[Obsolete ("Use UnregisterTaskObjectAssemblyLocal<T> (engine, key, lifetime, projectSpecific) instead.")]
+		public static T UnregisterTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime)
+			where T : class => UnregisterTaskObjectAssemblyLocal<T> (engine, key, lifetime, projectSpecific: true);
 
 		/// <summary>
 		/// Generic version of IBuildEngine4.UnregisterTaskObject, but adds the current assembly path into the key


### PR DESCRIPTION
Context https://github.com/dotnet/maui/issues/11605

If a solution has more than one Android "App" project there is the potential that objects registered using the `RegisterTaskObject` will be reused between the projects.

In most cases this is NOT the desired outcome. There are a few instances where it is safe to share the registered objects between projects. But for most of the time it is specific to that project that is being built. Historically we have probably got away with this because "most" users only have one project.....

So lets update the MSBuildExtensions extension methods to include an additional flags parameter. This will control if the registered object will be "project" scope or "solution" scope. Yes those are terms I just made up :D.

We do this by including the `engine.ProjectFileOfTaskNode` as part of the key.

Initially the thought was that everything would be "solution" scope if the `LifeTime` was set to `AppDomain`. However there are instances if "solution" scope usage for non `AppDomain` entires. A good example is the `aapt2` daemon which has a `LifeTime` of `Build` but can be "solution" scope. This is why we add a new parameter to control this.

The default for this new parameter is `RegisterTaskObjectKeyFlags.IncludeProjectFile`, this is to reduce the number of changes. We assume most items will be "project" scope.