### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Prefer major versions

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
@@ -75,6 +75,9 @@ namespace Xamarin.Android.Tools
 					MinStableVersion = version;
 				}
 			}
+			installedVersions.Sort ((x, y) => {
+				return x.VersionCodeFull.CompareTo (y.VersionCodeFull);
+			});
 		}
 
 		public int? GetApiLevelFromFrameworkVersion (string frameworkVersion)

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidVersionsTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidVersionsTests.cs
@@ -140,8 +140,10 @@ namespace Xamarin.Android.Tools.Tests
 				// Hides/shadows a Known Version
 				new AndroidVersion (apiLevel: 14,   osVersion: "4.0",   id: "II",   stable: false),
 				// Demonstrates new "minor" release support
+				new AndroidVersion (versionCodeFull: new Version (36, 1),   osVersion: "16.1",  id: "CANARY",   stable: true),
 				new AndroidVersion (versionCodeFull: new Version (36, 0),   osVersion: "16.0",  id: "Baklava",  stable: true),
-				new AndroidVersion (versionCodeFull: new Version (36, 1),   osVersion: "16.1",  id: "CANARY",   stable: false),
+				new AndroidVersion (versionCodeFull: new Version (37, 1),   osVersion: "17.1",  id: "E",        stable: false),
+				new AndroidVersion (versionCodeFull: new Version (37, 0),   osVersion: "17.0",  id: "D",        stable: true),
 			});
 		}
 
@@ -161,7 +163,10 @@ namespace Xamarin.Android.Tools.Tests
 			Assert.AreEqual (null,  versions.GetApiLevelFromFrameworkVersion ("1.3"));
 			Assert.AreEqual (14,    versions.GetApiLevelFromFrameworkVersion ("v4.0"));
 			Assert.AreEqual (14,    versions.GetApiLevelFromFrameworkVersion ("4.0"));
+			Assert.AreEqual (36,    versions.GetApiLevelFromFrameworkVersion ("16.0"));
 			Assert.AreEqual (36,    versions.GetApiLevelFromFrameworkVersion ("16.1"));
+			Assert.AreEqual (37,    versions.GetApiLevelFromFrameworkVersion ("17.0"));
+			Assert.AreEqual (37,    versions.GetApiLevelFromFrameworkVersion ("17.1"));
 
 			// via KnownVersions
 			Assert.AreEqual (4,     versions.GetApiLevelFromFrameworkVersion ("v1.6"));
@@ -183,9 +188,13 @@ namespace Xamarin.Android.Tools.Tests
 			Assert.AreEqual (14,    versions.GetApiLevelFromId ("14"));
 			Assert.AreEqual (14,    versions.GetApiLevelFromId ("II"));
 			Assert.AreEqual (36,    versions.GetApiLevelFromId ("36"));
+			Assert.AreEqual (36,    versions.GetApiLevelFromId ("36.1"));
 			Assert.AreEqual (36,    versions.GetApiLevelFromId ("CANARY"));
+			Assert.AreEqual (37,    versions.GetApiLevelFromId ("37"));
+			Assert.AreEqual (37,    versions.GetApiLevelFromId ("37.1"));
+			Assert.AreEqual (37,    versions.GetApiLevelFromId ("D"));
 
-			Assert.AreEqual (null,  versions.GetApiLevelFromId ("D"));
+			Assert.AreEqual (null,  versions.GetApiLevelFromId ("Z"));
 
 			// via KnownVersions
 			Assert.AreEqual (11,    versions.GetApiLevelFromId ("H"));
@@ -216,9 +225,17 @@ namespace Xamarin.Android.Tools.Tests
 			Assert.AreEqual ("CANARY",  versions.GetIdFromApiLevel ("36.1"));
 			Assert.AreEqual ("CANARY",  versions.GetIdFromApiLevel ("CANARY"));
 
+			Assert.AreEqual ("D",       versions.GetIdFromApiLevel (37));
+			Assert.AreEqual ("D",       versions.GetIdFromApiLevel ("37"));
+			Assert.AreEqual ("D",       versions.GetIdFromApiLevel ("37.0"));
+			Assert.AreEqual ("D",       versions.GetIdFromApiLevel ("D"));
+			Assert.AreEqual ("E",       versions.GetIdFromApiLevel ("37.1"));
+			Assert.AreEqual ("E",       versions.GetIdFromApiLevel ("E"));
+
+			// "GIGO"
 			Assert.AreEqual ("-1",  versions.GetIdFromApiLevel (-1));
 			Assert.AreEqual ("-1",  versions.GetIdFromApiLevel ("-1"));
-			Assert.AreEqual ("D",  versions.GetIdFromApiLevel ("D"));
+			Assert.AreEqual ("Z",   versions.GetIdFromApiLevel ("Z"));
 
 			// via KnownVersions
 			Assert.AreEqual ("11",  versions.GetIdFromApiLevel (11));
@@ -240,8 +257,12 @@ namespace Xamarin.Android.Tools.Tests
 			Assert.AreEqual ("C",   versions.GetIdFromFrameworkVersion ("1.2"));
 			Assert.AreEqual ("II",  versions.GetIdFromFrameworkVersion ("v4.0"));
 			Assert.AreEqual ("II",  versions.GetIdFromFrameworkVersion ("4.0"));
+			Assert.AreEqual ("Baklava", versions.GetIdFromFrameworkVersion ("16.0"));
 			Assert.AreEqual ("CANARY",  versions.GetIdFromFrameworkVersion ("16.1"));
+			Assert.AreEqual ("D",       versions.GetIdFromFrameworkVersion ("17.0"));
+			Assert.AreEqual ("E",       versions.GetIdFromFrameworkVersion ("17.1"));
 
+			// Unknown values
 			Assert.AreEqual (null,  versions.GetIdFromFrameworkVersion ("v0.99"));
 			Assert.AreEqual (null,  versions.GetIdFromFrameworkVersion ("0.99"));
 
@@ -261,6 +282,7 @@ namespace Xamarin.Android.Tools.Tests
 			Assert.AreEqual ("v1.2",    versions.GetFrameworkVersionFromApiLevel (3));
 			Assert.AreEqual ("v4.0",    versions.GetFrameworkVersionFromApiLevel (14));
 			Assert.AreEqual ("v16.0",   versions.GetFrameworkVersionFromApiLevel (36));
+			Assert.AreEqual ("v17.0",   versions.GetFrameworkVersionFromApiLevel (37));
 
 			// via KnownVersions
 			Assert.AreEqual ("v2.3",    versions.GetFrameworkVersionFromApiLevel (10));
@@ -284,6 +306,10 @@ namespace Xamarin.Android.Tools.Tests
 			Assert.AreEqual ("v16.0",   versions.GetFrameworkVersionFromId ("Baklava"));
 			Assert.AreEqual ("v16.1",   versions.GetFrameworkVersionFromId ("36.1"));
 			Assert.AreEqual ("v16.1",   versions.GetFrameworkVersionFromId ("CANARY"));
+			Assert.AreEqual ("v17.0",   versions.GetFrameworkVersionFromId ("37"));
+			Assert.AreEqual ("v17.0",   versions.GetFrameworkVersionFromId ("D"));
+			Assert.AreEqual ("v17.1",   versions.GetFrameworkVersionFromId ("37.1"));
+			Assert.AreEqual ("v17.1",   versions.GetFrameworkVersionFromId ("E"));
 
 			// via KnownVersions
 			Assert.AreEqual ("v3.0",    versions.GetFrameworkVersionFromId ("11"));


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/10438

On dotnet/android#10438, many unit tests are failing due to the following warning:

	Xamarin.Android.Tooling.targets(88,5): warning XA4211: AndroidManifest.xml //uses-sdk/@android:targetSdkVersion 'CANARY' is less than $(TargetPlatformVersion) '36.0'. Using API-CANARY for ACW compilation.

Looking at the diagnostic `.binlog`, we *also* see:

	Target "_ResolveSdks: …" in file "…\Xamarin.Android.Tooling.targets" from project "…\CodeBehindBuildTests.NET.csproj" (target "_ResolveMonoAndroidSdks" depends on it):
	…
	Added Item(s):
	    _AndroidApiInfo=
	        C:\a\_work\1\s\bin\Release\dotnet\packs\Microsoft.Android.Sdk.Windows\36.0.0-ci.pr.gh10438.318\tools\..\data\net10.0-android36.1\AndroidApiInfo.xml
	        C:\a\_work\1\s\bin\Release\dotnet\packs\Microsoft.Android.Sdk.Windows\36.0.0-ci.pr.gh10438.318\tools\..\data\net10.0-android36\AndroidApiInfo.xml
	…
	Task "ResolveSdks" (TaskId:104)
	  Task Parameter:AndroidSdkPath=C:\Android\android-sdk (TaskId:104)
	  Task Parameter:MinimumSupportedJavaVersion=17.0 (TaskId:104)
	  Task Parameter:JavaSdkPath=C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\17.0.16-8\x64 (TaskId:104)
	  Task Parameter:LatestSupportedJavaVersion=21.0.99 (TaskId:104)
	  Task Parameter:
	      ReferenceAssemblyPaths=
	          C:\a\_work\1\s\bin\Release\dotnet\packs\Microsoft.Android.Sdk.Windows\36.0.0-ci.pr.gh10438.318\data\net10.0-android36.1\
	          C:\a\_work\1\s\bin\Release\dotnet\packs\Microsoft.Android.Sdk.Windows\36.0.0-ci.pr.gh10438.318\data\net10.0-android36\ (TaskId:104)
	  Task Parameter:CommandLineToolsVersion=19.0 (TaskId:104)

The important thing being that the *preview*
`net10.0-android36.1\AndroidApiInfo.xml` is being processed *before* the *stable* `net10.0-android36\AndroidApiInfo.xml`.

This in turn means that when [`<GetJavaPlatformJar/>`][0] calls `AndroidVersions.GetIdFromApiLevel("36")`, it obtained the `AndroidVersion` instance for API-CANARY, *not* API-36!

	 Task "GetJavaPlatformJar" (TaskId:135)
	   Task Parameter:TargetFramework=net10.0-android (TaskId:135)
	   Task Parameter:BuildingInsideVisualStudio=False (TaskId:135)
	   Task Parameter:SupportedOSPlatformVersion=21.0 (TaskId:135)
	   Task Parameter:AndroidManifest=C:\a\_work\1\a\TestRelease\09-06_00.12.08\temp\CodeBehind\SuccessfulAndroidXApp\Release\project\Properties\AndroidManifest.xml (TaskId:135)
	   Task Parameter:DesignTimeBuild=False (TaskId:135)
	   Task Parameter:TargetPlatformVersion=36.0 (TaskId:135)
	   Task Parameter:AndroidSdkDirectory=C:\Android\android-sdk (TaskId:135)
	   Task Parameter:AndroidSdkPlatform=36 (TaskId:135)
	1:7>C:\…\Properties\AndroidManifest.xml : warning XA4211: AndroidManifest.xml //uses-sdk/@android:targetSdkVersion 'CANARY' is less than $(TargetPlatformVersion) '36.0'. Using API-CANARY for ACW compilation.
	   Output Property: JavaPlatformJarPath=C:\Android\android-sdk\platforms\android-CANARY\android.jar (TaskId:135)
	   Output Property: _AndroidTargetSdkVersion=36 (TaskId:135)
	 Done executing task "GetJavaPlatformJar". (TaskId:135)

Note input has `TargetPlatformVersion=36.0`, while output has `JavaPlatformJarPath=…\android-CANARY\android.jar`.

Update `AndroidVersionsTests` so that the preview API-36.1 is listed *before* API-36, as a *stable* API level (6 months in the future!), and *also* add stable API-37 and unstable API-37.1, to better represent this scenario.

Fix this by updating `AndroidVersions` to *sort*
`AndroidVersions.installedVersions` by
`AndroidVersion.VersionCodeFull`.  This ensures that `new Version(36, 0)` precedes `new Version(36, 1)`, and in turn ensures that `AndroidVersions.GetIdFromApiLevel("36")` returns info for API-36 and *not* API-CANARY.

[0]: https://github.com/dotnet/android/blob/976544ed415a16b1d44ab06f36f53513361307a5/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs#L120