### PR TITLE
[build] update $(MSBuildPackageReferenceVersion) to 17.6.3

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -4,7 +4,7 @@
 <Project>
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
-    <MSBuildPackageReferenceVersion>17.3.2</MSBuildPackageReferenceVersion>
+    <MSBuildPackageReferenceVersion>17.6.3</MSBuildPackageReferenceVersion>
     <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >3.0.0</LibZipSharpVersion>
     <MonoUnixVersion>7.1.0-final.1.21458.1</MonoUnixVersion>
   </PropertyGroup>

--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Build.Framework"      Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core"     Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageReferenceVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="7.0.1" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
     <PackageReference Include="Xamarin.Build.AsyncTask" Version="0.4.0" GeneratePathProperty="true" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" GeneratePathProperty="true" />

--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -4,7 +4,7 @@
 <Project>
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
-    <MSBuildPackageReferenceVersion>17.6.3</MSBuildPackageReferenceVersion>
+    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.8.3</MSBuildPackageReferenceVersion>
     <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >3.0.0</LibZipSharpVersion>
     <MonoUnixVersion>7.1.0-final.1.21458.1</MonoUnixVersion>
   </PropertyGroup>

--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -5,6 +5,7 @@
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
     <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.8.3</MSBuildPackageReferenceVersion>
+    <SystemSecurityCryptographyXmlVersion Condition=" '$(SystemSecurityCryptographyXmlVersion)' == '' ">7.0.1</SystemSecurityCryptographyXmlVersion>
     <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >3.0.0</LibZipSharpVersion>
     <MonoUnixVersion>7.1.0-final.1.21458.1</MonoUnixVersion>
   </PropertyGroup>
@@ -14,7 +15,7 @@
     <PackageReference Include="Microsoft.Build.Framework"      Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core"     Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageReferenceVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="7.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
     <PackageReference Include="Xamarin.Build.AsyncTask" Version="0.4.0" GeneratePathProperty="true" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" GeneratePathProperty="true" />


### PR DESCRIPTION
In xamarin/xamarin-android, we need to update `MSBuild.StructuredLogger` to be able to move to .NET 9. The `.binlog` file format changed in .NET 9.

It currently fails with:

    (Restore target) ->
    tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj : error NU1605: Warning As Error: Detected package downgrade: Microsoft.Build.Framework from 17.5.0 to 17.3.2. Reference the package directly from the project to select a different version.
    tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj : error NU1605:  MSBuildDeviceIntegration -> MSBuild.StructuredLogger 2.2.100 -> Microsoft.Build.Framework (>= 17.5.0)
    tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj : error NU1605:  MSBuildDeviceIntegration -> Microsoft.Build.Framework (>= 17.3.2)
    tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj : error NU1605: Warning As Error: Detected package downgrade: Microsoft.Build.Utilities.Core from 17.5.0 to 17.3.2. Reference the package directly from the project to select a different version.
    tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj : error NU1605:  MSBuildDeviceIntegration -> MSBuild.StructuredLogger 2.2.100 -> Microsoft.Build.Utilities.Core (>= 17.5.0)
    tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj : error NU1605:  MSBuildDeviceIntegration -> Microsoft.Build.Utilities.Core (>= 17.3.2)

Since a lot of other repos depend on xamarin-android-tools, I feel we should move to a new version, but not actually the newest. If we moved to 17.8.3, we could potentially break other repos.

VS 2022 17.6 is an LTS release that feels "safe", is new enough to solve the issue, and hopefully won't break anyone?