### PR TITLE
Add BenchmarkDotNet project for Files hash APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ TestResult-*.xml
 **/TestResults/*.trx
 .vs/
 *.nupkg
+BenchmarkDotNet.Artifacts/

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -27,6 +27,7 @@
     <PackageReference Update="Microsoft.VisualStudioEng.MicroBuild.Core"    Version="1.0.0" />
     <PackageReference Update="nunit"                                        Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter"                            Version="4.0.0" />
+    <PackageReference Update="BenchmarkDotNet"                              Version="0.14.0" />
   </ItemGroup>
 
 </Project>

--- a/Xamarin.Android.Tools.sln
+++ b/Xamarin.Android.Tools.sln
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{19FE1B44
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ls-jdks", "tools\ls-jdks\ls-jdks.csproj", "{3D2ADF77-62C7-4E0E-AB29-BDD266B7D56D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.Tools.Benchmarks", "tests\Xamarin.Android.Tools.Benchmarks\Xamarin.Android.Tools.Benchmarks.csproj", "{F1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -40,6 +42,10 @@ Global
 		{3D2ADF77-62C7-4E0E-AB29-BDD266B7D56D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3D2ADF77-62C7-4E0E-AB29-BDD266B7D56D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3D2ADF77-62C7-4E0E-AB29-BDD266B7D56D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/scripts/benchmarks.ps1
+++ b/scripts/benchmarks.ps1
@@ -1,0 +1,35 @@
+<#
+.SYNOPSIS
+    Runs the Files hash benchmarks and produces a markdown report.
+
+.DESCRIPTION
+    Builds and runs Xamarin.Android.Tools.Benchmarks in Release mode,
+    then copies the GitHub-flavored markdown results to
+    tests/Xamarin.Android.Tools.Benchmarks/README.md.
+#>
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$projectDir = Join-Path (Join-Path $repoRoot 'tests') 'Xamarin.Android.Tools.Benchmarks'
+$csproj = Join-Path $projectDir 'Xamarin.Android.Tools.Benchmarks.csproj'
+$artifactsDir = Join-Path $projectDir 'BenchmarkDotNet.Artifacts'
+$readme = Join-Path $projectDir 'README.md'
+
+Write-Host "Building benchmarks in Release..."
+dotnet build $csproj -c Release --nologo -v quiet
+if ($LASTEXITCODE -ne 0) { throw "Build failed." }
+
+Write-Host "Running benchmarks..."
+dotnet run --project $csproj -c Release --no-build -- --filter '*' --exporters github
+if ($LASTEXITCODE -ne 0) { throw "Benchmarks failed." }
+
+# Find the generated markdown report
+$mdFile = Get-ChildItem -Path (Join-Path $artifactsDir 'results') -Filter '*-report-github.md' | Select-Object -First 1
+if (-not $mdFile) { throw "No markdown report found in $artifactsDir\results" }
+
+Copy-Item $mdFile.FullName $readme -Force
+Write-Host "Results written to: $readme"
+
+# Clean up artifacts
+Remove-Item $artifactsDir -Recurse -Force
+Write-Host "Cleaned up BenchmarkDotNet.Artifacts."

--- a/scripts/benchmarks.ps1
+++ b/scripts/benchmarks.ps1
@@ -20,7 +20,7 @@ dotnet build $csproj -c Release --nologo -v quiet
 if ($LASTEXITCODE -ne 0) { throw "Build failed." }
 
 Write-Host "Running benchmarks..."
-dotnet run --project $csproj -c Release --no-build -- --filter '*' --exporters github
+dotnet run --project $csproj -c Release --no-build -- --filter '*' --exporters github --artifacts $artifactsDir
 if ($LASTEXITCODE -ne 0) { throw "Benchmarks failed." }
 
 # Find the generated markdown report

--- a/scripts/benchmarks.ps1
+++ b/scripts/benchmarks.ps1
@@ -24,7 +24,9 @@ dotnet run --project $csproj -c Release --no-build -- --filter '*' --exporters g
 if ($LASTEXITCODE -ne 0) { throw "Benchmarks failed." }
 
 # Find the generated markdown report
-$mdFile = Get-ChildItem -Path (Join-Path $artifactsDir 'results') -Filter '*-report-github.md' | Select-Object -First 1
+$mdFile = Get-ChildItem -Path (Join-Path $artifactsDir 'results') -Filter '*-report-github.md' |
+    Sort-Object -Property LastWriteTime -Descending |
+    Select-Object -First 1
 if (-not $mdFile) { throw "No markdown report found in $artifactsDir\results" }
 
 Copy-Item $mdFile.FullName $readme -Force

--- a/tests/Xamarin.Android.Tools.Benchmarks/FilesHashBenchmarks.cs
+++ b/tests/Xamarin.Android.Tools.Benchmarks/FilesHashBenchmarks.cs
@@ -12,7 +12,6 @@ public class FilesHashBenchmarks
 
 	byte [] data = Array.Empty<byte> ();
 	MemoryStream stream = new MemoryStream ();
-	string readmeFile = string.Empty;
 	string tempFile1 = string.Empty;
 	string tempFile2 = string.Empty;
 
@@ -24,20 +23,7 @@ public class FilesHashBenchmarks
 		new Random (42).NextBytes (data);
 		stream = new MemoryStream (data);
 
-		// Walk up from output directory to find README.md
-		var dir = AppContext.BaseDirectory;
-		while (dir is not null) {
-			var candidate = Path.Combine (dir, "README.md");
-			if (File.Exists (candidate)) {
-				readmeFile = candidate;
-				break;
-			}
-			dir = Path.GetDirectoryName (dir);
-		}
-		if (string.IsNullOrEmpty (readmeFile))
-			throw new FileNotFoundException ("Could not find README.md in any parent directory.");
-
-		// Two identical temp files for HasFileChanged benchmark
+		// Two identical 1MB temp files
 		tempFile1 = Path.GetTempFileName ();
 		tempFile2 = Path.GetTempFileName ();
 		File.WriteAllBytes (tempFile1, data);
@@ -64,9 +50,8 @@ public class FilesHashBenchmarks
 		return Files.HashStream (stream);
 	}
 
-	// README.md is currently 3,385 bytes
 	[Benchmark]
-	public string HashFile () => Files.HashFile (readmeFile);
+	public string HashFile () => Files.HashFile (tempFile1);
 
 	[Benchmark]
 	public bool HasFileChanged () => Files.HasFileChanged (tempFile1, tempFile2);

--- a/tests/Xamarin.Android.Tools.Benchmarks/FilesHashBenchmarks.cs
+++ b/tests/Xamarin.Android.Tools.Benchmarks/FilesHashBenchmarks.cs
@@ -64,6 +64,7 @@ public class FilesHashBenchmarks
 		return Files.HashStream (stream);
 	}
 
+	// README.md is currently 3,385 bytes
 	[Benchmark]
 	public string HashFile () => Files.HashFile (readmeFile);
 

--- a/tests/Xamarin.Android.Tools.Benchmarks/FilesHashBenchmarks.cs
+++ b/tests/Xamarin.Android.Tools.Benchmarks/FilesHashBenchmarks.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Android.Build.Tasks;
+
+namespace Xamarin.Android.Tools.Benchmarks;
+
+[MemoryDiagnoser]
+public class FilesHashBenchmarks
+{
+	const int OneMB = 1024 * 1024;
+
+	byte [] data = Array.Empty<byte> ();
+	MemoryStream stream = new MemoryStream ();
+	string readmeFile = string.Empty;
+	string tempFile1 = string.Empty;
+	string tempFile2 = string.Empty;
+
+	[GlobalSetup]
+	public void Setup ()
+	{
+		// 1MB byte array with reproducible random data
+		data = new byte [OneMB];
+		new Random (42).NextBytes (data);
+		stream = new MemoryStream (data);
+
+		// Walk up from output directory to find README.md
+		var dir = AppContext.BaseDirectory;
+		while (dir is not null) {
+			var candidate = Path.Combine (dir, "README.md");
+			if (File.Exists (candidate)) {
+				readmeFile = candidate;
+				break;
+			}
+			dir = Path.GetDirectoryName (dir);
+		}
+		if (string.IsNullOrEmpty (readmeFile))
+			throw new FileNotFoundException ("Could not find README.md in any parent directory.");
+
+		// Two identical temp files for HasFileChanged benchmark
+		tempFile1 = Path.GetTempFileName ();
+		tempFile2 = Path.GetTempFileName ();
+		File.WriteAllBytes (tempFile1, data);
+		File.WriteAllBytes (tempFile2, data);
+	}
+
+	[GlobalCleanup]
+	public void Cleanup ()
+	{
+		stream.Dispose ();
+		if (File.Exists (tempFile1))
+			File.Delete (tempFile1);
+		if (File.Exists (tempFile2))
+			File.Delete (tempFile2);
+	}
+
+	[Benchmark]
+	public string HashBytes () => Files.HashBytes (data);
+
+	[Benchmark]
+	public string HashStream ()
+	{
+		stream.Position = 0;
+		return Files.HashStream (stream);
+	}
+
+	[Benchmark]
+	public string HashFile () => Files.HashFile (readmeFile);
+
+	[Benchmark]
+	public bool HasFileChanged () => Files.HasFileChanged (tempFile1, tempFile2);
+}

--- a/tests/Xamarin.Android.Tools.Benchmarks/FilesHashBenchmarks.cs
+++ b/tests/Xamarin.Android.Tools.Benchmarks/FilesHashBenchmarks.cs
@@ -10,49 +10,46 @@ public class FilesHashBenchmarks
 {
 	const int OneMB = 1024 * 1024;
 
-	byte [] data = Array.Empty<byte> ();
-	MemoryStream stream = new MemoryStream ();
-	string tempFile1 = string.Empty;
-	string tempFile2 = string.Empty;
+	byte [] _data = Array.Empty<byte> ();
+	MemoryStream _stream = new MemoryStream ();
+	string _tempFile1 = string.Empty;
+	string _tempFile2 = string.Empty;
 
 	[GlobalSetup]
 	public void Setup ()
 	{
 		// 1MB byte array with reproducible random data
-		data = new byte [OneMB];
-		new Random (42).NextBytes (data);
-		stream = new MemoryStream (data);
+		_data = new byte [OneMB];
+		new Random (42).NextBytes (_data);
+		_stream.Dispose ();
+		_stream = new MemoryStream (_data);
 
 		// Two identical 1MB temp files
-		tempFile1 = Path.GetTempFileName ();
-		tempFile2 = Path.GetTempFileName ();
-		File.WriteAllBytes (tempFile1, data);
-		File.WriteAllBytes (tempFile2, data);
+		_tempFile1 = Path.GetTempFileName ();
+		_tempFile2 = Path.GetTempFileName ();
+		File.WriteAllBytes (_tempFile1, _data);
+		File.WriteAllBytes (_tempFile2, _data);
 	}
 
 	[GlobalCleanup]
 	public void Cleanup ()
 	{
-		stream.Dispose ();
-		if (File.Exists (tempFile1))
-			File.Delete (tempFile1);
-		if (File.Exists (tempFile2))
-			File.Delete (tempFile2);
+		_stream?.Dispose ();
+		if (File.Exists (_tempFile1))
+			File.Delete (_tempFile1);
+		if (File.Exists (_tempFile2))
+			File.Delete (_tempFile2);
 	}
 
 	[Benchmark]
-	public string HashBytes () => Files.HashBytes (data);
+	public string HashBytes () => Files.HashBytes (_data);
 
 	[Benchmark]
-	public string HashStream ()
-	{
-		stream.Position = 0;
-		return Files.HashStream (stream);
-	}
+	public string HashStream () => Files.HashStream (_stream);
 
 	[Benchmark]
-	public string HashFile () => Files.HashFile (tempFile1);
+	public string HashFile () => Files.HashFile (_tempFile1);
 
 	[Benchmark]
-	public bool HasFileChanged () => Files.HasFileChanged (tempFile1, tempFile2);
+	public bool HasFileChanged () => Files.HasFileChanged (_tempFile1, _tempFile2);
 }

--- a/tests/Xamarin.Android.Tools.Benchmarks/Program.cs
+++ b/tests/Xamarin.Android.Tools.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly (typeof (Program).Assembly).Run (args);

--- a/tests/Xamarin.Android.Tools.Benchmarks/README.md
+++ b/tests/Xamarin.Android.Tools.Benchmarks/README.md
@@ -1,0 +1,16 @@
+```
+
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26200.8246)
+Intel Core i9-14900KF, 1 CPU, 32 logical and 24 physical cores
+.NET SDK 10.0.202
+  [Host]     : .NET 10.0.6 (10.0.626.17701), X64 RyuJIT AVX2
+  DefaultJob : .NET 10.0.6 (10.0.626.17701), X64 RyuJIT AVX2
+
+
+```
+| Method         | Mean        | Error     | StdDev    | Allocated |
+|--------------- |------------:|----------:|----------:|----------:|
+| HashBytes      |   485.90 μs |  5.514 μs |  5.158 μs |     232 B |
+| HashStream     |   471.47 μs |  3.284 μs |  3.072 μs |     232 B |
+| HashFile       |    16.11 μs |  0.104 μs |  0.098 μs |     472 B |
+| HasFileChanged | 1,477.77 μs | 18.336 μs | 17.152 μs |     945 B |

--- a/tests/Xamarin.Android.Tools.Benchmarks/README.md
+++ b/tests/Xamarin.Android.Tools.Benchmarks/README.md
@@ -8,9 +8,9 @@ Intel Core i9-14900KF, 1 CPU, 32 logical and 24 physical cores
 
 
 ```
-| Method         | Mean       | Error    | StdDev   | Allocated |
-|--------------- |-----------:|---------:|---------:|----------:|
-| HashBytes      |   475.2 μs |  2.50 μs |  2.21 μs |     232 B |
-| HashStream     |   458.9 μs |  0.85 μs |  0.71 μs |     232 B |
-| HashFile       |   732.6 μs | 14.20 μs | 15.20 μs |     472 B |
-| HasFileChanged | 1,434.4 μs |  5.51 μs |  4.60 μs |     945 B |
+| Method         | Mean       | Error   | StdDev  | Allocated |
+|--------------- |-----------:|--------:|--------:|----------:|
+| HashBytes      |   468.2 μs | 2.01 μs | 1.57 μs |     232 B |
+| HashStream     |   482.9 μs | 7.47 μs | 6.99 μs |     232 B |
+| HashFile       |   764.9 μs | 8.08 μs | 7.56 μs |     474 B |
+| HasFileChanged | 1,496.6 μs | 5.74 μs | 5.08 μs |     945 B |

--- a/tests/Xamarin.Android.Tools.Benchmarks/README.md
+++ b/tests/Xamarin.Android.Tools.Benchmarks/README.md
@@ -8,9 +8,9 @@ Intel Core i9-14900KF, 1 CPU, 32 logical and 24 physical cores
 
 
 ```
-| Method         | Mean        | Error     | StdDev    | Allocated |
-|--------------- |------------:|----------:|----------:|----------:|
-| HashBytes      |   485.90 μs |  5.514 μs |  5.158 μs |     232 B |
-| HashStream     |   471.47 μs |  3.284 μs |  3.072 μs |     232 B |
-| HashFile       |    16.11 μs |  0.104 μs |  0.098 μs |     472 B |
-| HasFileChanged | 1,477.77 μs | 18.336 μs | 17.152 μs |     945 B |
+| Method         | Mean       | Error    | StdDev   | Allocated |
+|--------------- |-----------:|---------:|---------:|----------:|
+| HashBytes      |   475.2 μs |  2.50 μs |  2.21 μs |     232 B |
+| HashStream     |   458.9 μs |  0.85 μs |  0.71 μs |     232 B |
+| HashFile       |   732.6 μs | 14.20 μs | 15.20 μs |     472 B |
+| HasFileChanged | 1,434.4 μs |  5.51 μs |  4.60 μs |     945 B |

--- a/tests/Xamarin.Android.Tools.Benchmarks/Xamarin.Android.Tools.Benchmarks.csproj
+++ b/tests/Xamarin.Android.Tools.Benchmarks/Xamarin.Android.Tools.Benchmarks.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotNet" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Xamarin.Android.Tools.Benchmarks/Xamarin.Android.Tools.Benchmarks.csproj
+++ b/tests/Xamarin.Android.Tools.Benchmarks/Xamarin.Android.Tools.Benchmarks.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <RollForward>Major</RollForward>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Android.Build.BaseTasks\Microsoft.Android.Build.BaseTasks.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
The `Files` class hashing methods (`HashBytes`, `HashStream`, `HashFile`, `HasFileChanged`) are used heavily during incremental builds, but we have no benchmarks to measure their performance or track regressions.

This PR adds a new `tests/Xamarin.Android.Tools.Benchmarks` project using BenchmarkDotNet to benchmark the Crc64-based hashing APIs in `Files.cs`. It also includes a `scripts/benchmarks.ps1` script that builds in Release, runs the benchmarks with the GitHub markdown exporter, and writes the results to `tests/Xamarin.Android.Tools.Benchmarks/README.md`.

**What's included:**
- `Xamarin.Android.Tools.Benchmarks.csproj` -- Exe project targeting `net10.0` with BenchmarkDotNet 0.14.0
- `FilesHashBenchmarks.cs` -- benchmarks for `HashBytes`, `HashStream`, `HashFile`, and `HasFileChanged` using 1MB reproducible random data
- `Program.cs` -- `BenchmarkSwitcher` entry point
- `scripts/benchmarks.ps1` -- build + run + export results to README
- `BenchmarkDotNet.Artifacts/` added to `.gitignore`
- Project added to `Xamarin.Android.Tools.sln`