### PR TITLE
Add AVD skin enumeration API

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -199,6 +199,7 @@ virtual Xamarin.Android.Tools.AdbRunner.ListReversePortsAsync(string! serial, Sy
 virtual Xamarin.Android.Tools.AdbRunner.RemoveAllReversePortsAsync(string! serial, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 virtual Xamarin.Android.Tools.AdbRunner.RemoveReversePortAsync(string! serial, Xamarin.Android.Tools.AdbPortSpec! remote, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 virtual Xamarin.Android.Tools.AdbRunner.ReversePortAsync(string! serial, Xamarin.Android.Tools.AdbPortSpec! remote, Xamarin.Android.Tools.AdbPortSpec! local, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Xamarin.Android.Tools.AvdManagerRunner.ListAvdSkinsAsync(string! sdkPath, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<string!>!>!
 Xamarin.Android.Tools.AvdManagerRunner.ListDeviceProfilesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AvdDeviceProfile!>!>!
 Xamarin.Android.Tools.AvdDeviceProfile
 Xamarin.Android.Tools.AvdDeviceProfile.AvdDeviceProfile(string! Id) -> void

--- a/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -199,6 +199,7 @@ virtual Xamarin.Android.Tools.AdbRunner.ListReversePortsAsync(string! serial, Sy
 virtual Xamarin.Android.Tools.AdbRunner.RemoveAllReversePortsAsync(string! serial, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 virtual Xamarin.Android.Tools.AdbRunner.RemoveReversePortAsync(string! serial, Xamarin.Android.Tools.AdbPortSpec! remote, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 virtual Xamarin.Android.Tools.AdbRunner.ReversePortAsync(string! serial, Xamarin.Android.Tools.AdbPortSpec! remote, Xamarin.Android.Tools.AdbPortSpec! local, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Xamarin.Android.Tools.AvdManagerRunner.ListAvdSkinsAsync(string! sdkPath, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<string!>!>!
 Xamarin.Android.Tools.AvdManagerRunner.ListDeviceProfilesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AvdDeviceProfile!>!>!
 Xamarin.Android.Tools.AvdDeviceProfile
 Xamarin.Android.Tools.AvdDeviceProfile.AvdDeviceProfile(string! Id) -> void

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AvdManagerRunner.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AvdManagerRunner.cs
@@ -151,6 +151,106 @@ public class AvdManagerRunner
 		return profiles;
 	}
 
+	/// <summary>
+	/// Lists available AVD skins by scanning the SDK for built-in and downloaded skin definitions.
+	/// </summary>
+	/// <remarks>
+	/// The following SDK locations are scanned and the discovered skin directory names are deduplicated:
+	/// <list type="bullet">
+	///   <item><description><c>&lt;sdk&gt;/skins/</c> — top-level shared skins.</description></item>
+	///   <item><description><c>&lt;sdk&gt;/platforms/&lt;api&gt;/skins/</c> — per-platform built-in skins (e.g. <c>HVGA</c>, <c>WVGA800</c>, <c>WXGA720</c>).</description></item>
+	///   <item><description><c>&lt;sdk&gt;/add-ons/&lt;addon&gt;/skins/</c> — legacy SDK add-on skins (e.g. older Google APIs add-ons).</description></item>
+	///   <item><description><c>&lt;sdk&gt;/system-images/&lt;api&gt;/&lt;tag&gt;/&lt;abi&gt;/skins/</c> — per-system-image skins shipped with recent Pixel images.</description></item>
+	/// </list>
+	/// </remarks>
+	/// <param name="sdkPath">Root path of the Android SDK.</param>
+	/// <param name="cancellationToken">Cancellation token observed throughout directory enumeration.</param>
+	/// <returns>A sorted, deduplicated list of skin directory names discovered across the SDK.</returns>
+	public Task<IReadOnlyList<string>> ListAvdSkinsAsync (string sdkPath, CancellationToken cancellationToken = default)
+	{
+		if (string.IsNullOrWhiteSpace (sdkPath))
+			throw new ArgumentException ("SDK path must not be empty.", nameof (sdkPath));
+
+		// Skin enumeration is purely synchronous filesystem work, but it can walk a large SDK tree;
+		// offload to the thread pool so callers don't block, and to keep the runner's async surface consistent.
+		return Task.Run (() => EnumerateSkins (sdkPath, cancellationToken), cancellationToken);
+	}
+
+	internal static IReadOnlyList<string> EnumerateSkins (string sdkPath, CancellationToken cancellationToken = default)
+	{
+		cancellationToken.ThrowIfCancellationRequested ();
+
+		// Skin directory names round-trip case-sensitively on Linux/macOS, so only collapse case on Windows.
+		var skins = new SortedSet<string> (OS.IsWindows ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+
+		// Standalone skins: <sdk>/skins/<skinName>/
+		AddSkinDirectories (skins, Path.Combine (sdkPath, "skins"), cancellationToken);
+
+		// Per-platform built-in skins: <sdk>/platforms/<api>/skins/<skinName>/
+		// This is where the SDK Platforms package ships skins (HVGA, WVGA800, WXGA720, ...).
+		AddNestedSkinDirectories (skins, Path.Combine (sdkPath, "platforms"), cancellationToken);
+
+		// Legacy add-on skins: <sdk>/add-ons/<addon>/skins/<skinName>/
+		AddNestedSkinDirectories (skins, Path.Combine (sdkPath, "add-ons"), cancellationToken);
+
+		// Per-system-image skins: <sdk>/system-images/<api>/<tag>/<abi>/skins/<skinName>/
+		var systemImagesDir = Path.Combine (sdkPath, "system-images");
+		if (Directory.Exists (systemImagesDir)) {
+			try {
+				foreach (var apiDir in Directory.EnumerateDirectories (systemImagesDir)) {
+					cancellationToken.ThrowIfCancellationRequested ();
+					try {
+						foreach (var tagDir in Directory.EnumerateDirectories (apiDir)) {
+							cancellationToken.ThrowIfCancellationRequested ();
+							foreach (var abiDir in Directory.EnumerateDirectories (tagDir)) {
+								cancellationToken.ThrowIfCancellationRequested ();
+								AddSkinDirectories (skins, Path.Combine (abiDir, "skins"), cancellationToken);
+							}
+						}
+					} catch (IOException) {
+					} catch (UnauthorizedAccessException) {
+					}
+				}
+			} catch (IOException) {
+			} catch (UnauthorizedAccessException) {
+			}
+		}
+
+		return skins.ToList ();
+	}
+
+	// Walk a single level of subdirectories (e.g. platforms/<api> or add-ons/<addon>) and
+	// pull skin names out of each child's "skins" subdirectory if it exists.
+	static void AddNestedSkinDirectories (SortedSet<string> skins, string parentDir, CancellationToken cancellationToken)
+	{
+		cancellationToken.ThrowIfCancellationRequested ();
+		if (!Directory.Exists (parentDir))
+			return;
+		try {
+			foreach (var childDir in Directory.EnumerateDirectories (parentDir)) {
+				cancellationToken.ThrowIfCancellationRequested ();
+				AddSkinDirectories (skins, Path.Combine (childDir, "skins"), cancellationToken);
+			}
+		} catch (IOException) {
+		} catch (UnauthorizedAccessException) {
+		}
+	}
+
+	static void AddSkinDirectories (SortedSet<string> skins, string directory, CancellationToken cancellationToken)
+	{
+		cancellationToken.ThrowIfCancellationRequested ();
+		if (!Directory.Exists (directory))
+			return;
+		try {
+			foreach (var skinDir in Directory.EnumerateDirectories (directory)) {
+				cancellationToken.ThrowIfCancellationRequested ();
+				skins.Add (Path.GetFileName (skinDir));
+			}
+		} catch (IOException) {
+		} catch (UnauthorizedAccessException) {
+		}
+	}
+
 	internal static IReadOnlyList<AvdInfo> ParseAvdListOutput (string output)
 	{
 		var avds = new List<AvdInfo> ();

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AvdManagerRunnerTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AvdManagerRunnerTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using NUnit.Framework;
 
 namespace Xamarin.Android.Tools.Tests;
@@ -349,5 +350,211 @@ public class AvdManagerRunnerTests
 	{
 		var profiles = AvdManagerRunner.ParseCompactDeviceListOutput ("");
 		Assert.IsInstanceOf<IReadOnlyList<AvdDeviceProfile>> (profiles);
+	}
+
+	// --- EnumerateSkins tests ---
+
+	[Test]
+	public void EnumerateSkins_FindsStandaloneSkins ()
+	{
+		var sdkDir = Path.Combine (Path.GetTempPath (), $"sdk-skin-test-{Path.GetRandomFileName ()}");
+		try {
+			Directory.CreateDirectory (Path.Combine (sdkDir, "skins", "pixel_7_pro"));
+			Directory.CreateDirectory (Path.Combine (sdkDir, "skins", "nexus_5x"));
+
+			var skins = AvdManagerRunner.EnumerateSkins (sdkDir);
+
+			Assert.AreEqual (2, skins.Count);
+			Assert.That (skins, Contains.Item ("nexus_5x"));
+			Assert.That (skins, Contains.Item ("pixel_7_pro"));
+		} finally {
+			Directory.Delete (sdkDir, true);
+		}
+	}
+
+	[Test]
+	public void EnumerateSkins_FindsSystemImageSkins ()
+	{
+		var sdkDir = Path.Combine (Path.GetTempPath (), $"sdk-skin-test-{Path.GetRandomFileName ()}");
+		try {
+			var imgSkinsDir = Path.Combine (sdkDir, "system-images", "android-35", "google_apis", "x86_64", "skins");
+			Directory.CreateDirectory (Path.Combine (imgSkinsDir, "pixel_tablet"));
+
+			var skins = AvdManagerRunner.EnumerateSkins (sdkDir);
+
+			Assert.AreEqual (1, skins.Count);
+			Assert.AreEqual ("pixel_tablet", skins [0]);
+		} finally {
+			Directory.Delete (sdkDir, true);
+		}
+	}
+
+	[Test]
+	public void EnumerateSkins_DeduplicatesAndSorts ()
+	{
+		var sdkDir = Path.Combine (Path.GetTempPath (), $"sdk-skin-test-{Path.GetRandomFileName ()}");
+		try {
+			Directory.CreateDirectory (Path.Combine (sdkDir, "skins", "pixel_7"));
+			var imgSkinsDir = Path.Combine (sdkDir, "system-images", "android-35", "google_apis", "x86_64", "skins");
+			Directory.CreateDirectory (Path.Combine (imgSkinsDir, "pixel_7"));
+			Directory.CreateDirectory (Path.Combine (imgSkinsDir, "auto_skin"));
+
+			var skins = AvdManagerRunner.EnumerateSkins (sdkDir);
+
+			Assert.AreEqual (2, skins.Count);
+			Assert.AreEqual ("auto_skin", skins [0]);
+			Assert.AreEqual ("pixel_7", skins [1]);
+		} finally {
+			Directory.Delete (sdkDir, true);
+		}
+	}
+
+	[Test]
+	public void EnumerateSkins_MissingSdkDir_ReturnsEmpty ()
+	{
+		var skins = AvdManagerRunner.EnumerateSkins (Path.Combine (Path.GetTempPath (), "nonexistent-sdk-dir"));
+		Assert.AreEqual (0, skins.Count);
+	}
+
+	[Test]
+	public void EnumerateSkins_FindsPlatformSkins ()
+	{
+		var sdkDir = Path.Combine (Path.GetTempPath (), $"sdk-skin-test-{Path.GetRandomFileName ()}");
+		try {
+			Directory.CreateDirectory (Path.Combine (sdkDir, "platforms", "android-34", "skins", "HVGA"));
+			Directory.CreateDirectory (Path.Combine (sdkDir, "platforms", "android-34", "skins", "WVGA800"));
+			Directory.CreateDirectory (Path.Combine (sdkDir, "platforms", "android-35", "skins", "WXGA720"));
+
+			var skins = AvdManagerRunner.EnumerateSkins (sdkDir);
+
+			Assert.AreEqual (3, skins.Count);
+			Assert.AreEqual ("HVGA", skins [0]);
+			Assert.AreEqual ("WVGA800", skins [1]);
+			Assert.AreEqual ("WXGA720", skins [2]);
+		} finally {
+			Directory.Delete (sdkDir, true);
+		}
+	}
+
+	[Test]
+	public void EnumerateSkins_FindsAddOnSkins ()
+	{
+		var sdkDir = Path.Combine (Path.GetTempPath (), $"sdk-skin-test-{Path.GetRandomFileName ()}");
+		try {
+			Directory.CreateDirectory (Path.Combine (sdkDir, "add-ons", "addon-google_apis-google-24", "skins", "WSVGA"));
+
+			var skins = AvdManagerRunner.EnumerateSkins (sdkDir);
+
+			Assert.AreEqual (1, skins.Count);
+			Assert.AreEqual ("WSVGA", skins [0]);
+		} finally {
+			Directory.Delete (sdkDir, true);
+		}
+	}
+
+	// Regression test for the Visual Studio-installed SDK layout reported on PR #326:
+	// `<sdk>/system-images/...` exists with no `skins/` subfolder; skins live under
+	// `<sdk>/platforms/<api>/skins/` and `<sdk>/skins/`.
+	[Test]
+	public void EnumerateSkins_VsStyleLayout_FindsAll ()
+	{
+		var sdkDir = Path.Combine (Path.GetTempPath (), $"sdk-skin-test-{Path.GetRandomFileName ()}");
+		try {
+			Directory.CreateDirectory (Path.Combine (sdkDir, "skins", "AndroidWearRound"));
+			Directory.CreateDirectory (Path.Combine (sdkDir, "platforms", "android-34", "skins", "HVGA"));
+			Directory.CreateDirectory (Path.Combine (sdkDir, "platforms", "android-34", "skins", "WVGA800"));
+			// system-images tree exists with no skins/ subdirectories (the VS layout case)
+			Directory.CreateDirectory (Path.Combine (sdkDir, "system-images", "android-34", "google_apis", "x86_64"));
+
+			var skins = AvdManagerRunner.EnumerateSkins (sdkDir);
+
+			Assert.AreEqual (3, skins.Count);
+			Assert.AreEqual ("AndroidWearRound", skins [0]);
+			Assert.AreEqual ("HVGA", skins [1]);
+			Assert.AreEqual ("WVGA800", skins [2]);
+		} finally {
+			Directory.Delete (sdkDir, true);
+		}
+	}
+
+	[Test]
+	public void EnumerateSkins_CancelledToken_Throws ()
+	{
+		var sdkDir = Path.Combine (Path.GetTempPath (), $"sdk-skin-test-{Path.GetRandomFileName ()}");
+		try {
+			Directory.CreateDirectory (Path.Combine (sdkDir, "skins", "pixel_7"));
+			using var cts = new CancellationTokenSource ();
+			cts.Cancel ();
+
+			Assert.Throws<OperationCanceledException> (() => AvdManagerRunner.EnumerateSkins (sdkDir, cts.Token));
+		} finally {
+			Directory.Delete (sdkDir, true);
+		}
+	}
+
+	[Test]
+	public void EnumerateSkins_CancelledToken_EmptySdk_Throws ()
+	{
+		// Regression: an SDK directory with no skin subtrees must still observe cancellation
+		// rather than silently returning an empty list.
+		var sdkDir = Path.Combine (Path.GetTempPath (), $"sdk-skin-test-{Path.GetRandomFileName ()}");
+		try {
+			Directory.CreateDirectory (sdkDir);
+			using var cts = new CancellationTokenSource ();
+			cts.Cancel ();
+
+			Assert.Throws<OperationCanceledException> (() => AvdManagerRunner.EnumerateSkins (sdkDir, cts.Token));
+		} finally {
+			Directory.Delete (sdkDir, true);
+		}
+	}
+
+	[Test]
+	public void ListAvdSkinsAsync_ReturnsSkins ()
+	{
+		var sdkDir = Path.Combine (Path.GetTempPath (), $"sdk-skin-test-{Path.GetRandomFileName ()}");
+		try {
+			Directory.CreateDirectory (Path.Combine (sdkDir, "skins", "pixel_7"));
+			Directory.CreateDirectory (Path.Combine (sdkDir, "platforms", "android-34", "skins", "HVGA"));
+
+			var runner = new AvdManagerRunner ("/fake/avdmanager");
+			var skins = runner.ListAvdSkinsAsync (sdkDir).GetAwaiter ().GetResult ();
+
+			Assert.AreEqual (2, skins.Count);
+			Assert.AreEqual ("HVGA", skins [0]);
+			Assert.AreEqual ("pixel_7", skins [1]);
+		} finally {
+			Directory.Delete (sdkDir, true);
+		}
+	}
+
+	[Test]
+	public void ListAvdSkinsAsync_CancelledToken_Throws ()
+	{
+		var sdkDir = Path.Combine (Path.GetTempPath (), $"sdk-skin-test-{Path.GetRandomFileName ()}");
+		try {
+			Directory.CreateDirectory (Path.Combine (sdkDir, "skins", "pixel_7"));
+			using var cts = new CancellationTokenSource ();
+			cts.Cancel ();
+
+			var runner = new AvdManagerRunner ("/fake/avdmanager");
+			Assert.CatchAsync<OperationCanceledException> (() => runner.ListAvdSkinsAsync (sdkDir, cts.Token));
+		} finally {
+			Directory.Delete (sdkDir, true);
+		}
+	}
+
+	[Test]
+	public void ListAvdSkinsAsync_NullSdkPath_ThrowsArgumentException ()
+	{
+		var runner = new AvdManagerRunner ("/fake/avdmanager");
+		Assert.Throws<ArgumentException> (() => runner.ListAvdSkinsAsync (null!));
+	}
+
+	[Test]
+	public void ListAvdSkinsAsync_EmptySdkPath_ThrowsArgumentException ()
+	{
+		var runner = new AvdManagerRunner ("/fake/avdmanager");
+		Assert.Throws<ArgumentException> (() => runner.ListAvdSkinsAsync (""));
 	}
 }


### PR DESCRIPTION
## Summary

Add a method to list available Android emulator skins from the SDK's `skins/` directory and system image skin directories.

### Changes
- Added `AvdManagerRunner.ListAvdSkinsAsync(sdkPath)` static method
- Scans `<sdk>/skins/` for standalone skins
- Scans `<sdk>/system-images/<api>/<tag>/<abi>/skins/` for bundled skins
- Returns deduplicated, sorted `IReadOnlyList<string>`
- Internal `EnumerateSkins()` method for testability
- 6 unit tests covering standalone skins, system image skins, deduplication, missing directories
- Updated `PublicAPI.Unshipped.txt` for both `net10.0` and `netstandard2.0`

### Related
- #321 (device profile enumeration)

Closes #322