### PR TITLE
[ci] Disable API Scan on xamarin/public

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -85,7 +85,8 @@ jobs:
 - job: api_scan
   displayName: API Scan
   dependsOn: build
-  condition: and(eq(dependencies.build.result, 'Succeeded'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
+  condition: false
+  #condition: and(eq(dependencies.build.result, 'Succeeded'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
   pool:
     name: Azure Pipelines
     vmImage: windows-2022


### PR DESCRIPTION
We have migrated most of our API Scan runs to authenticate with a new
managed identity workflow.  It is not trivial to add this to pipeline
runs in the xamarin/public azure pipelines project.  Disable the API
Scan job for now as we will continue to get coverage through
xamarin/androidtools and xamarin/xamarin-android scans.