### PR TITLE
Bumps platforms-tools and cmdline-tools for d17.9

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
@@ -11,7 +11,7 @@
     -->
     <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">32.0.0</AndroidSdkBuildToolsVersion>
     <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">7.0</AndroidCommandLineToolsVersion>
-    <AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">34.0.1</AndroidSdkPlatformToolsVersion>
+    <AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">34.0.5</AndroidSdkPlatformToolsVersion>
     <AndroidSdkEmulatorVersion Condition="'$(AndroidSdkEmulatorVersion)' == ''"></AndroidSdkEmulatorVersion>
     <AndroidSdkPlatformVersion Condition="'$(AndroidSdkPlatformVersion)' == ''">android-34</AndroidSdkPlatformVersion>
     <AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">24.0.8215888</AndroidNdkVersion>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
@@ -10,7 +10,7 @@
     along with any other repo which references androidtools.
     -->
     <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">32.0.0</AndroidSdkBuildToolsVersion>
-    <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">7.0</AndroidCommandLineToolsVersion>
+    <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">11.0</AndroidCommandLineToolsVersion>
     <AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">34.0.5</AndroidSdkPlatformToolsVersion>
     <AndroidSdkEmulatorVersion Condition="'$(AndroidSdkEmulatorVersion)' == ''"></AndroidSdkEmulatorVersion>
     <AndroidSdkPlatformVersion Condition="'$(AndroidSdkPlatformVersion)' == ''">android-34</AndroidSdkPlatformVersion>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
@@ -14,7 +14,7 @@
     <AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">34.0.5</AndroidSdkPlatformToolsVersion>
     <AndroidSdkEmulatorVersion Condition="'$(AndroidSdkEmulatorVersion)' == ''"></AndroidSdkEmulatorVersion>
     <AndroidSdkPlatformVersion Condition="'$(AndroidSdkPlatformVersion)' == ''">android-34</AndroidSdkPlatformVersion>
-    <AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">24.0.8215888</AndroidNdkVersion>
+    <AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">26.1.10909125</AndroidNdkVersion>
 
     <!-- obsolete; should consider removing eventually -->
     <AndroidSdkToolsVersion Condition="'$(AndroidSdkToolsVersion)' == ''">26.1.1</AndroidSdkToolsVersion>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
@@ -9,7 +9,7 @@
     If this file is changed the submodule for androidtools should be updated,
     along with any other repo which references androidtools.
     -->
-    <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">32.0.0</AndroidSdkBuildToolsVersion>
+    <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">34.0.0</AndroidSdkBuildToolsVersion>
     <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">11.0</AndroidCommandLineToolsVersion>
     <AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">34.0.5</AndroidSdkPlatformToolsVersion>
     <AndroidSdkEmulatorVersion Condition="'$(AndroidSdkEmulatorVersion)' == ''"></AndroidSdkEmulatorVersion>


### PR DESCRIPTION
- Bump platforms-tool to version 34.0.5
- Bump cmdline-tools to version 11.0
- Bump build-tool to version 34.0.0
- Bump NDK to version 26.1.10909125

- Ensures be in sync with Xamarin Android Feed for d17.9
- Enables the creation of pixel 6/7 on VisualStudio Device Manager tool