### PR TITLE
[ci] Add API Scan job

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -103,14 +103,24 @@ jobs:
       artifactName: Output - windows
       downloadPath: $(Build.StagingDirectory)
 
-  - powershell: Get-ChildItem -Path "$(Build.StagingDirectory)" -Recurse
+  - task: CopyFiles@2
+    displayName: Collect Files for APIScan
+    inputs:
+      Contents: |
+        $(Build.SourcesDirectory)\$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)\**\?(*.dll|*.exe|*.pdb)
+        !$(Build.SourcesDirectory)\**\ls-jdks.*
+      TargetFolder: $(Build.StagingDirectory)\apiscan
+      OverWrite: true
+      flattenFolders: true
+
+  - powershell: Get-ChildItem -Path "$(Build.StagingDirectory)\apiscan" -Recurse
     displayName: List Files for APIScan
 
   - task: APIScan@2
     displayName: Run APIScan
     inputs:
-      softwareFolder: $(Build.StagingDirectory)
-      symbolsFolder: 'SRV*http://symweb;$(Build.StagingDirectory)'
+      softwareFolder: $(Build.StagingDirectory)\apiscan
+      symbolsFolder: 'SRV*http://symweb;$(Build.StagingDirectory)\apiscan'
       softwareName: $(ApiScanName)
       softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)$(System.JobAttempt)
       isLargeApp: true

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -103,20 +103,14 @@ jobs:
       artifactName: Output - windows
       downloadPath: $(Build.StagingDirectory)
 
-  - task: ExtractFiles@1
-    displayName: Extract nuget
-    inputs:
-      archiveFilePatterns: $(Build.StagingDirectory)\**\*.nupkg
-      destinationFolder: $(Build.StagingDirectory)\apiscan
-
-  - powershell: Get-ChildItem -Path "$(Build.StagingDirectory)\apiscan" -Recurse
+  - powershell: Get-ChildItem -Path "$(Build.StagingDirectory)" -Recurse
     displayName: List Files for APIScan
 
   - task: APIScan@2
     displayName: Run APIScan
     inputs:
-      softwareFolder: $(Build.StagingDirectory)\apiscan
-      symbolsFolder: 'SRV*http://symweb;$(Build.StagingDirectory)\apiscan'
+      softwareFolder: $(Build.StagingDirectory)
+      symbolsFolder: 'SRV*http://symweb;$(Build.StagingDirectory)'
       softwareName: $(ApiScanName)
       softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)$(System.JobAttempt)
       isLargeApp: true

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -107,7 +107,7 @@ jobs:
     displayName: Collect Files for APIScan
     inputs:
       Contents: |
-        $(Build.SourcesDirectory)\$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)\**\?(*.dll|*.exe|*.pdb)
+        $(Build.SourcesDirectory)\**\?(*.dll|*.exe|*.pdb)
         !$(Build.SourcesDirectory)\**\ls-jdks.*
       TargetFolder: $(Build.StagingDirectory)\apiscan
       OverWrite: true

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -77,19 +77,19 @@ jobs:
     displayName: Upload Build Output
     inputs:
       path: bin/Debug
-      artifactName: Output - $(Agent.JobName)
+      artifactName: Output - $(System.JobName)
 
   - task: PublishPipelineArtifact@1
     displayName: Upload Artifacts
     inputs:
       path: $(Build.ArtifactStagingDirectory)
-      artifactName: Artifacts - $(Agent.JobName)
+      artifactName: Artifacts - $(System.JobName)
     condition: always()
 
 - job: api_scan
   displayName: API Scan
-  dependsOn: build.windows
-  condition: and(eq(dependencies.build.windows.result, 'Succeeded'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
+  dependsOn: build
+  condition: and(eq(dependencies.build.result, 'Succeeded'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
   pool:
     name: Azure Pipelines
     vmImage: windows-2022

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -44,9 +44,6 @@ jobs:
   - checkout: self
     clean: true
 
-  - powershell:  'gci env: | format-table -autosize -wrap'
-    displayName:  dump environment
-
   - task: UseDotNet@2
     displayName: Use .NET Core $(DotNetCoreVersion)
     inputs:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -10,6 +10,10 @@ pr:
   - d16-*
   - d17-*
 
+parameters:
+- name: ApiScanSourceBranch
+  default: 'refs/heads/main'
+
 # Global variables
 variables:
   - name: DotNetCoreVersion
@@ -40,6 +44,9 @@ jobs:
   - checkout: self
     clean: true
 
+  - powershell:  'gci env: | format-table -autosize -wrap'
+    displayName:  dump environment
+
   - task: UseDotNet@2
     displayName: Use .NET Core $(DotNetCoreVersion)
     inputs:
@@ -67,8 +74,74 @@ jobs:
     condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
   - task: PublishPipelineArtifact@1
+    displayName: Upload Build Output
+    inputs:
+      path: bin/Debug
+      artifactName: Output - $(Agent.JobName)
+
+  - task: PublishPipelineArtifact@1
     displayName: Upload Artifacts
     inputs:
       path: $(Build.ArtifactStagingDirectory)
-      artifactName: $(vmImage)
+      artifactName: Artifacts - $(Agent.JobName)
     condition: always()
+
+- job: api_scan
+  displayName: API Scan
+  dependsOn: windows
+  condition: and(eq(dependencies.windows.result, 'Succeeded'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
+  pool:
+    name: Azure Pipelines
+    vmImage: windows-2022
+  timeoutInMinutes: 480
+  workspace:
+    clean: all
+  steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: Download build artifacts
+    inputs:
+      artifactName: Output - windows
+      downloadPath: $(Build.StagingDirectory)
+
+  - task: ExtractFiles@1
+    displayName: Extract nuget
+    inputs:
+      archiveFilePatterns: $(Build.StagingDirectory)\**\*.nupkg
+      destinationFolder: $(Build.StagingDirectory)\apiscan
+
+  - powershell: Get-ChildItem -Path "$(Build.StagingDirectory)\apiscan" -Recurse
+    displayName: List Files for APIScan
+
+  - task: APIScan@2
+    displayName: Run APIScan
+    inputs:
+      softwareFolder: $(Build.StagingDirectory)\apiscan
+      symbolsFolder: 'SRV*http://symweb;$(Build.StagingDirectory)\apiscan'
+      softwareName: $(ApiScanName)
+      softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)$(System.JobAttempt)
+      isLargeApp: true
+      toolVersion: Latest
+    env:
+      AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
+
+  - task: SdtReport@2
+    displayName: Guardian Export - Security Report
+    inputs:
+      GdnExportAllTools: false
+      GdnExportGdnToolApiScan: true
+      GdnExportOutputSuppressionFile: source.gdnsuppress
+
+  - task: PublishSecurityAnalysisLogs@3
+    displayName: Publish Guardian Artifacts
+    inputs:
+      ArtifactName: APIScan Logs
+      ArtifactType: Container
+      AllTools: false
+      APIScan: true
+      ToolLogsNotFoundAction: Warning
+
+  - task: PostAnalysis@2
+    displayName: Fail Build on Guardian Issues
+    inputs:
+      GdnBreakAllTools: false
+      GdnBreakGdnToolApiScan: true

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -101,7 +101,7 @@ jobs:
     displayName: Download build artifacts
     inputs:
       artifactName: Output - windows
-      downloadPath: $(Build.StagingDirectory)
+      downloadPath: $(Build.SourcesDirectory)
 
   - task: CopyFiles@2
     displayName: Collect Files for APIScan

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -88,8 +88,8 @@ jobs:
 
 - job: api_scan
   displayName: API Scan
-  #dependsOn: windows
-  condition: and(eq(dependencies.windows.result, 'Succeeded'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
+  dependsOn: build.windows
+  condition: and(eq(dependencies.build.windows.result, 'Succeeded'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
   pool:
     name: Azure Pipelines
     vmImage: windows-2022

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -88,7 +88,7 @@ jobs:
 
 - job: api_scan
   displayName: API Scan
-  dependsOn: windows
+  #dependsOn: windows
   condition: and(eq(dependencies.windows.result, 'Succeeded'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
   pool:
     name: Azure Pipelines


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/25351/APIScan-step-by-step-guide-to-setting-up-a-Pipeline

The ApiScan task has been added to pipeline runs against `main`.  This
task should help us identify related issues earlier, rather than having
to wait for a full scan of VS.