### PR TITLE
[build] update $(MSBuildPackageReferenceVersion) to 17.6.3

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -4,7 +4,7 @@
 <Project>
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
-    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.8.3</MSBuildPackageReferenceVersion>
+    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.6.3</MSBuildPackageReferenceVersion>
     <SystemSecurityCryptographyXmlVersion Condition=" '$(SystemSecurityCryptographyXmlVersion)' == '' ">7.0.1</SystemSecurityCryptographyXmlVersion>
     <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >3.0.0</LibZipSharpVersion>
     <MonoUnixVersion>7.1.0-final.1.21458.1</MonoUnixVersion>


### PR DESCRIPTION
In https://github.com/xamarin/xamarin-android-tools/pull/221, we updated `$(MSBuildPackageReferenceVersion)` to `17.8.3`.  This caused some issues for XA, potentially because `17.8.3` changes its TF from `net7.0` to `net8.0`.

Using the new conditional to overcome this is cumbersome, as we use `Microsoft.Android.Build.BaseTasks.csproj` from the XAT repo, and it does not inherit the value from XA's `Directory.Build.props`.  We would need to introduce an `external/xamarin-android-tools.override.props`, etc.

For now, let's revert to `17.6.3`.  Once XA has been [updated to .NET 9](https://github.com/xamarin/xamarin-android/pull/8366) we could probably update to `17.8.3` if desired.

Green XA test bump: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8749478&view=results