### PR TITLE
Bump LibZipSharp to 3.1.1

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.8.3</MSBuildPackageReferenceVersion>
     <SystemSecurityCryptographyXmlVersion Condition=" '$(SystemSecurityCryptographyXmlVersion)' == '' ">7.0.1</SystemSecurityCryptographyXmlVersion>
-    <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >3.0.0</LibZipSharpVersion>
+    <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >3.1.1</LibZipSharpVersion>
     <MonoUnixVersion>7.1.0-final.1.21458.1</MonoUnixVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Brings in changes https://github.com/xamarin/LibZipSharp/compare/3.0.0...3.1.1.

A round of library version updates (https://github.com/xamarin/LibZipSharp/commit/ed2ccd5fe34a6fb3327986e6972e7b3850bf1e93) 
[CMake] Add /PROFILE to MSVC link flags (https://github.com/xamarin/LibZipSharp/commit/ca8a64a1d2794dac66ae784a80be2029ccb5fe60)