### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Sync with .NET 8 versions

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
@@ -9,9 +9,9 @@
     If this file is changed the submodule for androidtools should be updated,
     along with any other repo which references androidtools.
     -->
-    <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">32.0.0</AndroidSdkBuildToolsVersion>
-    <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">7.0</AndroidCommandLineToolsVersion>
-    <AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">34.0.1</AndroidSdkPlatformToolsVersion>
+    <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">34.0.0</AndroidSdkBuildToolsVersion>
+    <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">11.0</AndroidCommandLineToolsVersion>
+    <AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">34.0.5</AndroidSdkPlatformToolsVersion>
     <AndroidSdkEmulatorVersion Condition="'$(AndroidSdkEmulatorVersion)' == ''"></AndroidSdkEmulatorVersion>
     <AndroidSdkPlatformVersion Condition="'$(AndroidSdkPlatformVersion)' == ''">android-33</AndroidSdkPlatformVersion>
     <AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">24.0.8215888</AndroidNdkVersion>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
@@ -9,7 +9,7 @@
     If this file is changed the submodule for androidtools should be updated,
     along with any other repo which references androidtools.
     -->
-    <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">34.0.0</AndroidSdkBuildToolsVersion>
+    <AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">32.0.0</AndroidSdkBuildToolsVersion>
     <AndroidCommandLineToolsVersion Condition=" '$(AndroidCommandLineToolsVersion)' == '' ">11.0</AndroidCommandLineToolsVersion>
     <AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">34.0.5</AndroidSdkPlatformToolsVersion>
     <AndroidSdkEmulatorVersion Condition="'$(AndroidSdkEmulatorVersion)' == ''"></AndroidSdkEmulatorVersion>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/8514

The scenario is as follows:

 1. Install Visual Studio 17.9 Preview 2 on a clean machine. This installs Android SDK build-tools 34.0.0, cmdline-tools v11.0.
 2. Create a new Xamarin.Android project.
 3. Build the project.

(3) prompts the user to install Android SDK build-tools 32.0.0 and cmdline-tools 7.0, because Xamarin.Android contains default values of `$(AndroidSdkBuildToolsVersion)`=32.0.0 and
`$(AndroidCommandLineToolsVersion)`=7.0.

This isn't a *blocker*; the user need only accept the license and install the downlevel package versions.  It's just not *ideal*.

Update `$(AndroidSdkBuildToolsVersion)`,
`$(AndroidCommandLineToolsVersion)` and
`$(AndroidSdkPlatformToolsVersion)` to be consistent with .NET 8:

  * `$(AndroidCommandLineToolsVersion)`/cmdline-tools to 11.0
  * `$(AndroidSdkBuildToolsVersion)`/build-tools to 34.0.0
  * `$(AndroidSdkPlatformToolsVersion)`/platform-tools to 34.0.5

This ensures that new classic Xamarin.Android projects won't require the installation of additional packages to install.