### PR TITLE
[ci] Add weekly schedule for OneLocBuild

### DIFF
--- a/Localize/onelocbuild.yaml
+++ b/Localize/onelocbuild.yaml
@@ -12,6 +12,12 @@ schedules:
   branches:
     include:
     - main
+- cron: "0 6 * * Sunday"
+  displayName: Run weekly on Sunday at 6:00 UTC
+  branches:
+    include:
+    - main
+  always: true
 
 jobs:
 - job: OneLocBuild


### PR DESCRIPTION
We've been notified that the localization system will create work items
for loc pipelines that do not have regular builds.  To address this, we
can add a weekly build that will always run the OneLocBuild task even if
sources haven't changed.