### PR TITLE
Fix CS8604 nullable warning in AndroidVersion.AlternateIds

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersion.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersion.cs
@@ -35,7 +35,10 @@ namespace Xamarin.Android.Tools
 
 		// Alternate Ids for a given API level. Allows for historical mapping, e.g. API-11 has alternate ID 'H'.
 		internal    string[]?   AlternateIds {
-			set => Ids.UnionWith (value);
+			set {
+				if (value is { Length: > 0 })
+					Ids.UnionWith (value);
+			}
 		}
 
 		public AndroidVersion (int apiLevel, string osVersion, string? codeName = null, string? id = null, bool stable = true)


### PR DESCRIPTION
## Summary

Fix the CS8604 compiler warning in \AndroidVersion.AlternateIds\ setter where \HashSet<string>.UnionWith()\ was called with a potentially null \string[]?\ value.

## Changes

- **\AndroidVersion.cs\**: Guard \UnionWith(value)\ with \if (value is { Length: > 0 })\ pattern match — skips the call when value is null or empty.

## Build

- 0 warnings, 0 errors (both \
etstandard2.0\ and \
et10.0\)
- 197/208 tests pass (1 pre-existing env-dependent failure, 10 skipped)

Fixes the warning seen in [build 1323580](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1323580&view=results).