### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Add Android Studio's Android SDK paths

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkUnix.cs
@@ -111,8 +111,14 @@ namespace Xamarin.Android.Tools
 			}
 
 			// Check some hardcoded paths for good measure
+			// macOS: ~/Library/Android/sdk
 			var macSdkPath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), "Library", "Android", "sdk");
-			yield return macSdkPath;
+			if (Directory.Exists (macSdkPath))
+				yield return macSdkPath;
+			// Linux: ~/Android/Sdk
+			var linuxSdkPath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), "Android", "Sdk");
+			if (Directory.Exists (linuxSdkPath))
+				yield return linuxSdkPath;
 		}
 
 		protected override string GetShortFormPath (string path)

--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -106,6 +106,7 @@ namespace Xamarin.Android.Tools
 					: Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ProgramFiles), "Android", "android-sdk"),
 				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), "Android", "android-sdk"),
 				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.CommonApplicationData), "Android", "android-sdk"),
+				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), "Android", "Sdk"),
 			};
 			foreach (var basePath in paths)
 				if (Directory.Exists (basePath))


### PR DESCRIPTION
We already had code looking for this path on macOS:

    ~/Library/Android/sdk

This is where Android Studio installs its Android SDK. Unfortunately, windows is at `%localappdata%\Android\Sdk` and we had no code looking for it! I also added a path for Linux.

This will also do a `Directory.Exists()` check before returning the new paths.

We will also have to probe for these locations *last* to preserve existing behavior.