### PR TITLE
[Xamarin.Android.Tools.Versions] Add JavaSdkVersion

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.Versions.props
@@ -15,6 +15,7 @@
     <AndroidSdkEmulatorVersion Condition="'$(AndroidSdkEmulatorVersion)' == ''"></AndroidSdkEmulatorVersion>
     <AndroidSdkPlatformVersion Condition="'$(AndroidSdkPlatformVersion)' == ''">android-34</AndroidSdkPlatformVersion>
     <AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">26.1.10909125</AndroidNdkVersion>
+    <JavaSdkVersion Condition="'$(JavaSdkVersion)' == ''">17.0.8.1</JavaSdkVersion>
 
     <!-- obsolete; should consider removing eventually -->
     <AndroidSdkToolsVersion Condition="'$(AndroidSdkToolsVersion)' == ''">26.1.1</AndroidSdkToolsVersion>


### PR DESCRIPTION
A `$(JavaSdkVersion)` property has been added to specify the preferred
Java SDK version that will be returned by `<GetAndroidDependencies/>`.