### PR TITLE
Fix RS0026 by splitting AcceptLicensesAsync optional-parameter overloads

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -90,8 +90,10 @@ Xamarin.Android.Tools.SdkLicense.SdkLicense(string! Id, string! Text) -> void
 Xamarin.Android.Tools.SdkLicense.Text.get -> string!
 Xamarin.Android.Tools.SdkLicense.Text.init -> void
 Xamarin.Android.Tools.SdkManager
-Xamarin.Android.Tools.SdkManager.AcceptLicensesAsync(System.Collections.Generic.IEnumerable<string!>! licenseIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-Xamarin.Android.Tools.SdkManager.AcceptLicensesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Xamarin.Android.Tools.SdkManager.AcceptLicensesAsync() -> System.Threading.Tasks.Task!
+Xamarin.Android.Tools.SdkManager.AcceptLicensesAsync(System.Collections.Generic.IEnumerable<string!>! licenseIds) -> System.Threading.Tasks.Task!
+Xamarin.Android.Tools.SdkManager.AcceptLicensesAsync(System.Collections.Generic.IEnumerable<string!>! licenseIds, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Xamarin.Android.Tools.SdkManager.AcceptLicensesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Xamarin.Android.Tools.SdkManager.AndroidSdkPath.get -> string?
 Xamarin.Android.Tools.SdkManager.AndroidSdkPath.set -> void
 Xamarin.Android.Tools.SdkManager.AreLicensesAccepted() -> bool

--- a/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -90,8 +90,10 @@ Xamarin.Android.Tools.SdkLicense.SdkLicense(string! Id, string! Text) -> void
 Xamarin.Android.Tools.SdkLicense.Text.get -> string!
 Xamarin.Android.Tools.SdkLicense.Text.init -> void
 Xamarin.Android.Tools.SdkManager
-Xamarin.Android.Tools.SdkManager.AcceptLicensesAsync(System.Collections.Generic.IEnumerable<string!>! licenseIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-Xamarin.Android.Tools.SdkManager.AcceptLicensesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Xamarin.Android.Tools.SdkManager.AcceptLicensesAsync() -> System.Threading.Tasks.Task!
+Xamarin.Android.Tools.SdkManager.AcceptLicensesAsync(System.Collections.Generic.IEnumerable<string!>! licenseIds) -> System.Threading.Tasks.Task!
+Xamarin.Android.Tools.SdkManager.AcceptLicensesAsync(System.Collections.Generic.IEnumerable<string!>! licenseIds, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Xamarin.Android.Tools.SdkManager.AcceptLicensesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Xamarin.Android.Tools.SdkManager.AndroidSdkPath.get -> string?
 Xamarin.Android.Tools.SdkManager.AndroidSdkPath.set -> void
 Xamarin.Android.Tools.SdkManager.AreLicensesAccepted() -> bool

--- a/src/Xamarin.Android.Tools.AndroidSdk/SdkManager.Licenses.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/SdkManager.Licenses.cs
@@ -17,8 +17,13 @@ public partial class SdkManager
 	/// <summary>
 	/// Accepts all SDK licenses using <c>sdkmanager --licenses</c>.
 	/// </summary>
+	public Task AcceptLicensesAsync () => AcceptLicensesAsync (CancellationToken.None);
+
+	/// <summary>
+	/// Accepts all SDK licenses using <c>sdkmanager --licenses</c>.
+	/// </summary>
 	/// <param name="cancellationToken">Cancellation token.</param>
-	public async Task AcceptLicensesAsync (CancellationToken cancellationToken = default)
+	public async Task AcceptLicensesAsync (CancellationToken cancellationToken)
 	{
 		var sdkManagerPath = RequireSdkManagerPath ();
 		logger (TraceLevel.Info, "Accepting SDK licenses...");
@@ -103,8 +108,14 @@ public partial class SdkManager
 	/// Accepts specific licenses by ID.
 	/// </summary>
 	/// <param name="licenseIds">The license IDs to accept (e.g., "android-sdk-license").</param>
+	public Task AcceptLicensesAsync (IEnumerable<string> licenseIds) => AcceptLicensesAsync (licenseIds, CancellationToken.None);
+
+	/// <summary>
+	/// Accepts specific licenses by ID.
+	/// </summary>
+	/// <param name="licenseIds">The license IDs to accept (e.g., "android-sdk-license").</param>
 	/// <param name="cancellationToken">Cancellation token.</param>
-	public async Task AcceptLicensesAsync (IEnumerable<string> licenseIds, CancellationToken cancellationToken = default)
+	public async Task AcceptLicensesAsync (IEnumerable<string> licenseIds, CancellationToken cancellationToken)
 	{
 		ThrowIfDisposed ();
 		if (licenseIds is null || !licenseIds.Any ())


### PR DESCRIPTION
## Fix RS0026 by splitting AcceptLicensesAsync optional-parameter overloads

### Problem

The two AcceptLicensesAsync overloads (parameterless and IEnumerable) both had optional CancellationToken parameters, which the PublicAPI analyzer (RS0026) flags as potentially ambiguous at call sites. This causes build failures in dotnet/android which treats warnings as errors via the submodule.

### Fix

Instead of suppressing the warning with #pragma, this restructures the API to use **explicit overloads** with no optional parameters anywhere:

| Overload | Role |
|----------|------|
| `AcceptLicensesAsync()` | Convenience — delegates to CT version with `CancellationToken.None` |
| `AcceptLicensesAsync(CancellationToken)` | Real implementation, required CT |
| `AcceptLicensesAsync(IEnumerable<string>)` | Convenience — delegates to CT version with `CancellationToken.None` |
| `AcceptLicensesAsync(IEnumerable<string>, CancellationToken)` | Real implementation, required CT |

This is the [recommended fix](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1026) for RS0026 — it eliminates ambiguity while remaining source- and binary-compatible with existing callers.

### Multi-Model Review Consensus

Reviewed by 3 models (GPT-5.2-Codex, Gemini 3 Pro, Claude Sonnet 4). All three independently recommended:
- Split ALL overloads (not just the parameterless pair) for full consistency
- No optional parameters in any public API surface
- Convenience overloads delegate with `CancellationToken.None`

### Files Changed

- **SdkManager.Licenses.cs** — split optional-parameter methods into explicit overload pairs (4 total overloads, was 2)
- **PublicAPI/net10.0/PublicAPI.Unshipped.txt** — updated signatures for 4 distinct overloads
- **PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt** — same

### Tests

All 32 SdkManager tests pass. Zero RS0016/RS0017/RS0026 warnings.

### Why This Matters

dotnet/android #10880 bumps the submodule to `b4da013` which includes the PublicAPI analyzer from #294. Without this fix, all 3 platforms (Linux, macOS, Windows) fail with RS0026 build errors.
