### PR TITLE
Check for ANDROID_HOME Sdk location on Windows.

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -108,6 +108,10 @@ namespace Xamarin.Android.Tools
 			foreach (var basePath in paths)
 				if (Directory.Exists (basePath))
 					yield return basePath;
+
+			// check for environment variables last.
+			foreach (string dir in GetSdkFromEnvironmentVariables ())
+				yield return dir;
 		}
 
 		protected override IEnumerable<string> GetAllAvailableAndroidNdks ()

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -93,6 +93,9 @@ namespace Xamarin.Android.Tools
 				if (CheckRegistryKeyForExecutable (root, ANDROID_INSTALLER_PATH, ANDROID_INSTALLER_KEY, wow, "platform-tools", Adb))
 					yield return RegistryEx.GetValueString (root, ANDROID_INSTALLER_PATH, ANDROID_INSTALLER_KEY, wow) ?? "";
 
+			foreach (string dir in GetSdkFromEnvironmentVariables ())
+				yield return dir;
+
 			// Check some hardcoded paths for good measure
 			var paths = new string [] {
 				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), "Xamarin", "MonoAndroid", "android-sdk-windows"),
@@ -108,10 +111,6 @@ namespace Xamarin.Android.Tools
 			foreach (var basePath in paths)
 				if (Directory.Exists (basePath))
 					yield return basePath;
-
-			// check for environment variables last.
-			foreach (string dir in GetSdkFromEnvironmentVariables ())
-				yield return dir;
 		}
 
 		protected override IEnumerable<string> GetAllAvailableAndroidNdks ()


### PR DESCRIPTION
For some reason we never check for the ANDROID_HOME environment variable on Windows. This might cause
issues with people using VSCode since we probably
will be using environment variables as a backup when using that IDE.

So lets check those last in the list of paths. This way we will pick up all the other defaults and backups before trying the environment variable.