### PR TITLE
[Build.Tasks] Use LogDebugMessage instead of LogWarning in ExtractAll()

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -472,7 +472,7 @@ namespace Microsoft.Android.Build.Tasks
 					var fullName = modifyCallback?.Invoke (entry.FullName) ?? entry.FullName;
 					var outfile = Path.GetFullPath (Path.Combine (destination, fullName));
 					if (!outfile.StartsWith (fullDestination, StringComparison.OrdinalIgnoreCase)) {
-						log?.LogWarning ($"Skipping zip entry \"{entry.FullName}\" (resolved as \"{fullName}\") because it would extract outside the destination directory: \"{outfile}\".");
+						log?.LogDebugMessage ($"Skipping zip entry \"{entry.FullName}\" (resolved as \"{fullName}\") because it would extract outside the destination directory: \"{outfile}\".");
 						continue;
 					}
 					files.Add (outfile);


### PR DESCRIPTION
The path-traversal skip message in `Files.ExtractAll()` (added in 9b8ef3c) used `LogWarning`, but this is a diagnostic/informational message that should use `LogDebugMessage` (`MessageImportance.Low`) instead.

This avoids surfacing unnecessary warnings to users during normal builds.