### PR TITLE
Bump LibZipSharp version

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -5,7 +5,7 @@
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
     <MSBuildPackageReferenceVersion>17.3.2</MSBuildPackageReferenceVersion>
-    <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >2.0.7</LibZipSharpVersion>
+    <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >2.1.0</LibZipSharpVersion>
     <MonoUnixVersion>7.1.0-final.1.21458.1</MonoUnixVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Context: https://github.com/xamarin/LibZipSharp/pull/125

The new LibZipSharp version potentially fixes the issue we see 
from time to time on Ci, when an attempt to process a zip 
archive (APK, in our case) ends with an error when trying to 
open the archive.