### PR TITLE
Add device profiles, skin enumeration, and ADB device tracking

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Models/AvdDeviceProfile.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Models/AvdDeviceProfile.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Xamarin.Android.Tools;
+
+/// <summary>
+/// Represents a hardware device profile (e.g., "pixel_7", "Nexus 5X") from <c>avdmanager list device</c>.
+/// </summary>
+public record AvdDeviceProfile (string Id, string Name, string? Oem = null, string? Tag = null);

--- a/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -199,3 +199,20 @@ virtual Xamarin.Android.Tools.AdbRunner.ListReversePortsAsync(string! serial, Sy
 virtual Xamarin.Android.Tools.AdbRunner.RemoveAllReversePortsAsync(string! serial, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 virtual Xamarin.Android.Tools.AdbRunner.RemoveReversePortAsync(string! serial, Xamarin.Android.Tools.AdbPortSpec! remote, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 virtual Xamarin.Android.Tools.AdbRunner.ReversePortAsync(string! serial, Xamarin.Android.Tools.AdbPortSpec! remote, Xamarin.Android.Tools.AdbPortSpec! local, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Xamarin.Android.Tools.AvdManagerRunner.ListDeviceProfilesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AvdDeviceProfile!>!>!
+static Xamarin.Android.Tools.AvdManagerRunner.ListAvdSkinsAsync(string! sdkPath, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<string!>!>!
+Xamarin.Android.Tools.AvdDeviceProfile
+Xamarin.Android.Tools.AvdDeviceProfile.AvdDeviceProfile(string! Id, string! Name, string? Oem = null, string? Tag = null) -> void
+Xamarin.Android.Tools.AvdDeviceProfile.Id.get -> string!
+Xamarin.Android.Tools.AvdDeviceProfile.Id.init -> void
+Xamarin.Android.Tools.AvdDeviceProfile.Name.get -> string!
+Xamarin.Android.Tools.AvdDeviceProfile.Name.init -> void
+Xamarin.Android.Tools.AvdDeviceProfile.Oem.get -> string?
+Xamarin.Android.Tools.AvdDeviceProfile.Oem.init -> void
+Xamarin.Android.Tools.AvdDeviceProfile.Tag.get -> string?
+Xamarin.Android.Tools.AvdDeviceProfile.Tag.init -> void
+Xamarin.Android.Tools.AdbDeviceTracker
+Xamarin.Android.Tools.AdbDeviceTracker.AdbDeviceTracker(string? adbPath = null, int port = 5037, System.Collections.Generic.IDictionary<string!, string!>? environmentVariables = null, System.Action<System.Diagnostics.TraceLevel, string!>? logger = null) -> void
+Xamarin.Android.Tools.AdbDeviceTracker.CurrentDevices.get -> System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AdbDeviceInfo!>!
+Xamarin.Android.Tools.AdbDeviceTracker.Dispose() -> void
+Xamarin.Android.Tools.AdbDeviceTracker.StartAsync(System.Action<System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AdbDeviceInfo!>!>! onDevicesChanged, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -199,3 +199,20 @@ virtual Xamarin.Android.Tools.AdbRunner.ListReversePortsAsync(string! serial, Sy
 virtual Xamarin.Android.Tools.AdbRunner.RemoveAllReversePortsAsync(string! serial, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 virtual Xamarin.Android.Tools.AdbRunner.RemoveReversePortAsync(string! serial, Xamarin.Android.Tools.AdbPortSpec! remote, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 virtual Xamarin.Android.Tools.AdbRunner.ReversePortAsync(string! serial, Xamarin.Android.Tools.AdbPortSpec! remote, Xamarin.Android.Tools.AdbPortSpec! local, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Xamarin.Android.Tools.AvdManagerRunner.ListDeviceProfilesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AvdDeviceProfile!>!>!
+static Xamarin.Android.Tools.AvdManagerRunner.ListAvdSkinsAsync(string! sdkPath, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<string!>!>!
+Xamarin.Android.Tools.AvdDeviceProfile
+Xamarin.Android.Tools.AvdDeviceProfile.AvdDeviceProfile(string! Id, string! Name, string? Oem = null, string? Tag = null) -> void
+Xamarin.Android.Tools.AvdDeviceProfile.Id.get -> string!
+Xamarin.Android.Tools.AvdDeviceProfile.Id.init -> void
+Xamarin.Android.Tools.AvdDeviceProfile.Name.get -> string!
+Xamarin.Android.Tools.AvdDeviceProfile.Name.init -> void
+Xamarin.Android.Tools.AvdDeviceProfile.Oem.get -> string?
+Xamarin.Android.Tools.AvdDeviceProfile.Oem.init -> void
+Xamarin.Android.Tools.AvdDeviceProfile.Tag.get -> string?
+Xamarin.Android.Tools.AvdDeviceProfile.Tag.init -> void
+Xamarin.Android.Tools.AdbDeviceTracker
+Xamarin.Android.Tools.AdbDeviceTracker.AdbDeviceTracker(string? adbPath = null, int port = 5037, System.Collections.Generic.IDictionary<string!, string!>? environmentVariables = null, System.Action<System.Diagnostics.TraceLevel, string!>? logger = null) -> void
+Xamarin.Android.Tools.AdbDeviceTracker.CurrentDevices.get -> System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AdbDeviceInfo!>!
+Xamarin.Android.Tools.AdbDeviceTracker.Dispose() -> void
+Xamarin.Android.Tools.AdbDeviceTracker.StartAsync(System.Action<System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AdbDeviceInfo!>!>! onDevicesChanged, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbDeviceTracker.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbDeviceTracker.cs
@@ -1,0 +1,189 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Xamarin.Android.Tools;
+
+/// <summary>
+/// Monitors ADB device connections in real-time via the <c>host:track-devices-l</c> socket protocol.
+/// Pushes device list updates through a callback whenever devices connect, disconnect, or change state.
+/// </summary>
+public sealed class AdbDeviceTracker : IDisposable
+{
+	readonly int port;
+	readonly Action<TraceLevel, string> logger;
+	readonly string? adbPath;
+	readonly IDictionary<string, string>? environmentVariables;
+	IReadOnlyList<AdbDeviceInfo> currentDevices = Array.Empty<AdbDeviceInfo> ();
+	CancellationTokenSource? trackingCts;
+	bool disposed;
+
+	/// <summary>
+	/// Creates a new AdbDeviceTracker.
+	/// </summary>
+	/// <param name="adbPath">Optional path to the adb executable for starting the server if needed.</param>
+	/// <param name="port">ADB daemon port (default 5037).</param>
+	/// <param name="environmentVariables">Optional environment variables for adb processes.</param>
+	/// <param name="logger">Optional logger callback.</param>
+	public AdbDeviceTracker (string? adbPath = null, int port = 5037,
+		IDictionary<string, string>? environmentVariables = null,
+		Action<TraceLevel, string>? logger = null)
+	{
+		if (port <= 0 || port > 65535)
+			throw new ArgumentOutOfRangeException (nameof (port), "Port must be between 1 and 65535.");
+		this.adbPath = adbPath;
+		this.port = port;
+		this.environmentVariables = environmentVariables;
+		this.logger = logger ?? RunnerDefaults.NullLogger;
+	}
+
+	/// <summary>
+	/// Current snapshot of tracked devices.
+	/// </summary>
+	public IReadOnlyList<AdbDeviceInfo> CurrentDevices => currentDevices;
+
+	/// <summary>
+	/// Starts tracking device changes. Calls <paramref name="onDevicesChanged"/> whenever
+	/// the device list changes. Blocks until cancelled or disposed.
+	/// Automatically reconnects on connection drops with exponential backoff.
+	/// </summary>
+	/// <param name="onDevicesChanged">Callback invoked with the updated device list on each change.</param>
+	/// <param name="cancellationToken">Token to stop tracking.</param>
+	public async Task StartAsync (
+		Action<IReadOnlyList<AdbDeviceInfo>> onDevicesChanged,
+		CancellationToken cancellationToken = default)
+	{
+		if (onDevicesChanged == null)
+			throw new ArgumentNullException (nameof (onDevicesChanged));
+		if (disposed)
+			throw new ObjectDisposedException (nameof (AdbDeviceTracker));
+
+		trackingCts = CancellationTokenSource.CreateLinkedTokenSource (cancellationToken);
+		var token = trackingCts.Token;
+		var backoffMs = InitialBackoffMs;
+
+		while (!token.IsCancellationRequested) {
+			try {
+				await TrackDevicesAsync (onDevicesChanged, token).ConfigureAwait (false);
+			} catch (OperationCanceledException) when (token.IsCancellationRequested) {
+				break;
+			} catch (Exception ex) {
+				logger.Invoke (TraceLevel.Warning, $"ADB tracking connection lost: {ex.Message}. Reconnecting in {backoffMs}ms...");
+				try {
+					await Task.Delay (backoffMs, token).ConfigureAwait (false);
+				} catch (OperationCanceledException) {
+					break;
+				}
+				backoffMs = Math.Min (backoffMs * 2, MaxBackoffMs);
+				continue;
+			}
+			// Reset backoff on clean connection
+			backoffMs = InitialBackoffMs;
+		}
+	}
+
+	const int InitialBackoffMs = 500;
+	const int MaxBackoffMs = 16000;
+
+	async Task TrackDevicesAsync (
+		Action<IReadOnlyList<AdbDeviceInfo>> onDevicesChanged,
+		CancellationToken cancellationToken)
+	{
+		using var client = new TcpClient ();
+#if NET5_0_OR_GREATER
+		await client.ConnectAsync ("127.0.0.1", port, cancellationToken).ConfigureAwait (false);
+#else
+		await client.ConnectAsync ("127.0.0.1", port).ConfigureAwait (false);
+		cancellationToken.ThrowIfCancellationRequested ();
+#endif
+
+		var stream = client.GetStream ();
+		logger.Invoke (TraceLevel.Verbose, "Connected to ADB daemon, sending track-devices-l command");
+
+		// Send: <4-digit hex length><command>
+		var command = "host:track-devices-l";
+		var header = command.Length.ToString ("x4") + command;
+		var headerBytes = Encoding.ASCII.GetBytes (header);
+		await stream.WriteAsync (headerBytes, 0, headerBytes.Length, cancellationToken).ConfigureAwait (false);
+		await stream.FlushAsync (cancellationToken).ConfigureAwait (false);
+
+		// Read response status (OKAY or FAIL)
+		var status = await ReadExactAsync (stream, 4, cancellationToken).ConfigureAwait (false);
+		if (status != "OKAY") {
+			var failMsg = await TryReadLengthPrefixedAsync (stream, cancellationToken).ConfigureAwait (false);
+			throw new InvalidOperationException ($"ADB daemon rejected track-devices: {status} {failMsg}");
+		}
+
+		logger.Invoke (TraceLevel.Verbose, "ADB tracking active");
+
+		// Read length-prefixed device list updates
+		while (!cancellationToken.IsCancellationRequested) {
+			var payload = await TryReadLengthPrefixedAsync (stream, cancellationToken).ConfigureAwait (false);
+			if (payload == null)
+				throw new IOException ("ADB daemon closed the connection.");
+
+			var lines = payload.Split ('\n');
+			var devices = AdbRunner.ParseAdbDevicesOutput (lines);
+			currentDevices = devices;
+			onDevicesChanged (devices);
+		}
+	}
+
+	internal static async Task<string?> TryReadLengthPrefixedAsync (Stream stream, CancellationToken cancellationToken)
+	{
+		// Length is a 4-digit hex string
+		var lengthHex = await ReadExactOrNullAsync (stream, 4, cancellationToken).ConfigureAwait (false);
+		if (lengthHex == null)
+			return null;
+
+		if (!int.TryParse (lengthHex, System.Globalization.NumberStyles.HexNumber, null, out var length))
+			throw new FormatException ($"Invalid ADB length prefix: '{lengthHex}'");
+
+		if (length == 0)
+			return string.Empty;
+
+		return await ReadExactAsync (stream, length, cancellationToken).ConfigureAwait (false);
+	}
+
+	static async Task<string> ReadExactAsync (Stream stream, int count, CancellationToken cancellationToken)
+	{
+		var result = await ReadExactOrNullAsync (stream, count, cancellationToken).ConfigureAwait (false);
+		return result ?? throw new IOException ($"Unexpected end of stream (expected {count} bytes).");
+	}
+
+	static async Task<string?> ReadExactOrNullAsync (Stream stream, int count, CancellationToken cancellationToken)
+	{
+		var buffer = new byte [count];
+		var totalRead = 0;
+		while (totalRead < count) {
+			cancellationToken.ThrowIfCancellationRequested ();
+#if NET5_0_OR_GREATER
+			var read = await stream.ReadAsync (buffer.AsMemory (totalRead, count - totalRead), cancellationToken).ConfigureAwait (false);
+#else
+			var read = await stream.ReadAsync (buffer, totalRead, count - totalRead, cancellationToken).ConfigureAwait (false);
+#endif
+			if (read == 0)
+				return totalRead == 0 ? null : throw new IOException ($"Unexpected end of stream (read {totalRead} of {count} bytes).");
+			totalRead += read;
+		}
+		return Encoding.ASCII.GetString (buffer, 0, count);
+	}
+
+	public void Dispose ()
+	{
+		if (disposed)
+			return;
+		disposed = true;
+		trackingCts?.Cancel ();
+		trackingCts?.Dispose ();
+	}
+}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AvdManagerRunner.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AvdManagerRunner.cs
@@ -122,6 +122,111 @@ public class AvdManagerRunner
 		ProcessUtils.ThrowIfFailed (exitCode, $"avdmanager delete avd --name {name}", stderr);
 	}
 
+	/// <summary>
+	/// Lists available device profiles (hardware definitions) using <c>avdmanager list device</c>.
+	/// </summary>
+	public async Task<IReadOnlyList<AvdDeviceProfile>> ListDeviceProfilesAsync (CancellationToken cancellationToken = default)
+	{
+		using var stdout = new StringWriter ();
+		using var stderr = new StringWriter ();
+		var psi = ProcessUtils.CreateProcessStartInfo (avdManagerPath, "list", "device");
+		logger.Invoke (TraceLevel.Verbose, "Running: avdmanager list device");
+		var exitCode = await ProcessUtils.StartProcess (psi, stdout, stderr, cancellationToken, environmentVariables).ConfigureAwait (false);
+
+		ProcessUtils.ThrowIfFailed (exitCode, "avdmanager list device", stderr, stdout);
+
+		return ParseDeviceListOutput (stdout.ToString ());
+	}
+
+	/// <summary>
+	/// Lists available AVD skins by scanning the SDK <c>skins/</c> directory.
+	/// </summary>
+	/// <param name="sdkPath">Root path of the Android SDK.</param>
+	/// <param name="cancellationToken">Cancellation token.</param>
+	/// <returns>Sorted list of unique skin directory names.</returns>
+	public static Task<IReadOnlyList<string>> ListAvdSkinsAsync (string sdkPath, CancellationToken cancellationToken = default)
+	{
+		if (string.IsNullOrWhiteSpace (sdkPath))
+			throw new ArgumentException ("SDK path must not be empty.", nameof (sdkPath));
+
+		cancellationToken.ThrowIfCancellationRequested ();
+
+		return Task.FromResult (EnumerateSkins (sdkPath));
+	}
+
+	internal static IReadOnlyList<string> EnumerateSkins (string sdkPath)
+	{
+		var skins = new SortedSet<string> (StringComparer.OrdinalIgnoreCase);
+
+		// Standalone skins: <sdk>/skins/<skinName>/
+		var skinsDir = Path.Combine (sdkPath, "skins");
+		AddSkinDirectories (skins, skinsDir);
+
+		// System image skins: <sdk>/system-images/<api>/<tag>/<abi>/skins/<skinName>/
+		var systemImagesDir = Path.Combine (sdkPath, "system-images");
+		if (Directory.Exists (systemImagesDir)) {
+			foreach (var apiDir in Directory.EnumerateDirectories (systemImagesDir)) {
+				foreach (var tagDir in Directory.EnumerateDirectories (apiDir)) {
+					foreach (var abiDir in Directory.EnumerateDirectories (tagDir)) {
+						var imgSkinsDir = Path.Combine (abiDir, "skins");
+						AddSkinDirectories (skins, imgSkinsDir);
+					}
+				}
+			}
+		}
+
+		return skins.ToList ();
+	}
+
+	static void AddSkinDirectories (SortedSet<string> skins, string directory)
+	{
+		if (!Directory.Exists (directory))
+			return;
+		foreach (var skinDir in Directory.EnumerateDirectories (directory))
+			skins.Add (Path.GetFileName (skinDir));
+	}
+
+	internal static IReadOnlyList<AvdDeviceProfile> ParseDeviceListOutput (string output)
+	{
+		var profiles = new List<AvdDeviceProfile> ();
+		string? currentId = null, currentName = null, currentOem = null, currentTag = null;
+
+		foreach (var line in output.Split ('\n')) {
+			var trimmed = line.Trim ();
+			if (trimmed.StartsWith ("id:", StringComparison.OrdinalIgnoreCase)) {
+				if (currentId is not null)
+					profiles.Add (new AvdDeviceProfile (currentId, currentName ?? currentId, currentOem, currentTag));
+				// Parse: id: 0 or "automotive_1024p_landscape"
+				currentOem = currentTag = null;
+				currentName = null;
+				var orIndex = trimmed.IndexOf (" or ", StringComparison.Ordinal);
+				if (orIndex >= 0) {
+					var rawId = trimmed.Substring (orIndex + 4).Trim ().Trim ('"');
+					currentId = rawId;
+				} else {
+					currentId = trimmed.Substring (3).Trim ().Trim ('"');
+				}
+			}
+			else if (trimmed.StartsWith ("Name:", StringComparison.OrdinalIgnoreCase))
+				currentName = trimmed.Substring (5).Trim ();
+			else if (trimmed.StartsWith ("OEM", StringComparison.OrdinalIgnoreCase)) {
+				var colonIndex = trimmed.IndexOf (':');
+				if (colonIndex >= 0)
+					currentOem = trimmed.Substring (colonIndex + 1).Trim ();
+			}
+			else if (trimmed.StartsWith ("Tag", StringComparison.OrdinalIgnoreCase)) {
+				var colonIndex = trimmed.IndexOf (':');
+				if (colonIndex >= 0)
+					currentTag = trimmed.Substring (colonIndex + 1).Trim ();
+			}
+		}
+
+		if (currentId is not null)
+			profiles.Add (new AvdDeviceProfile (currentId, currentName ?? currentId, currentOem, currentTag));
+
+		return profiles;
+	}
+
 	internal static IReadOnlyList<AvdInfo> ParseAvdListOutput (string output)
 	{
 		var avds = new List<AvdInfo> ();

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AdbDeviceTrackerTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AdbDeviceTrackerTests.cs
@@ -1,0 +1,127 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Xamarin.Android.Tools.Tests;
+
+[TestFixture]
+public class AdbDeviceTrackerTests
+{
+	[Test]
+	public void Constructor_InvalidPort_ThrowsArgumentOutOfRangeException ()
+	{
+		Assert.Throws<ArgumentOutOfRangeException> (() => new AdbDeviceTracker (port: 0));
+		Assert.Throws<ArgumentOutOfRangeException> (() => new AdbDeviceTracker (port: -1));
+		Assert.Throws<ArgumentOutOfRangeException> (() => new AdbDeviceTracker (port: 70000));
+	}
+
+	[Test]
+	public void Constructor_ValidPort_Succeeds ()
+	{
+		using var tracker = new AdbDeviceTracker (port: 5037);
+		Assert.IsNotNull (tracker);
+		Assert.AreEqual (0, tracker.CurrentDevices.Count);
+	}
+
+	[Test]
+	public void StartAsync_NullCallback_ThrowsArgumentNullException ()
+	{
+		using var tracker = new AdbDeviceTracker ();
+		Assert.ThrowsAsync<ArgumentNullException> (() => tracker.StartAsync (null!));
+	}
+
+	[Test]
+	public void StartAsync_AfterDispose_ThrowsObjectDisposedException ()
+	{
+		var tracker = new AdbDeviceTracker ();
+		tracker.Dispose ();
+		Assert.ThrowsAsync<ObjectDisposedException> (() => tracker.StartAsync (_ => { }));
+	}
+
+	[Test]
+	public void Dispose_MultipleTimes_DoesNotThrow ()
+	{
+		var tracker = new AdbDeviceTracker ();
+		tracker.Dispose ();
+		Assert.DoesNotThrow (() => tracker.Dispose ());
+	}
+
+	// --- TryReadLengthPrefixedAsync tests ---
+
+	[Test]
+	public async Task TryReadLengthPrefixedAsync_ValidPayload ()
+	{
+		var payload = "emulator-5554\tdevice\n";
+		var hex = payload.Length.ToString ("x4");
+		var data = Encoding.ASCII.GetBytes (hex + payload);
+		using var stream = new MemoryStream (data);
+
+		var result = await AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None);
+		Assert.AreEqual (payload, result);
+	}
+
+	[Test]
+	public async Task TryReadLengthPrefixedAsync_EmptyPayload ()
+	{
+		var data = Encoding.ASCII.GetBytes ("0000");
+		using var stream = new MemoryStream (data);
+
+		var result = await AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None);
+		Assert.AreEqual (string.Empty, result);
+	}
+
+	[Test]
+	public async Task TryReadLengthPrefixedAsync_EndOfStream_ReturnsNull ()
+	{
+		using var stream = new MemoryStream (Array.Empty<byte> ());
+
+		var result = await AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None);
+		Assert.IsNull (result);
+	}
+
+	[Test]
+	public async Task TryReadLengthPrefixedAsync_MultipleDevices ()
+	{
+		var payload =
+			"0A041FDD400327\tdevice product:redfin model:Pixel_5 device:redfin transport_id:2\n" +
+			"emulator-5554\tdevice product:sdk_gphone64_x86_64 model:sdk_gphone64_x86_64 device:emu64xa transport_id:1\n";
+		var hex = payload.Length.ToString ("x4");
+		var data = Encoding.ASCII.GetBytes (hex + payload);
+		using var stream = new MemoryStream (data);
+
+		var result = await AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None);
+		Assert.IsNotNull (result);
+
+		var devices = AdbRunner.ParseAdbDevicesOutput (result!.Split ('\n'));
+		Assert.AreEqual (2, devices.Count);
+		Assert.AreEqual ("0A041FDD400327", devices [0].Serial);
+		Assert.AreEqual ("emulator-5554", devices [1].Serial);
+	}
+
+	[Test]
+	public void TryReadLengthPrefixedAsync_InvalidHex_ThrowsFormatException ()
+	{
+		var data = Encoding.ASCII.GetBytes ("ZZZZ");
+		using var stream = new MemoryStream (data);
+
+		Assert.ThrowsAsync<FormatException> (
+			() => AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None));
+	}
+
+	[Test]
+	public void TryReadLengthPrefixedAsync_TruncatedPayload_ThrowsIOException ()
+	{
+		// Header says 100 bytes but only 5 are present
+		var data = Encoding.ASCII.GetBytes ("0064hello");
+		using var stream = new MemoryStream (data);
+
+		Assert.ThrowsAsync<IOException> (
+			() => AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None));
+	}
+}

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AvdManagerRunnerTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AvdManagerRunnerTests.cs
@@ -293,4 +293,173 @@ public class AvdManagerRunnerTests
 			Directory.Delete (tempDir, true);
 		}
 	}
+
+	// --- ParseDeviceListOutput tests ---
+
+	[Test]
+	public void ParseDeviceListOutput_MultipleProfiles ()
+	{
+		var output =
+			"Available devices definitions:\n" +
+			"id: 0 or \"automotive_1024p_landscape\"\n" +
+			"    Name: Automotive (1024p landscape)\n" +
+			"    OEM : Google\n" +
+			"    Tag : android-automotive-playstore\n" +
+			"---------\n" +
+			"id: 1 or \"pixel_7\"\n" +
+			"    Name: Pixel 7\n" +
+			"    OEM : Google\n" +
+			"---------\n" +
+			"id: 2 or \"Nexus 5X\"\n" +
+			"    Name: Nexus 5X\n" +
+			"    OEM : Google\n";
+
+		var profiles = AvdManagerRunner.ParseDeviceListOutput (output);
+
+		Assert.AreEqual (3, profiles.Count);
+
+		Assert.AreEqual ("automotive_1024p_landscape", profiles [0].Id);
+		Assert.AreEqual ("Automotive (1024p landscape)", profiles [0].Name);
+		Assert.AreEqual ("Google", profiles [0].Oem);
+		Assert.AreEqual ("android-automotive-playstore", profiles [0].Tag);
+
+		Assert.AreEqual ("pixel_7", profiles [1].Id);
+		Assert.AreEqual ("Pixel 7", profiles [1].Name);
+		Assert.AreEqual ("Google", profiles [1].Oem);
+		Assert.IsNull (profiles [1].Tag);
+
+		Assert.AreEqual ("Nexus 5X", profiles [2].Id);
+		Assert.AreEqual ("Nexus 5X", profiles [2].Name);
+	}
+
+	[Test]
+	public void ParseDeviceListOutput_EmptyOutput ()
+	{
+		var profiles = AvdManagerRunner.ParseDeviceListOutput ("");
+		Assert.AreEqual (0, profiles.Count);
+	}
+
+	[Test]
+	public void ParseDeviceListOutput_WindowsNewlines ()
+	{
+		var output =
+			"Available devices definitions:\r\n" +
+			"id: 0 or \"pixel_fold\"\r\n" +
+			"    Name: Pixel Fold\r\n" +
+			"    OEM : Google\r\n" +
+			"    Tag : default\r\n";
+
+		var profiles = AvdManagerRunner.ParseDeviceListOutput (output);
+
+		Assert.AreEqual (1, profiles.Count);
+		Assert.AreEqual ("pixel_fold", profiles [0].Id);
+		Assert.AreEqual ("Pixel Fold", profiles [0].Name);
+		Assert.AreEqual ("Google", profiles [0].Oem);
+		Assert.AreEqual ("default", profiles [0].Tag);
+	}
+
+	[Test]
+	public void ParseDeviceListOutput_NoNameFallsBackToId ()
+	{
+		var output =
+			"id: 0 or \"custom_device\"\n" +
+			"    OEM : SomeOem\n";
+
+		var profiles = AvdManagerRunner.ParseDeviceListOutput (output);
+
+		Assert.AreEqual (1, profiles.Count);
+		Assert.AreEqual ("custom_device", profiles [0].Id);
+		Assert.AreEqual ("custom_device", profiles [0].Name);
+	}
+
+	[Test]
+	public void ParseDeviceListOutput_HeaderOnly ()
+	{
+		var output = "Available devices definitions:\n";
+		var profiles = AvdManagerRunner.ParseDeviceListOutput (output);
+		Assert.AreEqual (0, profiles.Count);
+	}
+
+	[Test]
+	public void ParseDeviceListOutput_ReturnsIReadOnlyList ()
+	{
+		var profiles = AvdManagerRunner.ParseDeviceListOutput ("");
+		Assert.IsInstanceOf<IReadOnlyList<AvdDeviceProfile>> (profiles);
+	}
+
+	// --- EnumerateSkins tests ---
+
+	[Test]
+	public void EnumerateSkins_FindsStandaloneSkins ()
+	{
+		var sdkDir = Path.Combine (Path.GetTempPath (), $"sdk-skin-test-{Path.GetRandomFileName ()}");
+		try {
+			Directory.CreateDirectory (Path.Combine (sdkDir, "skins", "pixel_7_pro"));
+			Directory.CreateDirectory (Path.Combine (sdkDir, "skins", "nexus_5x"));
+
+			var skins = AvdManagerRunner.EnumerateSkins (sdkDir);
+
+			Assert.AreEqual (2, skins.Count);
+			Assert.That (skins, Contains.Item ("nexus_5x"));
+			Assert.That (skins, Contains.Item ("pixel_7_pro"));
+		} finally {
+			Directory.Delete (sdkDir, true);
+		}
+	}
+
+	[Test]
+	public void EnumerateSkins_FindsSystemImageSkins ()
+	{
+		var sdkDir = Path.Combine (Path.GetTempPath (), $"sdk-skin-test-{Path.GetRandomFileName ()}");
+		try {
+			var imgSkinsDir = Path.Combine (sdkDir, "system-images", "android-35", "google_apis", "x86_64", "skins");
+			Directory.CreateDirectory (Path.Combine (imgSkinsDir, "pixel_tablet"));
+
+			var skins = AvdManagerRunner.EnumerateSkins (sdkDir);
+
+			Assert.AreEqual (1, skins.Count);
+			Assert.AreEqual ("pixel_tablet", skins [0]);
+		} finally {
+			Directory.Delete (sdkDir, true);
+		}
+	}
+
+	[Test]
+	public void EnumerateSkins_DeduplicatesAndSorts ()
+	{
+		var sdkDir = Path.Combine (Path.GetTempPath (), $"sdk-skin-test-{Path.GetRandomFileName ()}");
+		try {
+			Directory.CreateDirectory (Path.Combine (sdkDir, "skins", "pixel_7"));
+			var imgSkinsDir = Path.Combine (sdkDir, "system-images", "android-35", "google_apis", "x86_64", "skins");
+			Directory.CreateDirectory (Path.Combine (imgSkinsDir, "pixel_7"));
+			Directory.CreateDirectory (Path.Combine (imgSkinsDir, "auto_skin"));
+
+			var skins = AvdManagerRunner.EnumerateSkins (sdkDir);
+
+			Assert.AreEqual (2, skins.Count);
+			Assert.AreEqual ("auto_skin", skins [0]);
+			Assert.AreEqual ("pixel_7", skins [1]);
+		} finally {
+			Directory.Delete (sdkDir, true);
+		}
+	}
+
+	[Test]
+	public void EnumerateSkins_MissingSdkDir_ReturnsEmpty ()
+	{
+		var skins = AvdManagerRunner.EnumerateSkins (Path.Combine (Path.GetTempPath (), "nonexistent-sdk-dir"));
+		Assert.AreEqual (0, skins.Count);
+	}
+
+	[Test]
+	public void ListAvdSkinsAsync_NullSdkPath_ThrowsArgumentException ()
+	{
+		Assert.ThrowsAsync<ArgumentException> (() => AvdManagerRunner.ListAvdSkinsAsync (null!));
+	}
+
+	[Test]
+	public void ListAvdSkinsAsync_EmptySdkPath_ThrowsArgumentException ()
+	{
+		Assert.ThrowsAsync<ArgumentException> (() => AvdManagerRunner.ListAvdSkinsAsync (""));
+	}
 }


### PR DESCRIPTION
## Summary

Implements three related features for AVD/device management in \Xamarin.Android.Tools.AndroidSdk\:

### Issue #321 — Device Profile Enumeration
- Added \AvdDeviceProfile\ record (\Id\, \Name\, \Oem\, \Tag\)
- Added \AvdManagerRunner.ListDeviceProfilesAsync()\ — runs \vdmanager list device\ and parses structured output
- Internal \ParseDeviceListOutput()\ for testability

### Issue #322 — AVD Skin Enumeration
- Added \AvdManagerRunner.ListAvdSkinsAsync(sdkPath)\ static method
- Scans \<sdk>/skins/\ for standalone skins and \<sdk>/system-images/.../skins/\ for bundled skins
- Returns deduplicated, sorted list of skin names

### Issue #323 — ADB Device Tracking
- Added \AdbDeviceTracker\ class implementing \IDisposable\
- Real-time device monitoring via \host:track-devices-l\ ADB daemon socket protocol
- Auto-reconnect with exponential backoff (500ms → 16s)
- Callback-based \StartAsync()\ with \CurrentDevices\ snapshot property
- Reuses existing \AdbRunner.ParseAdbDevicesOutput()\ for parsing

### Tests
- 23 new unit tests covering all parsing, edge cases, and protocol handling
- All existing tests continue to pass

### API Surface
- Updated \PublicAPI.Unshipped.txt\ for both \
et10.0\ and \
etstandard2.0\ targets

Closes #321
Closes #322
Closes #323