### PR TITLE
[build] add way to opt out of multi-targeting

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;$(DotNetTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(AndroidToolsDisableMultiTargeting)' != 'true' ">$(TargetFrameworks);$(DotNetTargetFramework)</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <DefineConstants>INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>


### PR DESCRIPTION
In d4382efa, we introduce `net9.0`, so we could get trim and aot analyzers.

This broke the build in dotnet/android, because it passes in `$(DotNetTargetFramework)` as `net10.0`:

    /Users/builder/.dotnet/sdk/9.0.302/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(166,5):
    error NETSDK1045: The current .NET SDK does not support targeting .NET 10.0.  Either target .NET 9.0 or lower, or use a version of the .NET SDK that supports .NET 10.0.
    Download the .NET SDK from https://aka.ms/dotnet/download

In the dotnet/android repo, we only use the `netstandard2.0` version of this library for MSBuild tasks that might run on .NET framework.

Let's introduce `$(AndroidToolsDisableMultiTargeting)` that can be set in dotnet/android to resolve this.