### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Add API-36.1 to `KnownVersions`

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
@@ -211,6 +211,9 @@ namespace Xamarin.Android.Tools
 			new AndroidVersion (36, "16.0") {
 				AlternateIds = new[]{ "Baklava" },
 			},
+			new AndroidVersion (new Version ("36.1"), "16.0") {
+				AlternateIds = new[]{ "Canary" },
+			},
 		};
 	}
 }


### PR DESCRIPTION
Context: https://github.com/dotnet/android/commit/35d471e71c986c302dbf019e5c7838e57d3e0a3e
Context: https://android-developers.googleblog.com/2025/08/android-16-qpr2-beta-1-is-here.html

Add API 36.1 to the list of known Android versions.

`Canary` appears to be the only other name used for API 36.1.

This is still Android 16.0, as it is a "quarterly release".