### PR TITLE
[AndroidToolTask] Log tool output as error

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/AndroidToolTask.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/AndroidToolTask.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Android.Build.Tasks
 				if (!taskResult && !string.IsNullOrEmpty (toolOutput?.ToString ())) {
 					Log.LogUnhandledToolError (TaskPrefix, toolOutput.ToString ().Trim ());
 				}
-				toolOutput.Clear ();
+				toolOutput?.Clear ();
 				return taskResult;
 			} catch (Exception ex) {
 				Log.LogUnhandledException (TaskPrefix, ex);

--- a/src/Microsoft.Android.Build.BaseTasks/AndroidToolTask.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/AndroidToolTask.cs
@@ -14,12 +14,11 @@ namespace Microsoft.Android.Build.Tasks
 
 		protected string WorkingDirectory { get; private set; }
 
-		StringBuilder toolOutput;
+		StringBuilder toolOutput = new StringBuilder ();
 
 		public AndroidToolTask ()
 		{
 			WorkingDirectory = Directory.GetCurrentDirectory();
-			toolOutput = new StringBuilder ();
 		}
 
 		public override bool Execute ()

--- a/src/Microsoft.Android.Build.BaseTasks/AndroidToolTask.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/AndroidToolTask.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Android.Build.Tasks
 			}
 		}
 
-		protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance)
+		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
 		{
 			base.LogEventsFromTextOutput (singleLine, messageImportance);
 			toolOutput.AppendLine (singleLine);

--- a/src/Microsoft.Android.Build.BaseTasks/AndroidToolTask.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/AndroidToolTask.cs
@@ -26,10 +26,10 @@ namespace Microsoft.Android.Build.Tasks
 		{
 			try {
 				bool taskResult = RunTask ();
-				if (!taskResult && !string.IsNullOrEmpty (toolOutput?.ToString ())) {
+				if (!taskResult && !string.IsNullOrEmpty (toolOutput.ToString ())) {
 					Log.LogUnhandledToolError (TaskPrefix, toolOutput.ToString ().Trim ());
 				}
-				toolOutput?.Clear ();
+				toolOutput.Clear ();
 				return taskResult;
 			} catch (Exception ex) {
 				Log.LogUnhandledException (TaskPrefix, ex);

--- a/src/Microsoft.Android.Build.BaseTasks/AndroidToolTask.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/AndroidToolTask.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Android.Build.Tasks
 			try {
 				bool taskResult = RunTask ();
 				if (!taskResult && !string.IsNullOrEmpty (toolOutput?.ToString ())) {
-					Log.LogError (toolOutput.ToString ().Trim ());
+					Log.LogUnhandledToolError (TaskPrefix, toolOutput.ToString ().Trim ());
 				}
 				toolOutput.Clear ();
 				return taskResult;

--- a/src/Microsoft.Android.Build.BaseTasks/UnhandledExceptionLogger.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/UnhandledExceptionLogger.cs
@@ -85,5 +85,10 @@ namespace Microsoft.Android.Build.Tasks
 			else
 				logCodedError (prefix + "7000", ex.ToString ());
 		}
+
+		public static void LogUnhandledToolError (this TaskLoggingHelper log, string prefix, string toolOutput)
+		{
+			log.LogCodedError ($"XA{prefix}0000", toolOutput);
+		}
 	}
 }

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/AndroidToolTaskTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/AndroidToolTaskTests.cs
@@ -134,6 +134,10 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 				Assert.IsEmpty (errors, "Successful task should not have any errors.");
 			} else {
 				Assert.IsNotEmpty (errors, "Task expected to fail should have errors.");
+				Assert.AreEqual ("MSB6006", errors [0].Code,
+					$"Expected error code MSB6006 but got {errors [0].Code}");
+				Assert.AreEqual ("XADTOT0000", errors [1].Code,
+					$"Expected error code XADTOT0000 but got {errors [1].Code}");
 				Assert.IsTrue (errors.Any (e => e.Message.Contains (expectedErrorText)),
 					"Task expected to fail should contain expected error text.");
 			}

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/Microsoft.Android.Build.BaseTasks-Tests.csproj
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/Microsoft.Android.Build.BaseTasks-Tests.csproj
@@ -9,6 +9,7 @@
     <IsPackable>false</IsPackable>
     <OutputPath>$(TestOutputFullPath)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <Import Project="..\..\src\Microsoft.Android.Build.BaseTasks\MSBuildReferences.projitems" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android-tools/issues/208

Updates AndroidToolTask to capture all standard output from the tool and log it as an error if the task fails.