### PR TITLE
TryGetPlatformDirectoryFromApiLevel: fall back to android-{major}.0

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -120,6 +120,15 @@ namespace Xamarin.Android.Tools
 			if (dir != null && Directory.Exists (dir))
 				return dir;
 
+			// Starting with API 37, Google's SDK Manager installs platforms to
+			// "android-37.0" instead of "android-37". Try the "{major}.0" fallback.
+			// See: https://github.com/dotnet/android-tools/issues/319
+			if (int.TryParse (id, out _)) {
+				dir = GetPlatformDirectoryFromId (id + ".0");
+				if (Directory.Exists (dir))
+					return dir;
+			}
+
 			return null;
 		}
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidSdkInfo.cs
@@ -134,7 +134,9 @@ namespace Xamarin.Android.Tools
 
 		public bool IsPlatformInstalled (int apiLevel)
 		{
-			return apiLevel != 0 && Directory.Exists (GetPlatformDirectory (apiLevel));
+			return apiLevel != 0 &&
+				(Directory.Exists (GetPlatformDirectory (apiLevel)) ||
+				 Directory.Exists (GetPlatformDirectoryFromId (apiLevel + ".0")));
 		}
 
 		public string? AndroidNdkPath {

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
@@ -662,6 +662,9 @@ namespace Xamarin.Android.Tools.Tests
 				var dir37 = info.TryGetPlatformDirectoryFromApiLevel ("37", versions);
 				Assert.IsNotNull (dir37, "Should fall back from android-37 to android-37.0");
 				Assert.AreEqual (platform370Path, dir37);
+
+				// IsPlatformInstalled should also find android-37.0
+				Assert.IsTrue (info.IsPlatformInstalled (37), "IsPlatformInstalled should find android-37.0");
 			}
 			finally {
 				Directory.Delete (root, recursive: true);

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidSdkInfoTests.cs
@@ -634,6 +634,41 @@ namespace Xamarin.Android.Tools.Tests
 		}
 
 		[Test]
+		public void TryGetPlatformDirectoryFromApiLevel_MajorFallsBackToMajorDotZero ()
+		{
+			// Starting with API 37, Google installs platforms to "android-37.0"
+			// instead of "android-37". Verify the fallback works.
+			// See: https://github.com/dotnet/android-tools/issues/319
+			CreateSdks (out string root, out string jdk, out string ndk, out string sdk);
+
+			// Only create android-37.0, not android-37
+			var platformsPath = Path.Combine (sdk, "platforms");
+			var platform370Path = Path.Combine (platformsPath, "android-37.0");
+			Directory.CreateDirectory (platform370Path);
+			File.WriteAllText (Path.Combine (platform370Path, "android.jar"), "");
+
+			var logs = new StringWriter ();
+			Action<TraceLevel, string> logger = (level, message) => {
+				logs.WriteLine ($"[{level}] {message}");
+			};
+
+			try {
+				var info = new AndroidSdkInfo (logger, androidSdkPath: sdk, androidNdkPath: ndk, javaSdkPath: jdk);
+				var versions = new AndroidVersions (new [] {
+					new AndroidVersion (37, "17.0"),
+				});
+
+				// Requesting "37" should fall back to android-37.0
+				var dir37 = info.TryGetPlatformDirectoryFromApiLevel ("37", versions);
+				Assert.IsNotNull (dir37, "Should fall back from android-37 to android-37.0");
+				Assert.AreEqual (platform370Path, dir37);
+			}
+			finally {
+				Directory.Delete (root, recursive: true);
+			}
+		}
+
+		[Test]
 		public void GetBuildToolsPaths_StableVersionsFirst ()
 		{
 			CreateSdks (out string root, out string jdk, out string ndk, out string sdk);


### PR DESCRIPTION
Starting with API 37, Google's SDK Manager installs platform directories as `android-37.0` instead of `android-37`. Both `TryGetPlatformDirectoryFromApiLevel` and `IsPlatformInstalled` only tried `android-{major}`, so projects targeting these newer API levels would fail with **XA5207**.

This adds a `.0` fallback to both methods: when the integer-only directory doesn't exist, also try `android-{id}.0`.

This complements the data-side fix in dotnet/android#11072 (which sets the `Id` to `"37.0"` directly) by providing a safety net when the `Id` is just `"37"`.

### Changes

- **`AndroidSdkInfo.TryGetPlatformDirectoryFromApiLevel`** — After existing lookups fail, try `GetPlatformDirectoryFromId(id + ".0")` when `id` is an integer.
- **`AndroidSdkInfo.IsPlatformInstalled`** — Apply the same `.0` fallback so it stays consistent with `TryGetPlatformDirectoryFromApiLevel`.
- **`AndroidSdkInfoTests`** — New test `TryGetPlatformDirectoryFromApiLevel_MajorFallsBackToMajorDotZero` creates only `android-37.0` and verifies both APIs find it.

Fixes #319