### PR TITLE
Allow `MaximumCompatibleNDKMajorVersion=28`

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkBase.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Android.Tools
 	{
 		// When this changes, update the test: Xamarin.Android.Tools.Tests.AndroidSdkInfoTests.Ndk_MultipleNdkVersionsInSdk
 		const int MinimumCompatibleNDKMajorVersion = 16;
-		const int MaximumCompatibleNDKMajorVersion = 26;
+		const int MaximumCompatibleNDKMajorVersion = 28;
 
 		static readonly char[] SourcePropertiesKeyValueSplit = new char[] { '=' };
 

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Android.Tools.Tests
 		{
 			// Must match like-named constants in AndroidSdkBase
 			const int MinimumCompatibleNDKMajorVersion = 16;
-			const int MaximumCompatibleNDKMajorVersion = 25;
+			const int MaximumCompatibleNDKMajorVersion = 28;
 
 			CreateSdks(out string root, out string jdk, out string ndk, out string sdk);
 
@@ -95,9 +95,12 @@ namespace Xamarin.Android.Tools.Tests
 				"23.1.7779620",
 				"24.0.8215888",
 				"25.0.8775105",
-				"26.0.3735928559",   // 0xdeadbeef
+				"26.0.10792818",
+				"27.0.11718014",
+				"28.0.12433566",
+				"29.0.3735928559",   // 0xdeadbeef
 			};
-			string expectedVersion = "25.0.8775105";
+			string expectedVersion = ndkVersions [^2]; // Second to last is the highest compatible version
 			string expectedNdkPath = Path.Combine (sdk, "ndk", expectedVersion);
 
 			try {


### PR DESCRIPTION
Context: https://github.com/dotnet/android/commit/80559b5b1daec9e9f0e12783c0349323bdad451c

We are already using the 28.x Android NDK, so we should allow it here.

I also updated a unit test that was outdated.