### PR TITLE
Fix CS0121 ambiguity errors.

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildExtensions.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildExtensions.cs
@@ -258,68 +258,69 @@ namespace Microsoft.Android.Build.Tasks
 		/// <summary>
 		/// IBuildEngine4.RegisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		[Obsolete ("Use RegisterTaskObjectAssemblyLocal (engine, key, value, allowEarlyCollection, lifetime, flags) instead.")]
 		public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection = false) =>
 			RegisterTaskObjectAssemblyLocal (engine, key, value, lifetime, allowEarlyCollection: false, flags: RegisterTaskObjectKeyFlags.IncludeProjectFile);
 
 		/// <summary>
 		/// IBuildEngine4.RegisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection = false, RegisterTaskObjectKeyFlags flags = RegisterTaskObjectKeyFlags.IncludeProjectFile) =>
+		public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, RegisterTaskObjectKeyFlags flags) =>
+			engine.RegisterTaskObject (engine.GetKey (AssemblyLocation, key, flags), value, lifetime, allowEarlyCollection: false);
+
+		/// <summary>
+		/// IBuildEngine4.RegisterTaskObject, but adds the current assembly path into the key
+		/// </summary>
+		public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection, RegisterTaskObjectKeyFlags flags) =>
 			engine.RegisterTaskObject (engine.GetKey (AssemblyLocation, key, flags), value, lifetime, allowEarlyCollection);
 
 		/// <summary>
 		/// IBuildEngine4.GetRegisteredTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		[Obsolete ("Use GetRegisteredTaskObjectAssemblyLocal (engine, key, lifetime, flags) instead.")]
 		public static object GetRegisteredTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime) =>
 			GetRegisteredTaskObjectAssemblyLocal (engine, key, lifetime, flags: RegisterTaskObjectKeyFlags.IncludeProjectFile);
 
 		/// <summary>
 		/// IBuildEngine4.GetRegisteredTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		public static object GetRegisteredTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, RegisterTaskObjectKeyFlags flags = RegisterTaskObjectKeyFlags.IncludeProjectFile) =>
+		public static object GetRegisteredTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, RegisterTaskObjectKeyFlags flags) =>
 			engine.GetRegisteredTaskObject (engine.GetKey (AssemblyLocation, key, flags), lifetime);
 
 
 		/// <summary>
 		/// Generic version of IBuildEngine4.GetRegisteredTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		[Obsolete ("Use GetRegisteredTaskObjectAssemblyLocal<T> (engine, key, lifetime, flags) instead.")]
 		public static T GetRegisteredTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime)
 			where T : class => GetRegisteredTaskObjectAssemblyLocal<T> (engine, key, lifetime, flags: RegisterTaskObjectKeyFlags.IncludeProjectFile);
 
 		/// <summary>
 		/// Generic version of IBuildEngine4.GetRegisteredTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		public static T GetRegisteredTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, RegisterTaskObjectKeyFlags flags = RegisterTaskObjectKeyFlags.IncludeProjectFile)
+		public static T GetRegisteredTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, RegisterTaskObjectKeyFlags flags)
 			where T : class =>
 			engine.GetRegisteredTaskObject (engine.GetKey (AssemblyLocation, key, flags), lifetime) as T;
 
 		/// <summary>
 		/// IBuildEngine4.UnregisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		[Obsolete ("Use UnregisterTaskObjectAssemblyLocal (engine, key, lifetime, flags) instead.")]
 		public static object UnregisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime) =>
 			UnregisterTaskObjectAssemblyLocal (engine, key, lifetime, flags: RegisterTaskObjectKeyFlags.IncludeProjectFile);
 
 		/// <summary>
 		/// IBuildEngine4.UnregisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		public static object UnregisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, RegisterTaskObjectKeyFlags flags = RegisterTaskObjectKeyFlags.IncludeProjectFile) =>
+		public static object UnregisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, RegisterTaskObjectKeyFlags flags) =>
 			engine.UnregisterTaskObject (engine.GetKey (AssemblyLocation, key, flags), lifetime);
 
 		/// <summary>
 		/// Generic version of IBuildEngine4.UnregisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		[Obsolete ("Use UnregisterTaskObjectAssemblyLocal<T> (engine, key, lifetime, flags) instead.")]
 		public static T UnregisterTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime)
 			where T : class => UnregisterTaskObjectAssemblyLocal<T> (engine, key, lifetime, flags: RegisterTaskObjectKeyFlags.IncludeProjectFile);
 
 		/// <summary>
 		/// Generic version of IBuildEngine4.UnregisterTaskObject, but adds the current assembly path into the key
 		/// </summary>
-		public static T UnregisterTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, RegisterTaskObjectKeyFlags flags = RegisterTaskObjectKeyFlags.IncludeProjectFile)
+		public static T UnregisterTaskObjectAssemblyLocal<T> (this IBuildEngine4 engine, object key, RegisteredTaskObjectLifetime lifetime, RegisterTaskObjectKeyFlags flags)
 			where T : class =>
 			engine.UnregisterTaskObject (engine.GetKey (AssemblyLocation, key, flags), lifetime) as T;
 


### PR DESCRIPTION
Context: 76c076fc4876c27e21ea2540e40a27742e7891f1

When attempting to update xamarin/xamarin-android to use 4ea2d5ad, lots of CS0121 errors appeared:

	…/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs(80,18): error CS0121: The call is ambiguous between the following methods or properties: 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool)' and 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool, RegisterTaskObjectKeyFlags)'
	…/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs(87,18): error CS0121: The call is ambiguous between the following methods or properties: 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool)' and 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool, RegisterTaskObjectKeyFlags)'
	…/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs(94,18): error CS0121: The call is ambiguous between the following methods or properties: 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool)' and 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool, RegisterTaskObjectKeyFlags)'
	…/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs(98,17): error CS0121: The call is ambiguous between the following methods or properties: 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool)' and 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool, RegisterTaskObjectKeyFlags)'
	…/src/Xamarin.Android.Build.Tasks/Tasks/GenerateCompressedAssembliesNativeSourceFiles.cs(72,17): error CS0121: The call is ambiguous between the following methods or properties: 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool)' and 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool, RegisterTaskObjectKeyFlags)'
	…/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJniRemappingNativeCode.cs(95,17): error CS0121: The call is ambiguous between the following methods or properties: 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool)' and 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool, RegisterTaskObjectKeyFlags)'
	…/src/Xamarin.Android.Build.Tasks/Tasks/WriteLockFile.cs(35,19): error CS0121: The call is ambiguous between the following methods or properties: 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool)' and 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool, RegisterTaskObjectKeyFlags)'
	…/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs(524,18): error CS0121: The call is ambiguous between the following methods or properties: 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool)' and 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool, RegisterTaskObjectKeyFlags)'
	…/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs(578,17): error CS0121: The call is ambiguous between the following methods or properties: 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool)' and 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool, RegisterTaskObjectKeyFlags)'
	…/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs(393,11): error CS0121: The call is ambiguous between the following methods or properties: 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool)' and 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool, RegisterTaskObjectKeyFlags)'
	…/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs(440,11): error CS0121: The call is ambiguous between the following methods or properties: 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool)' and 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool, RegisterTaskObjectKeyFlags)'
	…/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs(501,11): error CS0121: The call is ambiguous between the following methods or properties: 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool)' and 'MSBuildExtensions.RegisterTaskObjectAssemblyLocal(IBuildEngine4, object, object, RegisteredTaskObjectLifetime, bool, RegisterTaskObjectKeyFlags)'

This is because when given e.g.:

	partial class MSBuildExtensions {
	    public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection = false);
	    public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection = false, RegisterTaskObjectKeyFlags flags = RegisterTaskObjectKeyFlags.IncludeProjectFile);
	}

then this expression:

	engine.RegisterTaskObjectAssemblyLocal(key, value, lifetime);

has two possible matches, due to the default parameters.

Fix this by *removing* the default `RegisteredTaskObjectLifetime` parameter value, and (when appropriate) adding an overload:

	partial class MSBuildExtensions {
	    public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection = false);
	    public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, RegisterTaskObjectKeyFlags flagse);
	    public static void RegisterTaskObjectAssemblyLocal (this IBuildEngine4 engine, object key, object value, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection, RegisterTaskObjectKeyFlags flags);
	}

Additionally, *remove* the `[Obsolete]` attributes.  With `RegisterTaskObjectKeyFlags.IncludeProjectFile` part of the default behavior, there is no need to mark the original methods `[Obsolete]`. This allows existing code such as:

	var value = BuildEngine4.GetRegisteredTaskObjectAssemblyLocal (key, Lifetime);

to remain unchanged.