### PR TITLE
Validate extracted zip entry paths in Files.ExtractAll

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -441,14 +441,22 @@ namespace Microsoft.Android.Build.Tasks
 			}
 		}
 
+		[Obsolete ("Use the overload that accepts a TaskLoggingHelper parameter.")]
+		public static bool ExtractAll (ZipArchive zip, string destination, Action<int, int> progressCallback,
+			Func<string, string> modifyCallback, Func<string, bool> deleteCallback, Func<string, bool> skipCallback)
+		{
+			return ExtractAll (zip, destination, progressCallback, modifyCallback, deleteCallback, skipCallback, log: null);
+		}
+
 		public static bool ExtractAll (ZipArchive zip, string destination, Action<int, int> progressCallback = null, Func<string, string> modifyCallback = null,
-			Func<string, bool> deleteCallback = null, Func<string, bool> skipCallback = null)
+			Func<string, bool> deleteCallback = null, Func<string, bool> skipCallback = null, TaskLoggingHelper log = null)
 		{
 			int i = 0;
 			int total = (int)zip.EntryCount;
 			bool updated = false;
 			var files = new HashSet<string> ();
 			var memoryStream = MemoryStreamPool.Shared.Rent ();
+			var fullDestination = Path.GetFullPath (destination + Path.DirectorySeparatorChar);
 			try {
 				foreach (var entry in zip) {
 					progressCallback?.Invoke (i++, total);
@@ -463,6 +471,10 @@ namespace Microsoft.Android.Build.Tasks
 						continue;
 					var fullName = modifyCallback?.Invoke (entry.FullName) ?? entry.FullName;
 					var outfile = Path.GetFullPath (Path.Combine (destination, fullName));
+					if (!outfile.StartsWith (fullDestination, StringComparison.OrdinalIgnoreCase)) {
+						log?.LogWarning ($"Skipping zip entry \"{entry.FullName}\" (resolved as \"{fullName}\") because it would extract outside the destination directory: \"{outfile}\".");
+						continue;
+					}
 					files.Add (outfile);
 					memoryStream.SetLength (0); //Reuse the stream
 					entry.Extract (memoryStream);

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
@@ -626,6 +626,76 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 		}
 
 		[Test]
+		public void ExtractAll_SkipsPathTraversal ()
+		{
+			using (var zip = ZipArchive.Create (stream)) {
+				zip.AddEntry ("a.txt", "a", encoding);
+			}
+
+			var destinationDir = Path.Combine (tempDir, "dest");
+			stream.Position = 0;
+			using (var zip = ZipArchive.Open (stream)) {
+				// modifyCallback introduces a path traversal
+				bool changes = Files.ExtractAll (zip, destinationDir, modifyCallback: e => "../" + e);
+				Assert.IsFalse (changes, "ExtractAll should not report changes for skipped entries.");
+			}
+			FileAssert.DoesNotExist (Path.Combine (tempDir, "a.txt"));
+		}
+
+		[Test]
+		public void ExtractAll_SkipsPathTraversal_ExtractsValidEntries ()
+		{
+			using (var zip = ZipArchive.Create (stream)) {
+				zip.AddEntry ("good.txt", "good", encoding);
+				zip.AddEntry ("evil.txt", "evil", encoding);
+			}
+
+			var destinationDir = Path.Combine (tempDir, "dest");
+			stream.Position = 0;
+			using (var zip = ZipArchive.Open (stream)) {
+				// Only evil.txt gets a traversal prefix
+				bool changes = Files.ExtractAll (zip, destinationDir, modifyCallback: e =>
+					e == "evil.txt" ? "../" + e : e);
+				Assert.IsTrue (changes, "ExtractAll should report changes for the valid entry.");
+			}
+			AssertFile (Path.Combine ("dest", "good.txt"), "good");
+			FileAssert.DoesNotExist (Path.Combine (tempDir, "evil.txt"));
+		}
+
+		[TestCase ("../../")]
+		[TestCase ("foo/../../../")]
+		public void ExtractAll_SkipsPathTraversal_ForwardSlash (string prefix)
+		{
+			using (var zip = ZipArchive.Create (stream)) {
+				zip.AddEntry ("a.txt", "a", encoding);
+			}
+
+			var destinationDir = Path.Combine (tempDir, "dest");
+			stream.Position = 0;
+			using (var zip = ZipArchive.Open (stream)) {
+				bool changes = Files.ExtractAll (zip, destinationDir, modifyCallback: e => prefix + e);
+				Assert.IsFalse (changes, $"Entry with prefix '{prefix}' should be skipped.");
+			}
+		}
+
+		[TestCase ("..\\")]
+		[TestCase ("..\\..\\")]
+		[Platform ("Win")]
+		public void ExtractAll_SkipsPathTraversal_BackSlash (string prefix)
+		{
+			using (var zip = ZipArchive.Create (stream)) {
+				zip.AddEntry ("a.txt", "a", encoding);
+			}
+
+			var destinationDir = Path.Combine (tempDir, "dest");
+			stream.Position = 0;
+			using (var zip = ZipArchive.Open (stream)) {
+				bool changes = Files.ExtractAll (zip, destinationDir, modifyCallback: e => prefix + e);
+				Assert.IsFalse (changes, $"Entry with prefix '{prefix}' should be skipped.");
+			}
+		}
+
+		[Test]
 		public void ToHashString ()
 		{
 			var bytes = new byte [] { 0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF };


### PR DESCRIPTION
Ensure resolved output paths stay within the destination directory before extracting zip entries. This is just for correctness; there's no security enforcement here. Entries with path traversal (e.g. via `modifyCallback` introducing `../`) are skipped with a warning logged via the new `TaskLoggingHelper` parameter.

Note that libZipSharp already normalizes entry names on read:

```csharp
var stream = new MemoryStream();
using (var sysZip = new System.IO.Compression.ZipArchive(stream,
    System.IO.Compression.ZipArchiveMode.Create, leaveOpen: true))
{
    sysZip.CreateEntry("../relative.txt");
}
stream.Position = 0;
using (var zip = Xamarin.Tools.Zip.ZipArchive.Open(stream))
{
    foreach (var entry in zip)
        Console.WriteLine(entry.FullName); // prints 'evil.txt'
}
```

The original overload without `TaskLoggingHelper` is preserved and marked `[Obsolete]` to maintain binary compatibility.