### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Add API-36 to `KnownVersions`

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
@@ -197,6 +197,9 @@ namespace Xamarin.Android.Tools
 			new AndroidVersion (35, "15.0") {
 				AlternateIds = new[]{ "V", "VanillaIceCream", "Vanilla Ice Cream" },
 			},
+			new AndroidVersion (36, "16.0") {
+				AlternateIds = new[]{ "Baklava" },
+			},
 		};
 	}
 }


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2234904
Context: https://github.com/dotnet/android/commit/2dd4f7473fa2d39be2168d178efb03ea33affffe

It appears that IDEs use this list to decide what to show in API level dropdowns.

In a72bb9a, we simply added to this list.

`Baklava` appears to be the only other name used for API 36.