### PR TITLE
[MSBuildReferences.projitems] Allow consumers to opt into `Microsoft.Build` package.

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build"                Version="$(MSBuildPackageReferenceVersion)" />
+    <PackageReference Include="Microsoft.Build"                Version="$(MSBuildPackageReferenceVersion)" Condition=" '$(_IncludeMicrosoftBuildPackage)' == 'true' " />
     <PackageReference Include="Microsoft.Build.Framework"      Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core"     Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageReferenceVersion)" />


### PR DESCRIPTION
Projects that import `MSBuildReferences.projitems` receive a `<PackageReference>` to `Microsoft.Build`.  However, many consumers are `netstandard2.0` and this package does not have that framework, resulting in the following warnings:

```
Warning NU1701 Package 'Microsoft.Build 17.3.2' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework '.NETStandard,Version=v2.0'. This package may not be fully compatible with your project.
Warning NU1701 Package 'Microsoft.IO.Redist 6.0.0' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework '.NETStandard,Version=v2.0'. This package may not be fully compatible with your project.	
```

Most consumers do not actually need this package, so we can make it optional to prevent the warnings and extra dependencies in those projects.

Initially, this is done by making the package reference opt-in, with:
```xml
<_IncludeMicrosoftBuildPackage>true</_IncludeMicrosoftBuildPackage>
```

However this will be a "breaking" change to an unknown amount of consumers.  If we would like to avoid this, we can invert the change to allow projects to "opt-out" instead.