### PR TITLE
Add AvdManagerRunner.ListDeviceProfilesAsync() for device profile enumeration

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Models/AvdDeviceProfile.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Models/AvdDeviceProfile.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Xamarin.Android.Tools;
+
+/// <summary>
+/// Represents a hardware device profile (e.g., "pixel_7", "Nexus 5X") from <c>avdmanager list device --compact</c>.
+/// </summary>
+public record AvdDeviceProfile (string Id);

--- a/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -199,3 +199,8 @@ virtual Xamarin.Android.Tools.AdbRunner.ListReversePortsAsync(string! serial, Sy
 virtual Xamarin.Android.Tools.AdbRunner.RemoveAllReversePortsAsync(string! serial, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 virtual Xamarin.Android.Tools.AdbRunner.RemoveReversePortAsync(string! serial, Xamarin.Android.Tools.AdbPortSpec! remote, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 virtual Xamarin.Android.Tools.AdbRunner.ReversePortAsync(string! serial, Xamarin.Android.Tools.AdbPortSpec! remote, Xamarin.Android.Tools.AdbPortSpec! local, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Xamarin.Android.Tools.AvdManagerRunner.ListDeviceProfilesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AvdDeviceProfile!>!>!
+Xamarin.Android.Tools.AvdDeviceProfile
+Xamarin.Android.Tools.AvdDeviceProfile.AvdDeviceProfile(string! Id) -> void
+Xamarin.Android.Tools.AvdDeviceProfile.Id.get -> string!
+Xamarin.Android.Tools.AvdDeviceProfile.Id.init -> void

--- a/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -199,3 +199,8 @@ virtual Xamarin.Android.Tools.AdbRunner.ListReversePortsAsync(string! serial, Sy
 virtual Xamarin.Android.Tools.AdbRunner.RemoveAllReversePortsAsync(string! serial, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 virtual Xamarin.Android.Tools.AdbRunner.RemoveReversePortAsync(string! serial, Xamarin.Android.Tools.AdbPortSpec! remote, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 virtual Xamarin.Android.Tools.AdbRunner.ReversePortAsync(string! serial, Xamarin.Android.Tools.AdbPortSpec! remote, Xamarin.Android.Tools.AdbPortSpec! local, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Xamarin.Android.Tools.AvdManagerRunner.ListDeviceProfilesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AvdDeviceProfile!>!>!
+Xamarin.Android.Tools.AvdDeviceProfile
+Xamarin.Android.Tools.AvdDeviceProfile.AvdDeviceProfile(string! Id) -> void
+Xamarin.Android.Tools.AvdDeviceProfile.Id.get -> string!
+Xamarin.Android.Tools.AvdDeviceProfile.Id.init -> void

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AvdManagerRunner.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AvdManagerRunner.cs
@@ -122,6 +122,35 @@ public class AvdManagerRunner
 		ProcessUtils.ThrowIfFailed (exitCode, $"avdmanager delete avd --name {name}", stderr);
 	}
 
+	/// <summary>
+	/// Lists available device profiles (hardware definitions) using <c>avdmanager list device --compact</c>.
+	/// </summary>
+	public async Task<IReadOnlyList<AvdDeviceProfile>> ListDeviceProfilesAsync (CancellationToken cancellationToken = default)
+	{
+		using var stdout = new StringWriter ();
+		using var stderr = new StringWriter ();
+		var psi = ProcessUtils.CreateProcessStartInfo (avdManagerPath, "list", "device", "--compact");
+		logger.Invoke (TraceLevel.Verbose, "Running: avdmanager list device --compact");
+		var exitCode = await ProcessUtils.StartProcess (psi, stdout, stderr, cancellationToken, environmentVariables).ConfigureAwait (false);
+
+		ProcessUtils.ThrowIfFailed (exitCode, "avdmanager list device --compact", stderr, stdout);
+
+		return ParseCompactDeviceListOutput (stdout.ToString ());
+	}
+
+	internal static IReadOnlyList<AvdDeviceProfile> ParseCompactDeviceListOutput (string output)
+	{
+		var profiles = new List<AvdDeviceProfile> ();
+
+		foreach (var line in output.Split ('\n')) {
+			var trimmed = line.Trim ();
+			if (trimmed.Length > 0)
+				profiles.Add (new AvdDeviceProfile (trimmed));
+		}
+
+		return profiles;
+	}
+
 	internal static IReadOnlyList<AvdInfo> ParseAvdListOutput (string output)
 	{
 		var avds = new List<AvdInfo> ();

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AvdManagerRunnerTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AvdManagerRunnerTests.cs
@@ -293,4 +293,61 @@ public class AvdManagerRunnerTests
 			Directory.Delete (tempDir, true);
 		}
 	}
+
+	[Test]
+	public void ParseCompactDeviceListOutput_MultipleProfiles ()
+	{
+		var output =
+			"automotive_1024p_landscape\n" +
+			"pixel_7\n" +
+			"Nexus 5X\n" +
+			"Galaxy Nexus\n";
+
+		var profiles = AvdManagerRunner.ParseCompactDeviceListOutput (output);
+
+		Assert.AreEqual (4, profiles.Count);
+		Assert.AreEqual ("automotive_1024p_landscape", profiles [0].Id);
+		Assert.AreEqual ("pixel_7", profiles [1].Id);
+		Assert.AreEqual ("Nexus 5X", profiles [2].Id);
+		Assert.AreEqual ("Galaxy Nexus", profiles [3].Id);
+	}
+
+	[Test]
+	public void ParseCompactDeviceListOutput_EmptyOutput ()
+	{
+		var profiles = AvdManagerRunner.ParseCompactDeviceListOutput ("");
+		Assert.AreEqual (0, profiles.Count);
+	}
+
+	[Test]
+	public void ParseCompactDeviceListOutput_WindowsNewlines ()
+	{
+		var output =
+			"pixel_fold\r\n" +
+			"pixel_9_pro\r\n";
+
+		var profiles = AvdManagerRunner.ParseCompactDeviceListOutput (output);
+
+		Assert.AreEqual (2, profiles.Count);
+		Assert.AreEqual ("pixel_fold", profiles [0].Id);
+		Assert.AreEqual ("pixel_9_pro", profiles [1].Id);
+	}
+
+	[Test]
+	public void ParseCompactDeviceListOutput_SkipsBlankLines ()
+	{
+		var output = "\n\npixel_7\n\n";
+
+		var profiles = AvdManagerRunner.ParseCompactDeviceListOutput (output);
+
+		Assert.AreEqual (1, profiles.Count);
+		Assert.AreEqual ("pixel_7", profiles [0].Id);
+	}
+
+	[Test]
+	public void ParseCompactDeviceListOutput_ReturnsIReadOnlyList ()
+	{
+		var profiles = AvdManagerRunner.ParseCompactDeviceListOutput ("");
+		Assert.IsInstanceOf<IReadOnlyList<AvdDeviceProfile>> (profiles);
+	}
 }


### PR DESCRIPTION
## Summary

Add a method to enumerate available AVD device profiles (hardware definitions) using `avdmanager list device --compact`.

Uses the `--compact` flag for clean, script-friendly output (one device ID per line) instead of the verbose multi-line format.

### Changes
- Added `AvdDeviceProfile` record (`Id`) in `Models/`
- Added `AvdManagerRunner.ListDeviceProfilesAsync()` — runs `avdmanager list device --compact` and parses output
- Internal `ParseCompactDeviceListOutput()` static method for testability
- 5 unit tests covering multiple profiles, empty output, Windows newlines, blank lines
- Updated `PublicAPI.Unshipped.txt` for both `net10.0` and `netstandard2.0`

Closes #321