### PR TITLE
Return empty properties when Java fails to run

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -274,7 +274,8 @@ namespace Xamarin.Android.Tools
 
 			const string PropertySettings = "Property settings:";
 
-			ProcessUtils.Exec (javaProps, (o, e) => {
+			try {
+				ProcessUtils.Exec (javaProps, (o, e) => {
 					const string ContinuedValuePrefix   = "        ";
 					const string NewValuePrefix         = "    ";
 					const string NameValueDelim         = " = ";
@@ -307,7 +308,14 @@ namespace Xamarin.Android.Tools
 							props.Add (curKey, values = new List<string> ());
 						values.Add (value);
 					}
-			});
+				});
+			}
+			catch (Exception e) {
+				logger (TraceLevel.Error, $"Error retrieving Java properties by running `{javaProps.FileName} {javaProps.Arguments}`: {e.Message}");
+				logger (TraceLevel.Verbose, e.ToString ());
+				return props;
+			}
+
 			if (!foundPS) {
 				logger (TraceLevel.Warning, $"No Java properties found; did not find `{PropertySettings}` in `{java} -XshowSettings:properties -version` output: ```{output.ToString ()}```");
 			}


### PR DESCRIPTION
If the Java executable we are trying to run fails to be be executed (i.e., locked file, broken symlink, or any raeson actually) we should just return an empty dictionary. That way when running `GetPathEnvironmentJdkPaths`, the invalid/not available executable is just ignored.

Call stack from https://developercommunity.visualstudio.com/t/visual-studio-does-not-see-detect-the-co/10888076
```
System.ComponentModel.Win32Exception (0x80004005): The system cannot find the path specified
   at System.Diagnostics.Process.StartWithCreateProcess(ProcessStartInfo startInfo)
   at Xamarin.Android.Tools.ProcessUtils.Exec(ProcessStartInfo processStartInfo, DataReceivedEventHandler output, Boolean includeStderr)
   at Xamarin.Android.Tools.JdkInfo.GetJavaProperties(Action`2 logger, String java)
   at Xamarin.Android.Tools.JdkInfo.<GetPathEnvironmentJdkPaths>d__61.MoveNext()
```

The message `The system cannot find the path specified` is a bit misleading because we are already validating the file exist before calling `GetJavaProperties`, and this can only occurr if we found a broken symlink.