### PR TITLE
Update OpenJDK location for OpenJDK17 on windows

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Jdks/MicrosoftOpenJdkLocations.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Jdks/MicrosoftOpenJdkLocations.cs
@@ -12,6 +12,7 @@ namespace Xamarin.Android.Tools {
 		internal static IEnumerable<JdkInfo> GetMicrosoftOpenJdks (Action<TraceLevel, string> logger)
 		{
 			return GetMacOSSystemJdks ("microsoft-*.jdk", logger)
+				.Concat (GetWindowsFileSystemJdks (Path.Combine ("Android", "openjdk", "jdk-*"), logger))
 				.Concat (GetWindowsFileSystemJdks (Path.Combine ("Microsoft", "jdk-*"), logger))
 				.Concat (GetWindowsRegistryJdks (logger, @"SOFTWARE\Microsoft\JDK", "*", @"hotspot\MSI", "Path"))
 				.OrderByDescending (jdk => jdk, JdkInfoVersionComparer.Default);


### PR DESCRIPTION
- VS installer start using a zip payload to install the OpenJDK on %programFiles%/Android/openjdk/jdk-*