### PR TITLE
[ci] Only enable CodeQL on Windows build job

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -14,8 +14,6 @@ pr:
 variables:
   - name: DotNetCoreVersion
     value: 6.0.x
-  - name: Codeql.Enabled
-    value: True
 
 jobs:
 - job: build
@@ -29,6 +27,7 @@ jobs:
         vmImage: macOS-12
       windows:
         vmImage: windows-2022
+        Codeql.Enabled: true
 
   pool:
     vmImage: $(vmImage)


### PR DESCRIPTION
Enabling CodeQL on macOS seems to be occasionally causing issues with the Run Tests step:

    The argument -p:UseSharedCompilation=false is invalid. Please use the /help option to check the list of valid arguments.

We can avoid this by only enabling CodeQL on the Windows build job.