### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Check all <intent-filter/>s

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidAppManifest.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidAppManifest.cs
@@ -323,8 +323,7 @@ namespace Xamarin.Android.Tools
 		IEnumerable<XElement> GetLaunchableActivities ()
 		{
 			foreach (var activity in application.Elements ("activity")) {
-				var filter = activity.Element ("intent-filter");
-				if (filter != null) {
+				foreach (var filter in activity.Elements ("intent-filter")) {
 					foreach (var category in filter.Elements ("category"))
 						if (category != null && (string?)category.Attribute (aName) == "android.intent.category.LAUNCHER")
 							yield return activity;

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidAppManifestTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidAppManifestTests.cs
@@ -46,6 +46,16 @@ namespace Xamarin.Android.Tools.Tests
 		}
 
 		[Test]
+		public void GetLaunchableActivityNames ()
+		{
+			var versions	= new AndroidVersions (Array.Empty<AndroidVersion>());
+			var manifest    = AndroidAppManifest.Load (GetTestAppManifest (), versions);
+			var launchers   = manifest.GetLaunchableActivityNames ().ToList ();
+			Assert.AreEqual (1,                             launchers.Count);
+			Assert.AreEqual (".HasMultipleIntentFilters",	launchers [0]);
+		}
+
+		[Test]
 		public void SetNewPermissions ()
 		{
 			var versions = new AndroidVersions (new AndroidVersion [0]);

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Resources/manifest-simplewidget.xml
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Resources/manifest-simplewidget.xml
@@ -22,6 +22,17 @@
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
     </activity>
+    <activity android:name=".HasMultipleIntentFilters" android:label="launcher?">
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
   </application>
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.READ_CONTACTS" />


### PR DESCRIPTION
Context: https://developercommunity.visualstudio.com/t/Cannot-deploy-to-Android-emulators-and-d/10428163
Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1863835
Context: https://developer.android.com/guide/components/intents-filters

The [`<activity/>`][0] and related elements within `AndroidManifest.xml` can have multiple [`<intent-filter/>`][1]s specified.  Android does not require that `<intent-filter/>`s be listed in any particular order.

However, Visual Studio *does* care about the order (?!)!

	[Activity(Exported = true, Label = "@string/app_name", MainLauncher = true)]
	[IntentFilter(
	    new[] { Android.Content.Intent.ActionView },
	    Categories = new[] {
	        Android.Content.Intent.CategoryDefault,
	        Android.Content.Intent.CategoryBrowsable,
	    }
	)]
	[IntentFilter(
	    new[] { Android.Content.Intent.ActionMain },
	    Categories = new[] {
	        Android.Content.Intent.CategoryLauncher,
	        Android.Content.Intent.CategoryLeanbackLauncher,
	    }
	)]
	public partial class MainActivity : Activity {}

If the `[IntentFilter]` with `Android.Content.Intent.ActionMain` is *not* first, then Visual Studio does not consider this Activity to be a launchable activity.

The reason for this is, in part, because
`AndroidAppManifest.GetLaunchableActivities()` only looked at the *first* `<intent-filter/>` to see if it had the category of `android.intent.category.LAUNCHER`.

Update `AndroidAppManifest.GetLaunchableActivities()` so that *all* `<intent-filter/>` elements are checked for the
`.LAUNCHER` category.

**Workaround**: Specify the `[IntentFilter]` with `Intent.ActionMain` first:

	[Activity(Exported = true, Label = "@string/app_name", MainLauncher = true)]
	[IntentFilter(
	    new[] { Android.Content.Intent.ActionMain },
	    Categories = new[] {
	        Android.Content.Intent.CategoryLauncher,
	        Android.Content.Intent.CategoryLeanbackLauncher,
	    }
	)]
	[IntentFilter(
	    new[] { Android.Content.Intent.ActionView },
	    Categories = new[] {
	        Android.Content.Intent.CategoryDefault,
	        Android.Content.Intent.CategoryBrowsable,
	    }
	)]
	public partial class MainActivity : Activity {}

Note: this change, in and of itself, may not be sufficient to fix Visual Studio, as there are a few other places that have the same "only check the first `<intent-filter/>`" bug.

[0]: https://developer.android.com/guide/topics/manifest/activity-element
[1]: https://developer.android.com/guide/topics/manifest/intent-filter-element