### PR TITLE
Add ADB device tracking (host:track-devices) for real-time device monitoring

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -203,6 +203,11 @@ virtual Xamarin.Android.Tools.AdbRunner.ForwardPortAsync(string! serial, Xamarin
 virtual Xamarin.Android.Tools.AdbRunner.ListForwardPortsAsync(string! serial, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AdbPortRule!>!>!
 virtual Xamarin.Android.Tools.AdbRunner.RemoveAllForwardPortsAsync(string! serial, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 virtual Xamarin.Android.Tools.AdbRunner.RemoveForwardPortAsync(string! serial, Xamarin.Android.Tools.AdbPortSpec! local, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Xamarin.Android.Tools.AdbDeviceTracker
+Xamarin.Android.Tools.AdbDeviceTracker.AdbDeviceTracker(int port = 5037, System.Action<System.Diagnostics.TraceLevel, string!>? logger = null) -> void
+Xamarin.Android.Tools.AdbDeviceTracker.CurrentDevices.get -> System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AdbDeviceInfo!>!
+Xamarin.Android.Tools.AdbDeviceTracker.Dispose() -> void
+Xamarin.Android.Tools.AdbDeviceTracker.StartAsync(System.Action<System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AdbDeviceInfo!>!>! onDevicesChanged, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Xamarin.Android.Tools.AvdManagerRunner.ListDeviceProfilesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AvdDeviceProfile!>!>!
 Xamarin.Android.Tools.AvdDeviceProfile
 Xamarin.Android.Tools.AvdDeviceProfile.AvdDeviceProfile(string! Id) -> void

--- a/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Xamarin.Android.Tools.AndroidSdk/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -203,6 +203,11 @@ virtual Xamarin.Android.Tools.AdbRunner.ForwardPortAsync(string! serial, Xamarin
 virtual Xamarin.Android.Tools.AdbRunner.ListForwardPortsAsync(string! serial, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AdbPortRule!>!>!
 virtual Xamarin.Android.Tools.AdbRunner.RemoveAllForwardPortsAsync(string! serial, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 virtual Xamarin.Android.Tools.AdbRunner.RemoveForwardPortAsync(string! serial, Xamarin.Android.Tools.AdbPortSpec! local, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Xamarin.Android.Tools.AdbDeviceTracker
+Xamarin.Android.Tools.AdbDeviceTracker.AdbDeviceTracker(int port = 5037, System.Action<System.Diagnostics.TraceLevel, string!>? logger = null) -> void
+Xamarin.Android.Tools.AdbDeviceTracker.CurrentDevices.get -> System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AdbDeviceInfo!>!
+Xamarin.Android.Tools.AdbDeviceTracker.Dispose() -> void
+Xamarin.Android.Tools.AdbDeviceTracker.StartAsync(System.Action<System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AdbDeviceInfo!>!>! onDevicesChanged, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Xamarin.Android.Tools.AvdManagerRunner.ListDeviceProfilesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Xamarin.Android.Tools.AvdDeviceProfile!>!>!
 Xamarin.Android.Tools.AvdDeviceProfile
 Xamarin.Android.Tools.AvdDeviceProfile.AvdDeviceProfile(string! Id) -> void

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbClient.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbClient.cs
@@ -14,18 +14,14 @@ namespace Xamarin.Android.Tools;
 /// Low-level ADB daemon socket protocol client.
 /// Encapsulates a single TCP connection to the ADB server and exposes
 /// the wire protocol operations (send command, read status, read length-prefixed payloads).
-/// One instance = one connection. Dispose closes the socket.
+/// One instance can be reused across reconnections via <see cref="ReconnectAsync"/>.
+/// Dispose closes the socket.
 /// </summary>
 internal sealed class AdbClient : IDisposable
 {
-	readonly TcpClient client;
+	TcpClient? client;
 	NetworkStream? stream;
 	bool disposed;
-
-	public AdbClient ()
-	{
-		client = new TcpClient ();
-	}
 
 	/// <summary>
 	/// Connects to the ADB daemon at 127.0.0.1 on the specified port.
@@ -33,13 +29,24 @@ internal sealed class AdbClient : IDisposable
 	public async Task ConnectAsync (int port, CancellationToken cancellationToken = default)
 	{
 		ThrowIfDisposed ();
+		var tcp = new TcpClient ();
+		client = tcp;
 #if NET5_0_OR_GREATER
-		await client.ConnectAsync ("127.0.0.1", port, cancellationToken).ConfigureAwait (false);
+		await tcp.ConnectAsync ("127.0.0.1", port, cancellationToken).ConfigureAwait (false);
 #else
-		await client.ConnectAsync ("127.0.0.1", port).ConfigureAwait (false);
+		await tcp.ConnectAsync ("127.0.0.1", port).ConfigureAwait (false);
 		cancellationToken.ThrowIfCancellationRequested ();
 #endif
-		stream = client.GetStream ();
+		stream = tcp.GetStream ();
+	}
+
+	/// <summary>
+	/// Closes the current connection and establishes a new one.
+	/// </summary>
+	public async Task ReconnectAsync (int port, CancellationToken cancellationToken = default)
+	{
+		CloseConnection ();
+		await ConnectAsync (port, cancellationToken).ConfigureAwait (false);
 	}
 
 	/// <summary>
@@ -49,29 +56,37 @@ internal sealed class AdbClient : IDisposable
 	public async Task SendCommandAsync (string command, CancellationToken cancellationToken = default)
 	{
 		var s = GetStream ();
+		// Combine length prefix + command into a single write to minimize syscalls
 		var commandBytes = Encoding.ASCII.GetBytes (command);
-		var header = commandBytes.Length.ToString ("x4");
-		var headerBytes = Encoding.ASCII.GetBytes (header);
-
-		await s.WriteAsync (headerBytes, 0, headerBytes.Length, cancellationToken).ConfigureAwait (false);
-		await s.WriteAsync (commandBytes, 0, commandBytes.Length, cancellationToken).ConfigureAwait (false);
+		var lengthPrefix = commandBytes.Length.ToString ("x4");
+		var packet = new byte [4 + commandBytes.Length];
+		Encoding.ASCII.GetBytes (lengthPrefix, 0, 4, packet, 0);
+		Buffer.BlockCopy (commandBytes, 0, packet, 4, commandBytes.Length);
+#if NET5_0_OR_GREATER
+		await s.WriteAsync (packet.AsMemory (), cancellationToken).ConfigureAwait (false);
+#else
+		await s.WriteAsync (packet, 0, packet.Length, cancellationToken).ConfigureAwait (false);
+#endif
 		await s.FlushAsync (cancellationToken).ConfigureAwait (false);
 	}
 
 	/// <summary>
 	/// Reads the 4-byte status response from the ADB daemon.
-	/// Returns <see cref="AdbResponseStatus.Okay"/> or <see cref="AdbResponseStatus.Fail"/>.
 	/// </summary>
 	public async Task<AdbResponseStatus> ReadStatusAsync (CancellationToken cancellationToken = default)
 	{
 		var s = GetStream ();
-		var statusBytes = await ReadExactBytesAsync (s, 4, cancellationToken).ConfigureAwait (false);
+		var statusBytes = await ReadExactBytesIntoNewArrayAsync (s, 4, cancellationToken).ConfigureAwait (false);
+		// Status is always 4 ASCII chars
+		if (statusBytes [0] == (byte) 'O' && statusBytes [1] == (byte) 'K' &&
+			statusBytes [2] == (byte) 'A' && statusBytes [3] == (byte) 'Y')
+			return AdbResponseStatus.Okay;
+		if (statusBytes [0] == (byte) 'F' && statusBytes [1] == (byte) 'A' &&
+			statusBytes [2] == (byte) 'I' && statusBytes [3] == (byte) 'L')
+			return AdbResponseStatus.Fail;
+
 		var status = Encoding.ASCII.GetString (statusBytes, 0, 4);
-		return status switch {
-			"OKAY" => AdbResponseStatus.Okay,
-			"FAIL" => AdbResponseStatus.Fail,
-			_ => throw new InvalidOperationException ($"Unexpected ADB status: '{status}'"),
-		};
+		throw new InvalidOperationException ($"Unexpected ADB status: '{status}'");
 	}
 
 	/// <summary>
@@ -100,10 +115,8 @@ internal sealed class AdbClient : IDisposable
 	/// </summary>
 	public async Task<string?> ReadLengthPrefixedStringAsync (CancellationToken cancellationToken = default)
 	{
-		var bytes = await ReadLengthPrefixedBytesAsync (cancellationToken).ConfigureAwait (false);
-		if (bytes == null)
-			return null;
-		return Encoding.ASCII.GetString (bytes, 0, bytes.Length);
+		var s = GetStream ();
+		return await ReadLengthPrefixedStringCoreAsync (s, cancellationToken).ConfigureAwait (false);
 	}
 
 	/// <summary>
@@ -113,18 +126,7 @@ internal sealed class AdbClient : IDisposable
 	public async Task<byte[]?> ReadLengthPrefixedBytesAsync (CancellationToken cancellationToken = default)
 	{
 		var s = GetStream ();
-		var lengthBytes = await ReadExactBytesOrNullAsync (s, 4, cancellationToken).ConfigureAwait (false);
-		if (lengthBytes == null)
-			return null;
-
-		var lengthHex = Encoding.ASCII.GetString (lengthBytes, 0, 4);
-		if (!int.TryParse (lengthHex, System.Globalization.NumberStyles.HexNumber, null, out var length))
-			throw new FormatException ($"Invalid ADB length prefix: '{lengthHex}'");
-
-		if (length == 0)
-			return Array.Empty<byte> ();
-
-		return await ReadExactBytesAsync (s, length, cancellationToken).ConfigureAwait (false);
+		return await ReadLengthPrefixedBytesCoreAsync (s, cancellationToken).ConfigureAwait (false);
 	}
 
 	/// <summary>
@@ -132,7 +134,7 @@ internal sealed class AdbClient : IDisposable
 	/// </summary>
 	public void Close ()
 	{
-		client.Close ();
+		CloseConnection ();
 	}
 
 	public void Dispose ()
@@ -140,8 +142,18 @@ internal sealed class AdbClient : IDisposable
 		if (disposed)
 			return;
 		disposed = true;
-		client.Close ();
-		client.Dispose ();
+		CloseConnection ();
+	}
+
+	void CloseConnection ()
+	{
+		stream = null;
+		var tcp = client;
+		client = null;
+		if (tcp != null) {
+			tcp.Close ();
+			tcp.Dispose ();
+		}
 	}
 
 	NetworkStream GetStream ()
@@ -158,11 +170,26 @@ internal sealed class AdbClient : IDisposable
 			throw new ObjectDisposedException (nameof (AdbClient));
 	}
 
+	// --- Shared core implementations (used by both instance and static methods) ---
+
 	/// <summary>
 	/// Reads a length-prefixed ASCII string from a raw stream.
-	/// Useful for testing and for callers that already have a stream.
+	/// Shared core for both instance and static access patterns.
 	/// </summary>
 	internal static async Task<string?> ReadLengthPrefixedStringFromStreamAsync (Stream stream, CancellationToken cancellationToken)
+	{
+		return await ReadLengthPrefixedStringCoreAsync (stream, cancellationToken).ConfigureAwait (false);
+	}
+
+	static async Task<string?> ReadLengthPrefixedStringCoreAsync (Stream stream, CancellationToken cancellationToken)
+	{
+		var bytes = await ReadLengthPrefixedBytesCoreAsync (stream, cancellationToken).ConfigureAwait (false);
+		if (bytes == null)
+			return null;
+		return Encoding.ASCII.GetString (bytes, 0, bytes.Length);
+	}
+
+	static async Task<byte[]?> ReadLengthPrefixedBytesCoreAsync (Stream stream, CancellationToken cancellationToken)
 	{
 		var lengthBytes = await ReadExactBytesOrNullAsync (stream, 4, cancellationToken).ConfigureAwait (false);
 		if (lengthBytes == null)
@@ -173,13 +200,12 @@ internal sealed class AdbClient : IDisposable
 			throw new FormatException ($"Invalid ADB length prefix: '{lengthHex}'");
 
 		if (length == 0)
-			return string.Empty;
+			return Array.Empty<byte> ();
 
-		var payload = await ReadExactBytesAsync (stream, length, cancellationToken).ConfigureAwait (false);
-		return Encoding.ASCII.GetString (payload, 0, payload.Length);
+		return await ReadExactBytesIntoNewArrayAsync (stream, length, cancellationToken).ConfigureAwait (false);
 	}
 
-	static async Task<byte[]> ReadExactBytesAsync (Stream stream, int count, CancellationToken cancellationToken)
+	static async Task<byte[]> ReadExactBytesIntoNewArrayAsync (Stream stream, int count, CancellationToken cancellationToken)
 	{
 		var result = await ReadExactBytesOrNullAsync (stream, count, cancellationToken).ConfigureAwait (false);
 		if (result == null)

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbClient.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbClient.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Net.Sockets;
 using System.Text;
@@ -17,8 +18,14 @@ namespace Xamarin.Android.Tools;
 /// One instance can be reused across reconnections via <see cref="ReconnectAsync"/>.
 /// Dispose closes the socket.
 /// </summary>
+/// <remarks>
+/// This class is not thread-safe. All protocol operations must be serialized by the caller.
+/// </remarks>
 internal sealed class AdbClient : IDisposable
 {
+	// Reusable 4-byte buffer for status/length reads (safe: single-caller, non-concurrent)
+	readonly byte[] headerBuffer = new byte [4];
+
 	TcpClient? client;
 	NetworkStream? stream;
 	bool disposed;
@@ -56,17 +63,24 @@ internal sealed class AdbClient : IDisposable
 	public async Task SendCommandAsync (string command, CancellationToken cancellationToken = default)
 	{
 		var s = GetStream ();
-		// Combine length prefix + command into a single write to minimize syscalls
-		var commandBytes = Encoding.ASCII.GetBytes (command);
-		var lengthPrefix = commandBytes.Length.ToString ("x4");
-		var packet = new byte [4 + commandBytes.Length];
-		Encoding.ASCII.GetBytes (lengthPrefix, 0, 4, packet, 0);
-		Buffer.BlockCopy (commandBytes, 0, packet, 4, commandBytes.Length);
+		// Compute byte count without allocating a separate commandBytes array
+		var byteCount = Encoding.ASCII.GetByteCount (command);
+		var packetLength = 4 + byteCount;
+		var packet = ArrayPool<byte>.Shared.Rent (packetLength);
+		try {
+			// Write 4-hex-digit length prefix directly into packet
+			WriteHexLength (packet, byteCount);
+			// Encode command directly into packet after the prefix
+			Encoding.ASCII.GetBytes (command, 0, command.Length, packet, 4);
 #if NET5_0_OR_GREATER
-		await s.WriteAsync (packet.AsMemory (), cancellationToken).ConfigureAwait (false);
+			await s.WriteAsync (packet.AsMemory (0, packetLength), cancellationToken).ConfigureAwait (false);
 #else
-		await s.WriteAsync (packet, 0, packet.Length, cancellationToken).ConfigureAwait (false);
+			await s.WriteAsync (packet, 0, packetLength, cancellationToken).ConfigureAwait (false);
 #endif
+		}
+		finally {
+			ArrayPool<byte>.Shared.Return (packet);
+		}
 		await s.FlushAsync (cancellationToken).ConfigureAwait (false);
 	}
 
@@ -76,16 +90,15 @@ internal sealed class AdbClient : IDisposable
 	public async Task<AdbResponseStatus> ReadStatusAsync (CancellationToken cancellationToken = default)
 	{
 		var s = GetStream ();
-		var statusBytes = await ReadExactBytesIntoNewArrayAsync (s, 4, cancellationToken).ConfigureAwait (false);
-		// Status is always 4 ASCII chars
-		if (statusBytes [0] == (byte) 'O' && statusBytes [1] == (byte) 'K' &&
-			statusBytes [2] == (byte) 'A' && statusBytes [3] == (byte) 'Y')
+		await ReadExactBytesIntoBufferAsync (s, headerBuffer, 4, cancellationToken).ConfigureAwait (false);
+		if (headerBuffer [0] == (byte) 'O' && headerBuffer [1] == (byte) 'K' &&
+			headerBuffer [2] == (byte) 'A' && headerBuffer [3] == (byte) 'Y')
 			return AdbResponseStatus.Okay;
-		if (statusBytes [0] == (byte) 'F' && statusBytes [1] == (byte) 'A' &&
-			statusBytes [2] == (byte) 'I' && statusBytes [3] == (byte) 'L')
+		if (headerBuffer [0] == (byte) 'F' && headerBuffer [1] == (byte) 'A' &&
+			headerBuffer [2] == (byte) 'I' && headerBuffer [3] == (byte) 'L')
 			return AdbResponseStatus.Fail;
 
-		var status = Encoding.ASCII.GetString (statusBytes, 0, 4);
+		var status = Encoding.ASCII.GetString (headerBuffer, 0, 4);
 		throw new InvalidOperationException ($"Unexpected ADB status: '{status}'");
 	}
 
@@ -116,17 +129,46 @@ internal sealed class AdbClient : IDisposable
 	public async Task<string?> ReadLengthPrefixedStringAsync (CancellationToken cancellationToken = default)
 	{
 		var s = GetStream ();
-		return await ReadLengthPrefixedStringCoreAsync (s, cancellationToken).ConfigureAwait (false);
+		// Read 4-byte length prefix into reusable buffer
+		if (!await TryReadExactBytesIntoBufferAsync (s, headerBuffer, 4, cancellationToken).ConfigureAwait (false))
+			return null;
+
+		var length = ParseHexLength (headerBuffer);
+
+		if (length == 0)
+			return string.Empty;
+
+		// Rent from pool, decode to string, return immediately
+		var buffer = ArrayPool<byte>.Shared.Rent (length);
+		try {
+			await ReadExactBytesIntoBufferAsync (s, buffer, length, cancellationToken).ConfigureAwait (false);
+			return Encoding.ASCII.GetString (buffer, 0, length);
+		}
+		finally {
+			ArrayPool<byte>.Shared.Return (buffer);
+		}
 	}
 
 	/// <summary>
 	/// Reads a length-prefixed byte payload from the daemon.
 	/// Returns null if the connection is closed cleanly before the length prefix.
+	/// The returned byte[] is caller-owned (not pooled).
 	/// </summary>
 	public async Task<byte[]?> ReadLengthPrefixedBytesAsync (CancellationToken cancellationToken = default)
 	{
 		var s = GetStream ();
-		return await ReadLengthPrefixedBytesCoreAsync (s, cancellationToken).ConfigureAwait (false);
+		// Read 4-byte length prefix into reusable buffer
+		if (!await TryReadExactBytesIntoBufferAsync (s, headerBuffer, 4, cancellationToken).ConfigureAwait (false))
+			return null;
+
+		var length = ParseHexLength (headerBuffer);
+
+		if (length == 0)
+			return Array.Empty<byte> ();
+
+		var result = new byte [length];
+		await ReadExactBytesIntoBufferAsync (s, result, length, cancellationToken).ConfigureAwait (false);
+		return result;
 	}
 
 	/// <summary>
@@ -170,52 +212,58 @@ internal sealed class AdbClient : IDisposable
 			throw new ObjectDisposedException (nameof (AdbClient));
 	}
 
-	// --- Shared core implementations (used by both instance and static methods) ---
+	// --- Shared core implementations (used by static method for tests) ---
 
 	/// <summary>
 	/// Reads a length-prefixed ASCII string from a raw stream.
-	/// Shared core for both instance and static access patterns.
+	/// Used by tests that cannot construct an AdbClient instance.
+	/// Allocates fresh buffers (no pooling) since it has no instance state.
 	/// </summary>
 	internal static async Task<string?> ReadLengthPrefixedStringFromStreamAsync (Stream stream, CancellationToken cancellationToken)
 	{
-		return await ReadLengthPrefixedStringCoreAsync (stream, cancellationToken).ConfigureAwait (false);
-	}
-
-	static async Task<string?> ReadLengthPrefixedStringCoreAsync (Stream stream, CancellationToken cancellationToken)
-	{
-		var bytes = await ReadLengthPrefixedBytesCoreAsync (stream, cancellationToken).ConfigureAwait (false);
-		if (bytes == null)
-			return null;
-		return Encoding.ASCII.GetString (bytes, 0, bytes.Length);
-	}
-
-	static async Task<byte[]?> ReadLengthPrefixedBytesCoreAsync (Stream stream, CancellationToken cancellationToken)
-	{
-		var lengthBytes = await ReadExactBytesOrNullAsync (stream, 4, cancellationToken).ConfigureAwait (false);
-		if (lengthBytes == null)
+		var lengthBytes = new byte [4];
+		if (!await TryReadExactBytesIntoBufferAsync (stream, lengthBytes, 4, cancellationToken).ConfigureAwait (false))
 			return null;
 
-		var lengthHex = Encoding.ASCII.GetString (lengthBytes, 0, 4);
-		if (!int.TryParse (lengthHex, System.Globalization.NumberStyles.HexNumber, null, out var length))
-			throw new FormatException ($"Invalid ADB length prefix: '{lengthHex}'");
+		var length = ParseHexLength (lengthBytes);
 
 		if (length == 0)
-			return Array.Empty<byte> ();
+			return string.Empty;
 
-		return await ReadExactBytesIntoNewArrayAsync (stream, length, cancellationToken).ConfigureAwait (false);
+		var payload = new byte [length];
+		await ReadExactBytesIntoBufferAsync (stream, payload, length, cancellationToken).ConfigureAwait (false);
+		return Encoding.ASCII.GetString (payload, 0, length);
 	}
 
-	static async Task<byte[]> ReadExactBytesIntoNewArrayAsync (Stream stream, int count, CancellationToken cancellationToken)
+	// --- Low-level I/O helpers ---
+
+	/// <summary>
+	/// Reads exactly <paramref name="count"/> bytes into the provided buffer.
+	/// Throws IOException if the stream ends prematurely.
+	/// </summary>
+	static async Task ReadExactBytesIntoBufferAsync (Stream stream, byte[] buffer, int count, CancellationToken cancellationToken)
 	{
-		var result = await ReadExactBytesOrNullAsync (stream, count, cancellationToken).ConfigureAwait (false);
-		if (result == null)
-			throw new IOException ($"Unexpected end of stream (expected {count} bytes).");
-		return result;
+		var totalRead = 0;
+		while (totalRead < count) {
+			cancellationToken.ThrowIfCancellationRequested ();
+#if NET5_0_OR_GREATER
+			var read = await stream.ReadAsync (buffer.AsMemory (totalRead, count - totalRead), cancellationToken).ConfigureAwait (false);
+#else
+			var read = await stream.ReadAsync (buffer, totalRead, count - totalRead, cancellationToken).ConfigureAwait (false);
+#endif
+			if (read == 0)
+				throw new IOException ($"Unexpected end of stream (read {totalRead} of {count} bytes).");
+			totalRead += read;
+		}
 	}
 
-	static async Task<byte[]?> ReadExactBytesOrNullAsync (Stream stream, int count, CancellationToken cancellationToken)
+	/// <summary>
+	/// Tries to read exactly <paramref name="count"/> bytes into the buffer.
+	/// Returns false if the stream ends cleanly before the first byte.
+	/// Throws IOException on partial reads.
+	/// </summary>
+	static async Task<bool> TryReadExactBytesIntoBufferAsync (Stream stream, byte[] buffer, int count, CancellationToken cancellationToken)
 	{
-		var buffer = new byte [count];
 		var totalRead = 0;
 		while (totalRead < count) {
 			cancellationToken.ThrowIfCancellationRequested ();
@@ -226,11 +274,48 @@ internal sealed class AdbClient : IDisposable
 #endif
 			if (read == 0) {
 				if (totalRead == 0)
-					return null;
+					return false;
 				throw new IOException ($"Unexpected end of stream (read {totalRead} of {count} bytes).");
 			}
 			totalRead += read;
 		}
-		return buffer;
+		return true;
+	}
+
+	// --- Hex encoding/decoding helpers (avoid string allocations) ---
+
+	static readonly byte[] HexChars = Encoding.ASCII.GetBytes ("0123456789abcdef");
+
+	/// <summary>
+	/// Writes a 4-digit lowercase hex representation of <paramref name="value"/> into the first 4 bytes of <paramref name="buffer"/>.
+	/// </summary>
+	static void WriteHexLength (byte[] buffer, int value)
+	{
+		buffer [0] = HexChars [(value >> 12) & 0xF];
+		buffer [1] = HexChars [(value >> 8) & 0xF];
+		buffer [2] = HexChars [(value >> 4) & 0xF];
+		buffer [3] = HexChars [value & 0xF];
+	}
+
+	/// <summary>
+	/// Parses a 4-byte ASCII hex length prefix without allocating a string.
+	/// </summary>
+	static int ParseHexLength (byte[] buffer)
+	{
+		var value = 0;
+		for (var i = 0; i < 4; i++) {
+			var b = buffer [i];
+			int nibble;
+			if (b >= (byte) '0' && b <= (byte) '9')
+				nibble = b - '0';
+			else if (b >= (byte) 'a' && b <= (byte) 'f')
+				nibble = b - 'a' + 10;
+			else if (b >= (byte) 'A' && b <= (byte) 'F')
+				nibble = b - 'A' + 10;
+			else
+				throw new FormatException ($"Invalid ADB length prefix: '{Encoding.ASCII.GetString (buffer, 0, 4)}'");
+			value = (value << 4) | nibble;
+		}
+		return value;
 	}
 }

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbClient.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbClient.cs
@@ -1,0 +1,210 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Xamarin.Android.Tools;
+
+/// <summary>
+/// Low-level ADB daemon socket protocol client.
+/// Encapsulates a single TCP connection to the ADB server and exposes
+/// the wire protocol operations (send command, read status, read length-prefixed payloads).
+/// One instance = one connection. Dispose closes the socket.
+/// </summary>
+internal sealed class AdbClient : IDisposable
+{
+	readonly TcpClient client;
+	NetworkStream? stream;
+	bool disposed;
+
+	public AdbClient ()
+	{
+		client = new TcpClient ();
+	}
+
+	/// <summary>
+	/// Connects to the ADB daemon at 127.0.0.1 on the specified port.
+	/// </summary>
+	public async Task ConnectAsync (int port, CancellationToken cancellationToken = default)
+	{
+		ThrowIfDisposed ();
+#if NET5_0_OR_GREATER
+		await client.ConnectAsync ("127.0.0.1", port, cancellationToken).ConfigureAwait (false);
+#else
+		await client.ConnectAsync ("127.0.0.1", port).ConfigureAwait (false);
+		cancellationToken.ThrowIfCancellationRequested ();
+#endif
+		stream = client.GetStream ();
+	}
+
+	/// <summary>
+	/// Sends a length-prefixed command to the ADB daemon.
+	/// Wire format: &lt;4-digit hex byte length&gt;&lt;command bytes&gt;
+	/// </summary>
+	public async Task SendCommandAsync (string command, CancellationToken cancellationToken = default)
+	{
+		var s = GetStream ();
+		var commandBytes = Encoding.ASCII.GetBytes (command);
+		var header = commandBytes.Length.ToString ("x4");
+		var headerBytes = Encoding.ASCII.GetBytes (header);
+
+		await s.WriteAsync (headerBytes, 0, headerBytes.Length, cancellationToken).ConfigureAwait (false);
+		await s.WriteAsync (commandBytes, 0, commandBytes.Length, cancellationToken).ConfigureAwait (false);
+		await s.FlushAsync (cancellationToken).ConfigureAwait (false);
+	}
+
+	/// <summary>
+	/// Reads the 4-byte status response from the ADB daemon.
+	/// Returns <see cref="AdbResponseStatus.Okay"/> or <see cref="AdbResponseStatus.Fail"/>.
+	/// </summary>
+	public async Task<AdbResponseStatus> ReadStatusAsync (CancellationToken cancellationToken = default)
+	{
+		var s = GetStream ();
+		var statusBytes = await ReadExactBytesAsync (s, 4, cancellationToken).ConfigureAwait (false);
+		var status = Encoding.ASCII.GetString (statusBytes, 0, 4);
+		return status switch {
+			"OKAY" => AdbResponseStatus.Okay,
+			"FAIL" => AdbResponseStatus.Fail,
+			_ => throw new InvalidOperationException ($"Unexpected ADB status: '{status}'"),
+		};
+	}
+
+	/// <summary>
+	/// Reads the failure message after a FAIL status.
+	/// </summary>
+	public async Task<string> ReadFailMessageAsync (CancellationToken cancellationToken = default)
+	{
+		return await ReadLengthPrefixedStringAsync (cancellationToken).ConfigureAwait (false) ?? string.Empty;
+	}
+
+	/// <summary>
+	/// Ensures the last status was OKAY; throws with the FAIL message otherwise.
+	/// </summary>
+	public async Task EnsureOkayAsync (CancellationToken cancellationToken = default)
+	{
+		var status = await ReadStatusAsync (cancellationToken).ConfigureAwait (false);
+		if (status == AdbResponseStatus.Fail) {
+			var message = await ReadFailMessageAsync (cancellationToken).ConfigureAwait (false);
+			throw new InvalidOperationException ($"ADB command failed: {message}");
+		}
+	}
+
+	/// <summary>
+	/// Reads a length-prefixed ASCII string payload from the daemon.
+	/// Returns null if the connection is closed cleanly before the length prefix.
+	/// </summary>
+	public async Task<string?> ReadLengthPrefixedStringAsync (CancellationToken cancellationToken = default)
+	{
+		var bytes = await ReadLengthPrefixedBytesAsync (cancellationToken).ConfigureAwait (false);
+		if (bytes == null)
+			return null;
+		return Encoding.ASCII.GetString (bytes, 0, bytes.Length);
+	}
+
+	/// <summary>
+	/// Reads a length-prefixed byte payload from the daemon.
+	/// Returns null if the connection is closed cleanly before the length prefix.
+	/// </summary>
+	public async Task<byte[]?> ReadLengthPrefixedBytesAsync (CancellationToken cancellationToken = default)
+	{
+		var s = GetStream ();
+		var lengthBytes = await ReadExactBytesOrNullAsync (s, 4, cancellationToken).ConfigureAwait (false);
+		if (lengthBytes == null)
+			return null;
+
+		var lengthHex = Encoding.ASCII.GetString (lengthBytes, 0, 4);
+		if (!int.TryParse (lengthHex, System.Globalization.NumberStyles.HexNumber, null, out var length))
+			throw new FormatException ($"Invalid ADB length prefix: '{lengthHex}'");
+
+		if (length == 0)
+			return Array.Empty<byte> ();
+
+		return await ReadExactBytesAsync (s, length, cancellationToken).ConfigureAwait (false);
+	}
+
+	/// <summary>
+	/// Forcibly closes the underlying socket, unblocking any pending reads.
+	/// </summary>
+	public void Close ()
+	{
+		client.Close ();
+	}
+
+	public void Dispose ()
+	{
+		if (disposed)
+			return;
+		disposed = true;
+		client.Close ();
+		client.Dispose ();
+	}
+
+	NetworkStream GetStream ()
+	{
+		ThrowIfDisposed ();
+		if (stream == null)
+			throw new InvalidOperationException ("Not connected. Call ConnectAsync first.");
+		return stream;
+	}
+
+	void ThrowIfDisposed ()
+	{
+		if (disposed)
+			throw new ObjectDisposedException (nameof (AdbClient));
+	}
+
+	/// <summary>
+	/// Reads a length-prefixed ASCII string from a raw stream.
+	/// Useful for testing and for callers that already have a stream.
+	/// </summary>
+	internal static async Task<string?> ReadLengthPrefixedStringFromStreamAsync (Stream stream, CancellationToken cancellationToken)
+	{
+		var lengthBytes = await ReadExactBytesOrNullAsync (stream, 4, cancellationToken).ConfigureAwait (false);
+		if (lengthBytes == null)
+			return null;
+
+		var lengthHex = Encoding.ASCII.GetString (lengthBytes, 0, 4);
+		if (!int.TryParse (lengthHex, System.Globalization.NumberStyles.HexNumber, null, out var length))
+			throw new FormatException ($"Invalid ADB length prefix: '{lengthHex}'");
+
+		if (length == 0)
+			return string.Empty;
+
+		var payload = await ReadExactBytesAsync (stream, length, cancellationToken).ConfigureAwait (false);
+		return Encoding.ASCII.GetString (payload, 0, payload.Length);
+	}
+
+	static async Task<byte[]> ReadExactBytesAsync (Stream stream, int count, CancellationToken cancellationToken)
+	{
+		var result = await ReadExactBytesOrNullAsync (stream, count, cancellationToken).ConfigureAwait (false);
+		if (result == null)
+			throw new IOException ($"Unexpected end of stream (expected {count} bytes).");
+		return result;
+	}
+
+	static async Task<byte[]?> ReadExactBytesOrNullAsync (Stream stream, int count, CancellationToken cancellationToken)
+	{
+		var buffer = new byte [count];
+		var totalRead = 0;
+		while (totalRead < count) {
+			cancellationToken.ThrowIfCancellationRequested ();
+#if NET5_0_OR_GREATER
+			var read = await stream.ReadAsync (buffer.AsMemory (totalRead, count - totalRead), cancellationToken).ConfigureAwait (false);
+#else
+			var read = await stream.ReadAsync (buffer, totalRead, count - totalRead, cancellationToken).ConfigureAwait (false);
+#endif
+			if (read == 0) {
+				if (totalRead == 0)
+					return null;
+				throw new IOException ($"Unexpected end of stream (read {totalRead} of {count} bytes).");
+			}
+			totalRead += read;
+		}
+		return buffer;
+	}
+}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbClient.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbClient.cs
@@ -128,25 +128,7 @@ internal sealed class AdbClient : IDisposable
 	/// </summary>
 	public async Task<string?> ReadLengthPrefixedStringAsync (CancellationToken cancellationToken = default)
 	{
-		var s = GetStream ();
-		// Read 4-byte length prefix into reusable buffer
-		if (!await TryReadExactBytesIntoBufferAsync (s, headerBuffer, 4, cancellationToken).ConfigureAwait (false))
-			return null;
-
-		var length = ParseHexLength (headerBuffer);
-
-		if (length == 0)
-			return string.Empty;
-
-		// Rent from pool, decode to string, return immediately
-		var buffer = ArrayPool<byte>.Shared.Rent (length);
-		try {
-			await ReadExactBytesIntoBufferAsync (s, buffer, length, cancellationToken).ConfigureAwait (false);
-			return Encoding.ASCII.GetString (buffer, 0, length);
-		}
-		finally {
-			ArrayPool<byte>.Shared.Return (buffer);
-		}
+		return await ReadLengthPrefixedStringFromStreamAsync (GetStream (), cancellationToken).ConfigureAwait (false);
 	}
 
 	/// <summary>

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbClient.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbClient.cs
@@ -23,9 +23,6 @@ namespace Xamarin.Android.Tools;
 /// </remarks>
 internal sealed class AdbClient : IDisposable
 {
-	// Reusable 4-byte buffer for status/length reads (safe: single-caller, non-concurrent)
-	readonly byte[] headerBuffer = new byte [4];
-
 	TcpClient? client;
 	NetworkStream? stream;
 	bool disposed;
@@ -90,15 +87,16 @@ internal sealed class AdbClient : IDisposable
 	public async Task<AdbResponseStatus> ReadStatusAsync (CancellationToken cancellationToken = default)
 	{
 		var s = GetStream ();
-		await ReadExactBytesIntoBufferAsync (s, headerBuffer, 4, cancellationToken).ConfigureAwait (false);
-		if (headerBuffer [0] == (byte) 'O' && headerBuffer [1] == (byte) 'K' &&
-			headerBuffer [2] == (byte) 'A' && headerBuffer [3] == (byte) 'Y')
+		var statusBuffer = new byte [4];
+		await ReadExactBytesIntoBufferAsync (s, statusBuffer, 4, cancellationToken).ConfigureAwait (false);
+		if (statusBuffer [0] == (byte) 'O' && statusBuffer [1] == (byte) 'K' &&
+			statusBuffer [2] == (byte) 'A' && statusBuffer [3] == (byte) 'Y')
 			return AdbResponseStatus.Okay;
-		if (headerBuffer [0] == (byte) 'F' && headerBuffer [1] == (byte) 'A' &&
-			headerBuffer [2] == (byte) 'I' && headerBuffer [3] == (byte) 'L')
+		if (statusBuffer [0] == (byte) 'F' && statusBuffer [1] == (byte) 'A' &&
+			statusBuffer [2] == (byte) 'I' && statusBuffer [3] == (byte) 'L')
 			return AdbResponseStatus.Fail;
 
-		var status = Encoding.ASCII.GetString (headerBuffer, 0, 4);
+		var status = Encoding.ASCII.GetString (statusBuffer, 0, 4);
 		throw new InvalidOperationException ($"Unexpected ADB status: '{status}'");
 	}
 
@@ -141,7 +139,7 @@ internal sealed class AdbClient : IDisposable
 	/// </summary>
 	public async Task<byte[]?> ReadLengthPrefixedBytesAsync (CancellationToken cancellationToken = default)
 	{
-		return await ReadLengthPrefixedBytesFromStreamAsync (GetStream (), headerBuffer, cancellationToken).ConfigureAwait (false);
+		return await ReadLengthPrefixedBytesFromStreamAsync (GetStream (), new byte [4], cancellationToken).ConfigureAwait (false);
 	}
 
 	/// <summary>
@@ -185,8 +183,6 @@ internal sealed class AdbClient : IDisposable
 			throw new ObjectDisposedException (nameof (AdbClient));
 	}
 
-	// --- Shared core implementations (used by static method for tests) ---
-
 	/// <summary>
 	/// Reads a length-prefixed ASCII string from a raw stream.
 	/// Used by tests that cannot construct an AdbClient instance.
@@ -221,8 +217,6 @@ internal sealed class AdbClient : IDisposable
 		await ReadExactBytesIntoBufferAsync (stream, result, length, cancellationToken).ConfigureAwait (false);
 		return result;
 	}
-
-	// --- Low-level I/O helpers ---
 
 	/// <summary>
 	/// Reads exactly <paramref name="count"/> bytes into the provided buffer.
@@ -264,20 +258,18 @@ internal sealed class AdbClient : IDisposable
 		return true;
 	}
 
-	// --- Hex encoding/decoding helpers (avoid string allocations) ---
-
-	static readonly byte[] HexChars = Encoding.ASCII.GetBytes ("0123456789abcdef");
-
 	/// <summary>
 	/// Writes a 4-digit lowercase hex representation of <paramref name="value"/> into the first 4 bytes of <paramref name="buffer"/>.
 	/// </summary>
 	static void WriteHexLength (byte[] buffer, int value)
 	{
-		buffer [0] = HexChars [(value >> 12) & 0xF];
-		buffer [1] = HexChars [(value >> 8) & 0xF];
-		buffer [2] = HexChars [(value >> 4) & 0xF];
-		buffer [3] = HexChars [value & 0xF];
+		buffer [0] = ToAsciiHexNibble ((value >> 12) & 0xF);
+		buffer [1] = ToAsciiHexNibble ((value >> 8) & 0xF);
+		buffer [2] = ToAsciiHexNibble ((value >> 4) & 0xF);
+		buffer [3] = ToAsciiHexNibble (value & 0xF);
 	}
+
+	static byte ToAsciiHexNibble (int value) => (byte) (value < 10 ? '0' + value : 'a' + value - 10);
 
 	/// <summary>
 	/// Parses a 4-byte ASCII hex length prefix without allocating a string.

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbClient.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbClient.cs
@@ -128,7 +128,10 @@ internal sealed class AdbClient : IDisposable
 	/// </summary>
 	public async Task<string?> ReadLengthPrefixedStringAsync (CancellationToken cancellationToken = default)
 	{
-		return await ReadLengthPrefixedStringFromStreamAsync (GetStream (), cancellationToken).ConfigureAwait (false);
+		var bytes = await ReadLengthPrefixedBytesAsync (cancellationToken).ConfigureAwait (false);
+		if (bytes == null)
+			return null;
+		return Encoding.ASCII.GetString (bytes, 0, bytes.Length);
 	}
 
 	/// <summary>
@@ -138,19 +141,7 @@ internal sealed class AdbClient : IDisposable
 	/// </summary>
 	public async Task<byte[]?> ReadLengthPrefixedBytesAsync (CancellationToken cancellationToken = default)
 	{
-		var s = GetStream ();
-		// Read 4-byte length prefix into reusable buffer
-		if (!await TryReadExactBytesIntoBufferAsync (s, headerBuffer, 4, cancellationToken).ConfigureAwait (false))
-			return null;
-
-		var length = ParseHexLength (headerBuffer);
-
-		if (length == 0)
-			return Array.Empty<byte> ();
-
-		var result = new byte [length];
-		await ReadExactBytesIntoBufferAsync (s, result, length, cancellationToken).ConfigureAwait (false);
-		return result;
+		return await ReadLengthPrefixedBytesFromStreamAsync (GetStream (), headerBuffer, cancellationToken).ConfigureAwait (false);
 	}
 
 	/// <summary>
@@ -199,22 +190,36 @@ internal sealed class AdbClient : IDisposable
 	/// <summary>
 	/// Reads a length-prefixed ASCII string from a raw stream.
 	/// Used by tests that cannot construct an AdbClient instance.
-	/// Allocates fresh buffers (no pooling) since it has no instance state.
+	/// Allocates a fresh length-prefix buffer (no pooling) since it has no instance state.
 	/// </summary>
 	internal static async Task<string?> ReadLengthPrefixedStringFromStreamAsync (Stream stream, CancellationToken cancellationToken)
 	{
-		var lengthBytes = new byte [4];
-		if (!await TryReadExactBytesIntoBufferAsync (stream, lengthBytes, 4, cancellationToken).ConfigureAwait (false))
+		var bytes = await ReadLengthPrefixedBytesFromStreamAsync (stream, new byte [4], cancellationToken).ConfigureAwait (false);
+		if (bytes == null)
+			return null;
+		return Encoding.ASCII.GetString (bytes, 0, bytes.Length);
+	}
+
+	/// <summary>
+	/// Shared core for length-prefixed payload reads. Reads a 4-byte hex length prefix
+	/// into <paramref name="lengthBuffer"/>, then reads that many bytes from <paramref name="stream"/>.
+	/// Returns null if the stream closes cleanly before the length prefix.
+	/// Returns <see cref="Array.Empty{T}"/> when the prefix is "0000".
+	/// Throws <see cref="IOException"/> if the stream ends mid-prefix or mid-payload.
+	/// </summary>
+	static async Task<byte[]?> ReadLengthPrefixedBytesFromStreamAsync (Stream stream, byte[] lengthBuffer, CancellationToken cancellationToken)
+	{
+		if (!await TryReadExactBytesIntoBufferAsync (stream, lengthBuffer, 4, cancellationToken).ConfigureAwait (false))
 			return null;
 
-		var length = ParseHexLength (lengthBytes);
+		var length = ParseHexLength (lengthBuffer);
 
 		if (length == 0)
-			return string.Empty;
+			return Array.Empty<byte> ();
 
-		var payload = new byte [length];
-		await ReadExactBytesIntoBufferAsync (stream, payload, length, cancellationToken).ConfigureAwait (false);
-		return Encoding.ASCII.GetString (payload, 0, length);
+		var result = new byte [length];
+		await ReadExactBytesIntoBufferAsync (stream, result, length, cancellationToken).ConfigureAwait (false);
+		return result;
 	}
 
 	// --- Low-level I/O helpers ---

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbClient.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbClient.cs
@@ -228,21 +228,8 @@ internal sealed class AdbClient : IDisposable
 	/// Reads exactly <paramref name="count"/> bytes into the provided buffer.
 	/// Throws IOException if the stream ends prematurely.
 	/// </summary>
-	static async Task ReadExactBytesIntoBufferAsync (Stream stream, byte[] buffer, int count, CancellationToken cancellationToken)
-	{
-		var totalRead = 0;
-		while (totalRead < count) {
-			cancellationToken.ThrowIfCancellationRequested ();
-#if NET5_0_OR_GREATER
-			var read = await stream.ReadAsync (buffer.AsMemory (totalRead, count - totalRead), cancellationToken).ConfigureAwait (false);
-#else
-			var read = await stream.ReadAsync (buffer, totalRead, count - totalRead, cancellationToken).ConfigureAwait (false);
-#endif
-			if (read == 0)
-				throw new IOException ($"Unexpected end of stream (read {totalRead} of {count} bytes).");
-			totalRead += read;
-		}
-	}
+	static Task ReadExactBytesIntoBufferAsync (Stream stream, byte[] buffer, int count, CancellationToken cancellationToken)
+		=> ReadExactBytesCoreAsync (stream, buffer, count, allowCleanEof: false, cancellationToken);
 
 	/// <summary>
 	/// Tries to read exactly <paramref name="count"/> bytes into the buffer.
@@ -250,6 +237,14 @@ internal sealed class AdbClient : IDisposable
 	/// Throws IOException on partial reads.
 	/// </summary>
 	static async Task<bool> TryReadExactBytesIntoBufferAsync (Stream stream, byte[] buffer, int count, CancellationToken cancellationToken)
+		=> await ReadExactBytesCoreAsync (stream, buffer, count, allowCleanEof: true, cancellationToken).ConfigureAwait (false);
+
+	/// <summary>
+	/// Shared core for exact-byte reads. When <paramref name="allowCleanEof"/> is true, returns false
+	/// if the stream ends before any byte has been read; otherwise throws <see cref="IOException"/>.
+	/// Partial reads (some bytes read then EOF) always throw <see cref="IOException"/>.
+	/// </summary>
+	static async Task<bool> ReadExactBytesCoreAsync (Stream stream, byte[] buffer, int count, bool allowCleanEof, CancellationToken cancellationToken)
 	{
 		var totalRead = 0;
 		while (totalRead < count) {
@@ -260,7 +255,7 @@ internal sealed class AdbClient : IDisposable
 			var read = await stream.ReadAsync (buffer, totalRead, count - totalRead, cancellationToken).ConfigureAwait (false);
 #endif
 			if (read == 0) {
-				if (totalRead == 0)
+				if (allowCleanEof && totalRead == 0)
 					return false;
 				throw new IOException ($"Unexpected end of stream (read {totalRead} of {count} bytes).");
 			}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbDeviceTracker.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbDeviceTracker.cs
@@ -5,9 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -19,30 +17,26 @@ namespace Xamarin.Android.Tools;
 /// </summary>
 public sealed class AdbDeviceTracker : IDisposable
 {
+	readonly object syncLock = new object ();
 	readonly int port;
 	readonly Action<TraceLevel, string> logger;
-	readonly string? adbPath;
-	readonly IDictionary<string, string>? environmentVariables;
-	IReadOnlyList<AdbDeviceInfo> currentDevices = Array.Empty<AdbDeviceInfo> ();
+	volatile IReadOnlyList<AdbDeviceInfo> currentDevices = Array.Empty<AdbDeviceInfo> ();
+	AdbClient? activeClient;
 	CancellationTokenSource? trackingCts;
+	bool isTracking;
 	bool disposed;
 
 	/// <summary>
 	/// Creates a new AdbDeviceTracker.
 	/// </summary>
-	/// <param name="adbPath">Optional path to the adb executable for starting the server if needed.</param>
 	/// <param name="port">ADB daemon port (default 5037).</param>
-	/// <param name="environmentVariables">Optional environment variables for adb processes.</param>
 	/// <param name="logger">Optional logger callback.</param>
-	public AdbDeviceTracker (string? adbPath = null, int port = 5037,
-		IDictionary<string, string>? environmentVariables = null,
+	public AdbDeviceTracker (int port = 5037,
 		Action<TraceLevel, string>? logger = null)
 	{
 		if (port <= 0 || port > 65535)
 			throw new ArgumentOutOfRangeException (nameof (port), "Port must be between 1 and 65535.");
-		this.adbPath = adbPath;
 		this.port = port;
-		this.environmentVariables = environmentVariables;
 		this.logger = logger ?? RunnerDefaults.NullLogger;
 	}
 
@@ -58,36 +52,52 @@ public sealed class AdbDeviceTracker : IDisposable
 	/// </summary>
 	/// <param name="onDevicesChanged">Callback invoked with the updated device list on each change.</param>
 	/// <param name="cancellationToken">Token to stop tracking.</param>
+	/// <exception cref="InvalidOperationException">Thrown if tracking is already active.</exception>
 	public async Task StartAsync (
 		Action<IReadOnlyList<AdbDeviceInfo>> onDevicesChanged,
 		CancellationToken cancellationToken = default)
 	{
 		if (onDevicesChanged == null)
 			throw new ArgumentNullException (nameof (onDevicesChanged));
-		if (disposed)
-			throw new ObjectDisposedException (nameof (AdbDeviceTracker));
 
-		trackingCts = CancellationTokenSource.CreateLinkedTokenSource (cancellationToken);
-		var token = trackingCts.Token;
+		CancellationTokenSource cts;
+		lock (syncLock) {
+			if (disposed)
+				throw new ObjectDisposedException (nameof (AdbDeviceTracker));
+			if (isTracking)
+				throw new InvalidOperationException ("Tracking is already active. Cancel the token or dispose before starting again.");
+			isTracking = true;
+			cts = CancellationTokenSource.CreateLinkedTokenSource (cancellationToken);
+			trackingCts = cts;
+		}
+
+		var token = cts.Token;
 		var backoffMs = InitialBackoffMs;
 
-		while (!token.IsCancellationRequested) {
-			try {
-				await TrackDevicesAsync (onDevicesChanged, token).ConfigureAwait (false);
-			} catch (OperationCanceledException) when (token.IsCancellationRequested) {
-				break;
-			} catch (Exception ex) {
-				logger.Invoke (TraceLevel.Warning, $"ADB tracking connection lost: {ex.Message}. Reconnecting in {backoffMs}ms...");
+		try {
+			while (!token.IsCancellationRequested) {
 				try {
-					await Task.Delay (backoffMs, token).ConfigureAwait (false);
-				} catch (OperationCanceledException) {
+					await TrackDevicesAsync (onDevicesChanged, token).ConfigureAwait (false);
+				} catch (OperationCanceledException) when (token.IsCancellationRequested) {
 					break;
+				} catch (Exception ex) when (ex is IOException || ex is SocketException || ex is ObjectDisposedException) {
+					if (token.IsCancellationRequested)
+						break;
+					logger.Invoke (TraceLevel.Warning, $"ADB tracking connection lost: {ex.Message}. Reconnecting in {backoffMs}ms...");
+					try {
+						await Task.Delay (backoffMs, token).ConfigureAwait (false);
+					} catch (OperationCanceledException) {
+						break;
+					}
+					backoffMs = Math.Min (backoffMs * 2, MaxBackoffMs);
 				}
-				backoffMs = Math.Min (backoffMs * 2, MaxBackoffMs);
-				continue;
 			}
-			// Reset backoff on clean connection
-			backoffMs = InitialBackoffMs;
+		} finally {
+			lock (syncLock) {
+				isTracking = false;
+				trackingCts = null;
+			}
+			cts.Dispose ();
 		}
 	}
 
@@ -98,92 +108,47 @@ public sealed class AdbDeviceTracker : IDisposable
 		Action<IReadOnlyList<AdbDeviceInfo>> onDevicesChanged,
 		CancellationToken cancellationToken)
 	{
-		using var client = new TcpClient ();
-#if NET5_0_OR_GREATER
-		await client.ConnectAsync ("127.0.0.1", port, cancellationToken).ConfigureAwait (false);
-#else
-		await client.ConnectAsync ("127.0.0.1", port).ConfigureAwait (false);
-		cancellationToken.ThrowIfCancellationRequested ();
-#endif
-
-		var stream = client.GetStream ();
-		logger.Invoke (TraceLevel.Verbose, "Connected to ADB daemon, sending track-devices-l command");
-
-		// Send: <4-digit hex length><command>
-		var command = "host:track-devices-l";
-		var header = command.Length.ToString ("x4") + command;
-		var headerBytes = Encoding.ASCII.GetBytes (header);
-		await stream.WriteAsync (headerBytes, 0, headerBytes.Length, cancellationToken).ConfigureAwait (false);
-		await stream.FlushAsync (cancellationToken).ConfigureAwait (false);
-
-		// Read response status (OKAY or FAIL)
-		var status = await ReadExactAsync (stream, 4, cancellationToken).ConfigureAwait (false);
-		if (status != "OKAY") {
-			var failMsg = await TryReadLengthPrefixedAsync (stream, cancellationToken).ConfigureAwait (false);
-			throw new InvalidOperationException ($"ADB daemon rejected track-devices: {status} {failMsg}");
+		var adb = new AdbClient ();
+		lock (syncLock) {
+			activeClient = adb;
 		}
+		try {
+			await adb.ConnectAsync (port, cancellationToken).ConfigureAwait (false);
+			logger.Invoke (TraceLevel.Verbose, "Connected to ADB daemon, sending track-devices-l command");
 
-		logger.Invoke (TraceLevel.Verbose, "ADB tracking active");
+			await adb.SendCommandAsync ("host:track-devices-l", cancellationToken).ConfigureAwait (false);
+			await adb.EnsureOkayAsync (cancellationToken).ConfigureAwait (false);
 
-		// Read length-prefixed device list updates
-		while (!cancellationToken.IsCancellationRequested) {
-			var payload = await TryReadLengthPrefixedAsync (stream, cancellationToken).ConfigureAwait (false);
-			if (payload == null)
-				throw new IOException ("ADB daemon closed the connection.");
+			logger.Invoke (TraceLevel.Verbose, "ADB tracking active");
 
-			var lines = payload.Split ('\n');
-			var devices = AdbRunner.ParseAdbDevicesOutput (lines);
-			currentDevices = devices;
-			onDevicesChanged (devices);
+			// Read length-prefixed device list updates
+			while (!cancellationToken.IsCancellationRequested) {
+				var payload = await adb.ReadLengthPrefixedStringAsync (cancellationToken).ConfigureAwait (false);
+				if (payload == null)
+					throw new IOException ("ADB daemon closed the connection.");
+
+				var lines = payload.Split ('\n');
+				var devices = AdbRunner.ParseAdbDevicesOutput (lines);
+				currentDevices = devices;
+				onDevicesChanged (devices);
+			}
+		} finally {
+			lock (syncLock) {
+				activeClient = null;
+			}
+			adb.Dispose ();
 		}
-	}
-
-	internal static async Task<string?> TryReadLengthPrefixedAsync (Stream stream, CancellationToken cancellationToken)
-	{
-		// Length is a 4-digit hex string
-		var lengthHex = await ReadExactOrNullAsync (stream, 4, cancellationToken).ConfigureAwait (false);
-		if (lengthHex == null)
-			return null;
-
-		if (!int.TryParse (lengthHex, System.Globalization.NumberStyles.HexNumber, null, out var length))
-			throw new FormatException ($"Invalid ADB length prefix: '{lengthHex}'");
-
-		if (length == 0)
-			return string.Empty;
-
-		return await ReadExactAsync (stream, length, cancellationToken).ConfigureAwait (false);
-	}
-
-	static async Task<string> ReadExactAsync (Stream stream, int count, CancellationToken cancellationToken)
-	{
-		var result = await ReadExactOrNullAsync (stream, count, cancellationToken).ConfigureAwait (false);
-		return result ?? throw new IOException ($"Unexpected end of stream (expected {count} bytes).");
-	}
-
-	static async Task<string?> ReadExactOrNullAsync (Stream stream, int count, CancellationToken cancellationToken)
-	{
-		var buffer = new byte [count];
-		var totalRead = 0;
-		while (totalRead < count) {
-			cancellationToken.ThrowIfCancellationRequested ();
-#if NET5_0_OR_GREATER
-			var read = await stream.ReadAsync (buffer.AsMemory (totalRead, count - totalRead), cancellationToken).ConfigureAwait (false);
-#else
-			var read = await stream.ReadAsync (buffer, totalRead, count - totalRead, cancellationToken).ConfigureAwait (false);
-#endif
-			if (read == 0)
-				return totalRead == 0 ? null : throw new IOException ($"Unexpected end of stream (read {totalRead} of {count} bytes).");
-			totalRead += read;
-		}
-		return Encoding.ASCII.GetString (buffer, 0, count);
 	}
 
 	public void Dispose ()
 	{
-		if (disposed)
-			return;
-		disposed = true;
-		trackingCts?.Cancel ();
-		trackingCts?.Dispose ();
+		lock (syncLock) {
+			if (disposed)
+				return;
+			disposed = true;
+			trackingCts?.Cancel ();
+			activeClient?.Close ();
+			trackingCts?.Dispose ();
+		}
 	}
 }

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbDeviceTracker.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbDeviceTracker.cs
@@ -20,8 +20,8 @@ public sealed class AdbDeviceTracker : IDisposable
 	readonly object syncLock = new object ();
 	readonly int port;
 	readonly Action<TraceLevel, string> logger;
+	readonly AdbClient adbClient;
 	volatile IReadOnlyList<AdbDeviceInfo> currentDevices = Array.Empty<AdbDeviceInfo> ();
-	AdbClient? activeClient;
 	CancellationTokenSource? trackingCts;
 	bool isTracking;
 	bool disposed;
@@ -38,6 +38,7 @@ public sealed class AdbDeviceTracker : IDisposable
 			throw new ArgumentOutOfRangeException (nameof (port), "Port must be between 1 and 65535.");
 		this.port = port;
 		this.logger = logger ?? RunnerDefaults.NullLogger;
+		this.adbClient = new AdbClient ();
 	}
 
 	/// <summary>
@@ -90,7 +91,9 @@ public sealed class AdbDeviceTracker : IDisposable
 						break;
 					}
 					backoffMs = Math.Min (backoffMs * 2, MaxBackoffMs);
+					continue;
 				}
+				backoffMs = InitialBackoffMs;
 			}
 		} finally {
 			lock (syncLock) {
@@ -108,35 +111,24 @@ public sealed class AdbDeviceTracker : IDisposable
 		Action<IReadOnlyList<AdbDeviceInfo>> onDevicesChanged,
 		CancellationToken cancellationToken)
 	{
-		var adb = new AdbClient ();
-		lock (syncLock) {
-			activeClient = adb;
-		}
-		try {
-			await adb.ConnectAsync (port, cancellationToken).ConfigureAwait (false);
-			logger.Invoke (TraceLevel.Verbose, "Connected to ADB daemon, sending track-devices-l command");
+		await adbClient.ReconnectAsync (port, cancellationToken).ConfigureAwait (false);
+		logger.Invoke (TraceLevel.Verbose, "Connected to ADB daemon, sending track-devices-l command");
 
-			await adb.SendCommandAsync ("host:track-devices-l", cancellationToken).ConfigureAwait (false);
-			await adb.EnsureOkayAsync (cancellationToken).ConfigureAwait (false);
+		await adbClient.SendCommandAsync ("host:track-devices-l", cancellationToken).ConfigureAwait (false);
+		await adbClient.EnsureOkayAsync (cancellationToken).ConfigureAwait (false);
 
-			logger.Invoke (TraceLevel.Verbose, "ADB tracking active");
+		logger.Invoke (TraceLevel.Verbose, "ADB tracking active");
 
-			// Read length-prefixed device list updates
-			while (!cancellationToken.IsCancellationRequested) {
-				var payload = await adb.ReadLengthPrefixedStringAsync (cancellationToken).ConfigureAwait (false);
-				if (payload == null)
-					throw new IOException ("ADB daemon closed the connection.");
+		// Read length-prefixed device list updates
+		while (!cancellationToken.IsCancellationRequested) {
+			var payload = await adbClient.ReadLengthPrefixedStringAsync (cancellationToken).ConfigureAwait (false);
+			if (payload == null)
+				throw new IOException ("ADB daemon closed the connection.");
 
-				var lines = payload.Split ('\n');
-				var devices = AdbRunner.ParseAdbDevicesOutput (lines);
-				currentDevices = devices;
-				onDevicesChanged (devices);
-			}
-		} finally {
-			lock (syncLock) {
-				activeClient = null;
-			}
-			adb.Dispose ();
+			var lines = payload.Split ('\n');
+			var devices = AdbRunner.ParseAdbDevicesOutput (lines);
+			currentDevices = devices;
+			onDevicesChanged (devices);
 		}
 	}
 
@@ -147,8 +139,9 @@ public sealed class AdbDeviceTracker : IDisposable
 				return;
 			disposed = true;
 			trackingCts?.Cancel ();
-			activeClient?.Close ();
+			adbClient.Close ();
 			trackingCts?.Dispose ();
 		}
+		adbClient.Dispose ();
 	}
 }

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbDeviceTracker.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbDeviceTracker.cs
@@ -1,0 +1,189 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Xamarin.Android.Tools;
+
+/// <summary>
+/// Monitors ADB device connections in real-time via the <c>host:track-devices-l</c> socket protocol.
+/// Pushes device list updates through a callback whenever devices connect, disconnect, or change state.
+/// </summary>
+public sealed class AdbDeviceTracker : IDisposable
+{
+	readonly int port;
+	readonly Action<TraceLevel, string> logger;
+	readonly string? adbPath;
+	readonly IDictionary<string, string>? environmentVariables;
+	IReadOnlyList<AdbDeviceInfo> currentDevices = Array.Empty<AdbDeviceInfo> ();
+	CancellationTokenSource? trackingCts;
+	bool disposed;
+
+	/// <summary>
+	/// Creates a new AdbDeviceTracker.
+	/// </summary>
+	/// <param name="adbPath">Optional path to the adb executable for starting the server if needed.</param>
+	/// <param name="port">ADB daemon port (default 5037).</param>
+	/// <param name="environmentVariables">Optional environment variables for adb processes.</param>
+	/// <param name="logger">Optional logger callback.</param>
+	public AdbDeviceTracker (string? adbPath = null, int port = 5037,
+		IDictionary<string, string>? environmentVariables = null,
+		Action<TraceLevel, string>? logger = null)
+	{
+		if (port <= 0 || port > 65535)
+			throw new ArgumentOutOfRangeException (nameof (port), "Port must be between 1 and 65535.");
+		this.adbPath = adbPath;
+		this.port = port;
+		this.environmentVariables = environmentVariables;
+		this.logger = logger ?? RunnerDefaults.NullLogger;
+	}
+
+	/// <summary>
+	/// Current snapshot of tracked devices.
+	/// </summary>
+	public IReadOnlyList<AdbDeviceInfo> CurrentDevices => currentDevices;
+
+	/// <summary>
+	/// Starts tracking device changes. Calls <paramref name="onDevicesChanged"/> whenever
+	/// the device list changes. Blocks until cancelled or disposed.
+	/// Automatically reconnects on connection drops with exponential backoff.
+	/// </summary>
+	/// <param name="onDevicesChanged">Callback invoked with the updated device list on each change.</param>
+	/// <param name="cancellationToken">Token to stop tracking.</param>
+	public async Task StartAsync (
+		Action<IReadOnlyList<AdbDeviceInfo>> onDevicesChanged,
+		CancellationToken cancellationToken = default)
+	{
+		if (onDevicesChanged == null)
+			throw new ArgumentNullException (nameof (onDevicesChanged));
+		if (disposed)
+			throw new ObjectDisposedException (nameof (AdbDeviceTracker));
+
+		trackingCts = CancellationTokenSource.CreateLinkedTokenSource (cancellationToken);
+		var token = trackingCts.Token;
+		var backoffMs = InitialBackoffMs;
+
+		while (!token.IsCancellationRequested) {
+			try {
+				await TrackDevicesAsync (onDevicesChanged, token).ConfigureAwait (false);
+			} catch (OperationCanceledException) when (token.IsCancellationRequested) {
+				break;
+			} catch (Exception ex) {
+				logger.Invoke (TraceLevel.Warning, $"ADB tracking connection lost: {ex.Message}. Reconnecting in {backoffMs}ms...");
+				try {
+					await Task.Delay (backoffMs, token).ConfigureAwait (false);
+				} catch (OperationCanceledException) {
+					break;
+				}
+				backoffMs = Math.Min (backoffMs * 2, MaxBackoffMs);
+				continue;
+			}
+			// Reset backoff on clean connection
+			backoffMs = InitialBackoffMs;
+		}
+	}
+
+	const int InitialBackoffMs = 500;
+	const int MaxBackoffMs = 16000;
+
+	async Task TrackDevicesAsync (
+		Action<IReadOnlyList<AdbDeviceInfo>> onDevicesChanged,
+		CancellationToken cancellationToken)
+	{
+		using var client = new TcpClient ();
+#if NET5_0_OR_GREATER
+		await client.ConnectAsync ("127.0.0.1", port, cancellationToken).ConfigureAwait (false);
+#else
+		await client.ConnectAsync ("127.0.0.1", port).ConfigureAwait (false);
+		cancellationToken.ThrowIfCancellationRequested ();
+#endif
+
+		var stream = client.GetStream ();
+		logger.Invoke (TraceLevel.Verbose, "Connected to ADB daemon, sending track-devices-l command");
+
+		// Send: <4-digit hex length><command>
+		var command = "host:track-devices-l";
+		var header = command.Length.ToString ("x4") + command;
+		var headerBytes = Encoding.ASCII.GetBytes (header);
+		await stream.WriteAsync (headerBytes, 0, headerBytes.Length, cancellationToken).ConfigureAwait (false);
+		await stream.FlushAsync (cancellationToken).ConfigureAwait (false);
+
+		// Read response status (OKAY or FAIL)
+		var status = await ReadExactAsync (stream, 4, cancellationToken).ConfigureAwait (false);
+		if (status != "OKAY") {
+			var failMsg = await TryReadLengthPrefixedAsync (stream, cancellationToken).ConfigureAwait (false);
+			throw new InvalidOperationException ($"ADB daemon rejected track-devices: {status} {failMsg}");
+		}
+
+		logger.Invoke (TraceLevel.Verbose, "ADB tracking active");
+
+		// Read length-prefixed device list updates
+		while (!cancellationToken.IsCancellationRequested) {
+			var payload = await TryReadLengthPrefixedAsync (stream, cancellationToken).ConfigureAwait (false);
+			if (payload == null)
+				throw new IOException ("ADB daemon closed the connection.");
+
+			var lines = payload.Split ('\n');
+			var devices = AdbRunner.ParseAdbDevicesOutput (lines);
+			currentDevices = devices;
+			onDevicesChanged (devices);
+		}
+	}
+
+	internal static async Task<string?> TryReadLengthPrefixedAsync (Stream stream, CancellationToken cancellationToken)
+	{
+		// Length is a 4-digit hex string
+		var lengthHex = await ReadExactOrNullAsync (stream, 4, cancellationToken).ConfigureAwait (false);
+		if (lengthHex == null)
+			return null;
+
+		if (!int.TryParse (lengthHex, System.Globalization.NumberStyles.HexNumber, null, out var length))
+			throw new FormatException ($"Invalid ADB length prefix: '{lengthHex}'");
+
+		if (length == 0)
+			return string.Empty;
+
+		return await ReadExactAsync (stream, length, cancellationToken).ConfigureAwait (false);
+	}
+
+	static async Task<string> ReadExactAsync (Stream stream, int count, CancellationToken cancellationToken)
+	{
+		var result = await ReadExactOrNullAsync (stream, count, cancellationToken).ConfigureAwait (false);
+		return result ?? throw new IOException ($"Unexpected end of stream (expected {count} bytes).");
+	}
+
+	static async Task<string?> ReadExactOrNullAsync (Stream stream, int count, CancellationToken cancellationToken)
+	{
+		var buffer = new byte [count];
+		var totalRead = 0;
+		while (totalRead < count) {
+			cancellationToken.ThrowIfCancellationRequested ();
+#if NET5_0_OR_GREATER
+			var read = await stream.ReadAsync (buffer.AsMemory (totalRead, count - totalRead), cancellationToken).ConfigureAwait (false);
+#else
+			var read = await stream.ReadAsync (buffer, totalRead, count - totalRead, cancellationToken).ConfigureAwait (false);
+#endif
+			if (read == 0)
+				return totalRead == 0 ? null : throw new IOException ($"Unexpected end of stream (read {totalRead} of {count} bytes).");
+			totalRead += read;
+		}
+		return Encoding.ASCII.GetString (buffer, 0, count);
+	}
+
+	public void Dispose ()
+	{
+		if (disposed)
+			return;
+		disposed = true;
+		trackingCts?.Cancel ();
+		trackingCts?.Dispose ();
+	}
+}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbDeviceTracker.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbDeviceTracker.cs
@@ -79,11 +79,16 @@ public sealed class AdbDeviceTracker : IDisposable
 			while (!token.IsCancellationRequested) {
 				try {
 					await ConnectAndHandshakeAsync (token).ConfigureAwait (false);
-					// Reset backoff only after a fully successful connection + protocol handshake,
-					// so a long-lived session that drops after hours starts retrying from InitialBackoffMs
-					// instead of using the accumulated backoff from the previous reconnect storm.
-					backoffMs = InitialBackoffMs;
-					await ReadTrackingUpdatesAsync (onDevicesChanged, token).ConfigureAwait (false);
+					await ReadTrackingUpdatesAsync (
+						onDevicesChanged,
+						// Reset backoff only after the first payload is delivered — proof that the
+						// session is actually usable, not just that the TCP socket accepted us.
+						// Resetting at handshake (OKAY) would let a daemon that flaps OKAY-then-drop
+						// pin reconnects at InitialBackoffMs forever instead of climbing to MaxBackoffMs.
+						// host:track-devices-l always pushes the full device list immediately on
+						// connect, so under healthy conditions this fires within milliseconds.
+						onConnectionStable: () => backoffMs = InitialBackoffMs,
+						token).ConfigureAwait (false);
 				} catch (OperationCanceledException) when (token.IsCancellationRequested) {
 					break;
 				} catch (Exception ex) when (ex is IOException || ex is SocketException || ex is ObjectDisposedException) {
@@ -123,13 +128,20 @@ public sealed class AdbDeviceTracker : IDisposable
 
 	async Task ReadTrackingUpdatesAsync (
 		Action<IReadOnlyList<AdbDeviceInfo>> onDevicesChanged,
+		Action onConnectionStable,
 		CancellationToken cancellationToken)
 	{
+		var connectionProven = false;
 		// Read length-prefixed device list updates
 		while (!cancellationToken.IsCancellationRequested) {
 			var payload = await adbClient.ReadLengthPrefixedStringAsync (cancellationToken).ConfigureAwait (false);
 			if (payload == null)
 				throw new IOException ("ADB daemon closed the connection.");
+
+			if (!connectionProven) {
+				onConnectionStable ();
+				connectionProven = true;
+			}
 
 			var lines = payload.Split ('\n');
 			var devices = AdbRunner.ParseAdbDevicesOutput (lines);

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbDeviceTracker.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbDeviceTracker.cs
@@ -78,7 +78,12 @@ public sealed class AdbDeviceTracker : IDisposable
 		try {
 			while (!token.IsCancellationRequested) {
 				try {
-					await TrackDevicesAsync (onDevicesChanged, token).ConfigureAwait (false);
+					await ConnectAndHandshakeAsync (token).ConfigureAwait (false);
+					// Reset backoff only after a fully successful connection + protocol handshake,
+					// so a long-lived session that drops after hours starts retrying from InitialBackoffMs
+					// instead of using the accumulated backoff from the previous reconnect storm.
+					backoffMs = InitialBackoffMs;
+					await ReadTrackingUpdatesAsync (onDevicesChanged, token).ConfigureAwait (false);
 				} catch (OperationCanceledException) when (token.IsCancellationRequested) {
 					break;
 				} catch (Exception ex) when (ex is IOException || ex is SocketException || ex is ObjectDisposedException) {
@@ -91,9 +96,7 @@ public sealed class AdbDeviceTracker : IDisposable
 						break;
 					}
 					backoffMs = Math.Min (backoffMs * 2, MaxBackoffMs);
-					continue;
 				}
-				backoffMs = InitialBackoffMs;
 			}
 		} finally {
 			lock (syncLock) {
@@ -107,9 +110,7 @@ public sealed class AdbDeviceTracker : IDisposable
 	const int InitialBackoffMs = 500;
 	const int MaxBackoffMs = 16000;
 
-	async Task TrackDevicesAsync (
-		Action<IReadOnlyList<AdbDeviceInfo>> onDevicesChanged,
-		CancellationToken cancellationToken)
+	async Task ConnectAndHandshakeAsync (CancellationToken cancellationToken)
 	{
 		await adbClient.ReconnectAsync (port, cancellationToken).ConfigureAwait (false);
 		logger.Invoke (TraceLevel.Verbose, "Connected to ADB daemon, sending track-devices-l command");
@@ -118,7 +119,12 @@ public sealed class AdbDeviceTracker : IDisposable
 		await adbClient.EnsureOkayAsync (cancellationToken).ConfigureAwait (false);
 
 		logger.Invoke (TraceLevel.Verbose, "ADB tracking active");
+	}
 
+	async Task ReadTrackingUpdatesAsync (
+		Action<IReadOnlyList<AdbDeviceInfo>> onDevicesChanged,
+		CancellationToken cancellationToken)
+	{
 		// Read length-prefixed device list updates
 		while (!cancellationToken.IsCancellationRequested) {
 			var payload = await adbClient.ReadLengthPrefixedStringAsync (cancellationToken).ConfigureAwait (false);

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbResponseStatus.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbResponseStatus.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Xamarin.Android.Tools;
+
+/// <summary>
+/// Status response from the ADB daemon after sending a command.
+/// </summary>
+internal enum AdbResponseStatus
+{
+	Okay,
+	Fail,
+}

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AdbClientTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AdbClientTests.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Xamarin.Android.Tools.Tests;
+
+[TestFixture]
+public class AdbClientTests
+{
+	[Test]
+	public async Task ReadLengthPrefixedStringFromStreamAsync_ValidPayload ()
+	{
+		var payload = "emulator-5554\tdevice\n";
+		var hex = payload.Length.ToString ("x4");
+		var data = Encoding.ASCII.GetBytes (hex + payload);
+		using var stream = new MemoryStream (data);
+
+		var result = await AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None);
+		Assert.AreEqual (payload, result);
+	}
+
+	[Test]
+	public async Task ReadLengthPrefixedStringFromStreamAsync_EmptyPayload ()
+	{
+		var data = Encoding.ASCII.GetBytes ("0000");
+		using var stream = new MemoryStream (data);
+
+		var result = await AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None);
+		Assert.AreEqual (string.Empty, result);
+	}
+
+	[Test]
+	public async Task ReadLengthPrefixedStringFromStreamAsync_EndOfStream_ReturnsNull ()
+	{
+		using var stream = new MemoryStream (Array.Empty<byte> ());
+
+		var result = await AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None);
+		Assert.IsNull (result);
+	}
+
+	[Test]
+	public async Task ReadLengthPrefixedStringFromStreamAsync_MultipleDevices ()
+	{
+		var payload =
+			"0A041FDD400327\tdevice product:redfin model:Pixel_5 device:redfin transport_id:2\n" +
+			"emulator-5554\tdevice product:sdk_gphone64_x86_64 model:sdk_gphone64_x86_64 device:emu64xa transport_id:1\n";
+		var hex = payload.Length.ToString ("x4");
+		var data = Encoding.ASCII.GetBytes (hex + payload);
+		using var stream = new MemoryStream (data);
+
+		var result = await AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None);
+		Assert.IsNotNull (result);
+
+		var devices = AdbRunner.ParseAdbDevicesOutput (result!.Split ('\n'));
+		Assert.AreEqual (2, devices.Count);
+		Assert.AreEqual ("0A041FDD400327", devices [0].Serial);
+		Assert.AreEqual ("emulator-5554", devices [1].Serial);
+	}
+
+	[Test]
+	public void ReadLengthPrefixedStringFromStreamAsync_InvalidHex_ThrowsFormatException ()
+	{
+		var data = Encoding.ASCII.GetBytes ("ZZZZ");
+		using var stream = new MemoryStream (data);
+
+		Assert.ThrowsAsync<FormatException> (
+			() => AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None));
+	}
+
+	[Test]
+	public void ReadLengthPrefixedStringFromStreamAsync_TruncatedPayload_ThrowsIOException ()
+	{
+		// Header says 100 bytes but only 5 are present
+		var data = Encoding.ASCII.GetBytes ("0064hello");
+		using var stream = new MemoryStream (data);
+
+		Assert.ThrowsAsync<IOException> (
+			() => AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None));
+	}
+}

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AdbDeviceTrackerTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AdbDeviceTrackerTests.cs
@@ -45,6 +45,24 @@ public class AdbDeviceTrackerTests
 	}
 
 	[Test]
+	public async Task StartAsync_CalledTwice_ThrowsInvalidOperationException ()
+	{
+		// Use a port where nothing is listening so ConnectAsync yields quickly
+		using var tracker = new AdbDeviceTracker (port: 59999);
+		using var cts = new CancellationTokenSource ();
+
+		// First call sets isTracking synchronously before the first await
+		var trackingTask = tracker.StartAsync (_ => { }, cts.Token);
+
+		// Second call should throw because tracking is already active
+		Assert.ThrowsAsync<InvalidOperationException> (
+			() => tracker.StartAsync (_ => { }, cts.Token));
+
+		cts.Cancel ();
+		try { await trackingTask.ConfigureAwait (false); } catch (OperationCanceledException) { }
+	}
+
+	[Test]
 	public void Dispose_MultipleTimes_DoesNotThrow ()
 	{
 		var tracker = new AdbDeviceTracker ();
@@ -52,41 +70,41 @@ public class AdbDeviceTrackerTests
 		Assert.DoesNotThrow (() => tracker.Dispose ());
 	}
 
-	// --- TryReadLengthPrefixedAsync tests ---
+	// --- AdbClient protocol tests ---
 
 	[Test]
-	public async Task TryReadLengthPrefixedAsync_ValidPayload ()
+	public async Task ReadLengthPrefixedStringFromStreamAsync_ValidPayload ()
 	{
 		var payload = "emulator-5554\tdevice\n";
 		var hex = payload.Length.ToString ("x4");
 		var data = Encoding.ASCII.GetBytes (hex + payload);
 		using var stream = new MemoryStream (data);
 
-		var result = await AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None);
+		var result = await AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None);
 		Assert.AreEqual (payload, result);
 	}
 
 	[Test]
-	public async Task TryReadLengthPrefixedAsync_EmptyPayload ()
+	public async Task ReadLengthPrefixedStringFromStreamAsync_EmptyPayload ()
 	{
 		var data = Encoding.ASCII.GetBytes ("0000");
 		using var stream = new MemoryStream (data);
 
-		var result = await AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None);
+		var result = await AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None);
 		Assert.AreEqual (string.Empty, result);
 	}
 
 	[Test]
-	public async Task TryReadLengthPrefixedAsync_EndOfStream_ReturnsNull ()
+	public async Task ReadLengthPrefixedStringFromStreamAsync_EndOfStream_ReturnsNull ()
 	{
 		using var stream = new MemoryStream (Array.Empty<byte> ());
 
-		var result = await AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None);
+		var result = await AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None);
 		Assert.IsNull (result);
 	}
 
 	[Test]
-	public async Task TryReadLengthPrefixedAsync_MultipleDevices ()
+	public async Task ReadLengthPrefixedStringFromStreamAsync_MultipleDevices ()
 	{
 		var payload =
 			"0A041FDD400327\tdevice product:redfin model:Pixel_5 device:redfin transport_id:2\n" +
@@ -95,7 +113,7 @@ public class AdbDeviceTrackerTests
 		var data = Encoding.ASCII.GetBytes (hex + payload);
 		using var stream = new MemoryStream (data);
 
-		var result = await AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None);
+		var result = await AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None);
 		Assert.IsNotNull (result);
 
 		var devices = AdbRunner.ParseAdbDevicesOutput (result!.Split ('\n'));
@@ -105,23 +123,23 @@ public class AdbDeviceTrackerTests
 	}
 
 	[Test]
-	public void TryReadLengthPrefixedAsync_InvalidHex_ThrowsFormatException ()
+	public void ReadLengthPrefixedStringFromStreamAsync_InvalidHex_ThrowsFormatException ()
 	{
 		var data = Encoding.ASCII.GetBytes ("ZZZZ");
 		using var stream = new MemoryStream (data);
 
 		Assert.ThrowsAsync<FormatException> (
-			() => AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None));
+			() => AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None));
 	}
 
 	[Test]
-	public void TryReadLengthPrefixedAsync_TruncatedPayload_ThrowsIOException ()
+	public void ReadLengthPrefixedStringFromStreamAsync_TruncatedPayload_ThrowsIOException ()
 	{
 		// Header says 100 bytes but only 5 are present
 		var data = Encoding.ASCII.GetBytes ("0064hello");
 		using var stream = new MemoryStream (data);
 
 		Assert.ThrowsAsync<IOException> (
-			() => AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None));
+			() => AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None));
 	}
 }

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AdbDeviceTrackerTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AdbDeviceTrackerTests.cs
@@ -1,0 +1,127 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Xamarin.Android.Tools.Tests;
+
+[TestFixture]
+public class AdbDeviceTrackerTests
+{
+	[Test]
+	public void Constructor_InvalidPort_ThrowsArgumentOutOfRangeException ()
+	{
+		Assert.Throws<ArgumentOutOfRangeException> (() => new AdbDeviceTracker (port: 0));
+		Assert.Throws<ArgumentOutOfRangeException> (() => new AdbDeviceTracker (port: -1));
+		Assert.Throws<ArgumentOutOfRangeException> (() => new AdbDeviceTracker (port: 70000));
+	}
+
+	[Test]
+	public void Constructor_ValidPort_Succeeds ()
+	{
+		using var tracker = new AdbDeviceTracker (port: 5037);
+		Assert.IsNotNull (tracker);
+		Assert.AreEqual (0, tracker.CurrentDevices.Count);
+	}
+
+	[Test]
+	public void StartAsync_NullCallback_ThrowsArgumentNullException ()
+	{
+		using var tracker = new AdbDeviceTracker ();
+		Assert.ThrowsAsync<ArgumentNullException> (() => tracker.StartAsync (null!));
+	}
+
+	[Test]
+	public void StartAsync_AfterDispose_ThrowsObjectDisposedException ()
+	{
+		var tracker = new AdbDeviceTracker ();
+		tracker.Dispose ();
+		Assert.ThrowsAsync<ObjectDisposedException> (() => tracker.StartAsync (_ => { }));
+	}
+
+	[Test]
+	public void Dispose_MultipleTimes_DoesNotThrow ()
+	{
+		var tracker = new AdbDeviceTracker ();
+		tracker.Dispose ();
+		Assert.DoesNotThrow (() => tracker.Dispose ());
+	}
+
+	// --- TryReadLengthPrefixedAsync tests ---
+
+	[Test]
+	public async Task TryReadLengthPrefixedAsync_ValidPayload ()
+	{
+		var payload = "emulator-5554\tdevice\n";
+		var hex = payload.Length.ToString ("x4");
+		var data = Encoding.ASCII.GetBytes (hex + payload);
+		using var stream = new MemoryStream (data);
+
+		var result = await AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None);
+		Assert.AreEqual (payload, result);
+	}
+
+	[Test]
+	public async Task TryReadLengthPrefixedAsync_EmptyPayload ()
+	{
+		var data = Encoding.ASCII.GetBytes ("0000");
+		using var stream = new MemoryStream (data);
+
+		var result = await AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None);
+		Assert.AreEqual (string.Empty, result);
+	}
+
+	[Test]
+	public async Task TryReadLengthPrefixedAsync_EndOfStream_ReturnsNull ()
+	{
+		using var stream = new MemoryStream (Array.Empty<byte> ());
+
+		var result = await AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None);
+		Assert.IsNull (result);
+	}
+
+	[Test]
+	public async Task TryReadLengthPrefixedAsync_MultipleDevices ()
+	{
+		var payload =
+			"0A041FDD400327\tdevice product:redfin model:Pixel_5 device:redfin transport_id:2\n" +
+			"emulator-5554\tdevice product:sdk_gphone64_x86_64 model:sdk_gphone64_x86_64 device:emu64xa transport_id:1\n";
+		var hex = payload.Length.ToString ("x4");
+		var data = Encoding.ASCII.GetBytes (hex + payload);
+		using var stream = new MemoryStream (data);
+
+		var result = await AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None);
+		Assert.IsNotNull (result);
+
+		var devices = AdbRunner.ParseAdbDevicesOutput (result!.Split ('\n'));
+		Assert.AreEqual (2, devices.Count);
+		Assert.AreEqual ("0A041FDD400327", devices [0].Serial);
+		Assert.AreEqual ("emulator-5554", devices [1].Serial);
+	}
+
+	[Test]
+	public void TryReadLengthPrefixedAsync_InvalidHex_ThrowsFormatException ()
+	{
+		var data = Encoding.ASCII.GetBytes ("ZZZZ");
+		using var stream = new MemoryStream (data);
+
+		Assert.ThrowsAsync<FormatException> (
+			() => AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None));
+	}
+
+	[Test]
+	public void TryReadLengthPrefixedAsync_TruncatedPayload_ThrowsIOException ()
+	{
+		// Header says 100 bytes but only 5 are present
+		var data = Encoding.ASCII.GetBytes ("0064hello");
+		using var stream = new MemoryStream (data);
+
+		Assert.ThrowsAsync<IOException> (
+			() => AdbDeviceTracker.TryReadLengthPrefixedAsync (stream, CancellationToken.None));
+	}
+}

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AdbDeviceTrackerTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AdbDeviceTrackerTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -68,78 +66,5 @@ public class AdbDeviceTrackerTests
 		var tracker = new AdbDeviceTracker ();
 		tracker.Dispose ();
 		Assert.DoesNotThrow (() => tracker.Dispose ());
-	}
-
-	// --- AdbClient protocol tests ---
-
-	[Test]
-	public async Task ReadLengthPrefixedStringFromStreamAsync_ValidPayload ()
-	{
-		var payload = "emulator-5554\tdevice\n";
-		var hex = payload.Length.ToString ("x4");
-		var data = Encoding.ASCII.GetBytes (hex + payload);
-		using var stream = new MemoryStream (data);
-
-		var result = await AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None);
-		Assert.AreEqual (payload, result);
-	}
-
-	[Test]
-	public async Task ReadLengthPrefixedStringFromStreamAsync_EmptyPayload ()
-	{
-		var data = Encoding.ASCII.GetBytes ("0000");
-		using var stream = new MemoryStream (data);
-
-		var result = await AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None);
-		Assert.AreEqual (string.Empty, result);
-	}
-
-	[Test]
-	public async Task ReadLengthPrefixedStringFromStreamAsync_EndOfStream_ReturnsNull ()
-	{
-		using var stream = new MemoryStream (Array.Empty<byte> ());
-
-		var result = await AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None);
-		Assert.IsNull (result);
-	}
-
-	[Test]
-	public async Task ReadLengthPrefixedStringFromStreamAsync_MultipleDevices ()
-	{
-		var payload =
-			"0A041FDD400327\tdevice product:redfin model:Pixel_5 device:redfin transport_id:2\n" +
-			"emulator-5554\tdevice product:sdk_gphone64_x86_64 model:sdk_gphone64_x86_64 device:emu64xa transport_id:1\n";
-		var hex = payload.Length.ToString ("x4");
-		var data = Encoding.ASCII.GetBytes (hex + payload);
-		using var stream = new MemoryStream (data);
-
-		var result = await AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None);
-		Assert.IsNotNull (result);
-
-		var devices = AdbRunner.ParseAdbDevicesOutput (result!.Split ('\n'));
-		Assert.AreEqual (2, devices.Count);
-		Assert.AreEqual ("0A041FDD400327", devices [0].Serial);
-		Assert.AreEqual ("emulator-5554", devices [1].Serial);
-	}
-
-	[Test]
-	public void ReadLengthPrefixedStringFromStreamAsync_InvalidHex_ThrowsFormatException ()
-	{
-		var data = Encoding.ASCII.GetBytes ("ZZZZ");
-		using var stream = new MemoryStream (data);
-
-		Assert.ThrowsAsync<FormatException> (
-			() => AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None));
-	}
-
-	[Test]
-	public void ReadLengthPrefixedStringFromStreamAsync_TruncatedPayload_ThrowsIOException ()
-	{
-		// Header says 100 bytes but only 5 are present
-		var data = Encoding.ASCII.GetBytes ("0064hello");
-		using var stream = new MemoryStream (data);
-
-		Assert.ThrowsAsync<IOException> (
-			() => AdbClient.ReadLengthPrefixedStringFromStreamAsync (stream, CancellationToken.None));
 	}
 }


### PR DESCRIPTION
## Summary

Add support for real-time device connection/disconnection monitoring via the ADB daemon socket protocol (`host:track-devices-l`).

### Changes
- Added `AdbDeviceTracker` class implementing `IDisposable`
- Added `AdbClient` internal class encapsulating ADB daemon TCP socket protocol
- Socket connection to `localhost:5037` (ADB daemon)
- Sends `host:track-devices-l` command and reads length-prefixed device list updates
- Callback-based `StartAsync()` with `CancellationToken` support
- `CurrentDevices` snapshot property for current device state
- Auto-reconnect with exponential backoff (500ms to 16s) on connection drops
- Reuses existing `AdbRunner.ParseAdbDevicesOutput()` for parsing
- Unit tests covering protocol parsing, lifecycle, and edge cases
- Updated `PublicAPI.Unshipped.txt` for both `net10.0` and `netstandard2.0`

### API
```csharp
public sealed class AdbDeviceTracker : IDisposable
{
    public AdbDeviceTracker(int port = 5037, Action<TraceLevel, string>? logger = null);
    public IReadOnlyList<AdbDeviceInfo> CurrentDevices { get; }
    public Task StartAsync(Action<IReadOnlyList<AdbDeviceInfo>> onDevicesChanged, CancellationToken cancellationToken = default);
    public void Dispose();
}
```

Closes #323
