### PR TITLE
Replace Crc64 with XxHash64 in Files class

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -28,6 +28,7 @@
     <PackageReference Update="nunit"                                        Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter"                            Version="4.0.0" />
     <PackageReference Update="BenchmarkDotNet"                              Version="0.14.0" />
+    <PackageReference Update="System.IO.Hashing"                            Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Hashing;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -531,22 +532,22 @@ namespace Microsoft.Android.Build.Tasks
 
 		public static string HashBytes (byte [] bytes)
 		{
-			using (HashAlgorithm hashAlg = new Crc64 ()) {
-				byte [] hash = hashAlg.ComputeHash (bytes);
-				return ToHexString (hash);
-			}
+			byte [] hash = XxHash64.Hash (bytes);
+			return ToHexString (hash);
 		}
 
 		public static string HashFile (string filename)
 		{
-			using (HashAlgorithm hashAlg = new Crc64 ()) {
-				return HashFile (filename, hashAlg);
+			var hasher = new XxHash64 ();
+			using (var file = File.OpenRead (filename)) {
+				hasher.Append (file);
 			}
+			return ToHexString (hasher.GetCurrentHash ());
 		}
 
 		public static string HashFile (string filename, HashAlgorithm hashAlg)
 		{
-			using (Stream file = new FileStream (filename, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+			using (var file = File.OpenRead (filename)) {
 				byte[] hash = hashAlg.ComputeHash (file);
 				return ToHexString (hash);
 			}
@@ -555,11 +556,9 @@ namespace Microsoft.Android.Build.Tasks
 		public static string HashStream (Stream stream)
 		{
 			stream.Position = 0;
-
-			using (HashAlgorithm hashAlg = new Crc64 ()) {
-				byte[] hash = hashAlg.ComputeHash (stream);
-				return ToHexString (hash);
-			}
+			var hasher = new XxHash64 ();
+			hasher.Append (stream);
+			return ToHexString (hasher.GetCurrentHash ());
 		}
 
 		public static string ToHexString (byte[] hash)

--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Android.Build.Tasks
 
 		const int DEFAULT_FILE_WRITE_RETRY_DELAY_MS = 1000;
 
+		const int XXHASH64_SIZE_IN_BYTES = 8;
+
 		static int fileWriteRetry = -1;
 		static int fileWriteRetryDelay = -1;
 
@@ -532,7 +534,8 @@ namespace Microsoft.Android.Build.Tasks
 
 		public static string HashBytes (byte [] bytes)
 		{
-			byte [] hash = XxHash64.Hash (bytes);
+			Span<byte> hash = stackalloc byte[XXHASH64_SIZE_IN_BYTES];
+			XxHash64.Hash (bytes, hash);
 			return ToHexString (hash);
 		}
 
@@ -542,7 +545,9 @@ namespace Microsoft.Android.Build.Tasks
 			using (var file = File.OpenRead (filename)) {
 				hasher.Append (file);
 			}
-			return ToHexString (hasher.GetCurrentHash ());
+			Span<byte> hash = stackalloc byte[XXHASH64_SIZE_IN_BYTES];
+			hasher.GetCurrentHash (hash);
+			return ToHexString (hash);
 		}
 
 		public static string HashFile (string filename, HashAlgorithm hashAlg)
@@ -558,18 +563,31 @@ namespace Microsoft.Android.Build.Tasks
 			stream.Position = 0;
 			var hasher = new XxHash64 ();
 			hasher.Append (stream);
-			return ToHexString (hasher.GetCurrentHash ());
+			Span<byte> hash = stackalloc byte[XXHASH64_SIZE_IN_BYTES];
+			hasher.GetCurrentHash (hash);
+			return ToHexString (hash);
 		}
 
 		public static string ToHexString (byte[] hash)
 		{
-			char [] array = new char [hash.Length * 2];
+			if (hash == null)
+				throw new ArgumentNullException (nameof (hash));
+			return ToHexString ((ReadOnlySpan<byte>) hash);
+		}
+
+		public static string ToHexString (ReadOnlySpan<byte> hash)
+		{
+			const int MaxStackCharLength = 128;
+			int charLength = hash.Length * 2;
+			Span<char> chars = charLength <= MaxStackCharLength
+				? stackalloc char[charLength]
+				: new char[charLength];
 			for (int i = 0, j = 0; i < hash.Length; i += 1, j += 2) {
 				byte b = hash [i];
-				array [j] = GetHexValue (b / 16);
-				array [j + 1] = GetHexValue (b % 16);
+				chars [j] = GetHexValue (b / 16);
+				chars [j + 1] = GetHexValue (b % 16);
 			}
-			return new string (array);
+			return ((ReadOnlySpan<char>) chars).ToString ();
 		}
 
 		static char GetHexValue (int i) => (char) (i < 10 ? i + 48 : i - 10 + 65);

--- a/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj
+++ b/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="System.IO.Hashing" />
   </ItemGroup>
 
 </Project>

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
@@ -43,89 +43,104 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 		[Test]
 		public void CopyIfStringChanged ()
 		{
+			Directory.CreateDirectory (tempDir);
+			var tempFile = Path.Combine (tempDir, "foo.txt");
+
 			var foo = "bar";
-			Assert.IsTrue (Files.CopyIfStringChanged (foo, tempDir), "Should write on new file.");
-			FileAssert.Exists (tempDir);
-			Assert.IsFalse (Files.CopyIfStringChanged (foo, tempDir), "Should *not* write unless changed.");
+			Assert.IsTrue (Files.CopyIfStringChanged (foo, tempFile), "Should write on new file.");
+			FileAssert.Exists (tempFile);
+			Assert.IsFalse (Files.CopyIfStringChanged (foo, tempFile), "Should *not* write unless changed.");
 			foo += "\n";
-			Assert.IsTrue (Files.CopyIfStringChanged (foo, tempDir), "Should write when changed.");
+			Assert.IsTrue (Files.CopyIfStringChanged (foo, tempFile), "Should write when changed.");
 		}
 
 		[Test]
 		public void CopyIfBytesChanged ()
 		{
+			Directory.CreateDirectory (tempDir);
+			var tempFile = Path.Combine (tempDir, "foo.bin");
+
 			var foo = new byte [32];
-			Assert.IsTrue (Files.CopyIfBytesChanged (foo, tempDir), "Should write on new file.");
-			FileAssert.Exists (tempDir);
-			Assert.IsFalse (Files.CopyIfBytesChanged (foo, tempDir), "Should *not* write unless changed.");
+			Assert.IsTrue (Files.CopyIfBytesChanged (foo, tempFile), "Should write on new file.");
+			FileAssert.Exists (tempFile);
+			Assert.IsFalse (Files.CopyIfBytesChanged (foo, tempFile), "Should *not* write unless changed.");
 			foo [0] = 0xFF;
-			Assert.IsTrue (Files.CopyIfBytesChanged (foo, tempDir), "Should write when changed.");
+			Assert.IsTrue (Files.CopyIfBytesChanged (foo, tempFile), "Should write when changed.");
 		}
 
 		[Test]
 		public void CopyIfStreamChanged ()
 		{
+			Directory.CreateDirectory (tempDir);
+			var tempFile = Path.Combine (tempDir, "foo.txt");
+
 			using (var foo = new MemoryStream ())
 			using (var writer = new StreamWriter (foo)) {
 				writer.WriteLine ("bar");
 				writer.Flush ();
 
-				Assert.IsTrue (Files.CopyIfStreamChanged (foo, tempDir), "Should write on new file.");
-				FileAssert.Exists (tempDir);
-				Assert.IsFalse (Files.CopyIfStreamChanged (foo, tempDir), "Should *not* write unless changed.");
+				Assert.IsTrue (Files.CopyIfStreamChanged (foo, tempFile), "Should write on new file.");
+				FileAssert.Exists (tempFile);
+				Assert.IsFalse (Files.CopyIfStreamChanged (foo, tempFile), "Should *not* write unless changed.");
 				writer.WriteLine ();
 				writer.Flush ();
-				Assert.IsTrue (Files.CopyIfStreamChanged (foo, tempDir), "Should write when changed.");
+				Assert.IsTrue (Files.CopyIfStreamChanged (foo, tempFile), "Should write when changed.");
 			}
 		}
 
 		[Test]
 		public void CopyIfStringChanged_NewDirectory ()
 		{
-			tempDir = Path.Combine (tempDir, "foo.txt");
+			Directory.CreateDirectory (tempDir);
+			var tempFile = Path.Combine (tempDir, "foo.txt");
 
 			var foo = "bar";
-			Assert.IsTrue (Files.CopyIfStringChanged (foo, tempDir), "Should write on new file.");
-			FileAssert.Exists (tempDir);
+			Assert.IsTrue (Files.CopyIfStringChanged (foo, tempFile), "Should write on new file.");
+			FileAssert.Exists (tempFile);
 		}
 
 		[Test]
 		public void CopyIfBytesChanged_NewDirectory ()
 		{
-			tempDir = Path.Combine (tempDir, "foo.bin");
+			Directory.CreateDirectory (tempDir);
+			var tempFile = Path.Combine (tempDir, "foo.bin");
 
 			var foo = new byte [32];
-			Assert.IsTrue (Files.CopyIfBytesChanged (foo, tempDir), "Should write on new file.");
-			FileAssert.Exists (tempDir);
+			Assert.IsTrue (Files.CopyIfBytesChanged (foo, tempFile), "Should write on new file.");
+			FileAssert.Exists (tempFile);
 		}
 
 		[Test]
 		public void CopyIfStreamChanged_NewDirectory ()
 		{
-			tempDir = Path.Combine (tempDir, "foo.txt");
+			Directory.CreateDirectory (tempDir);
+			var tempFile = Path.Combine (tempDir, "foo.txt");
 
 			using (var foo = new MemoryStream ())
 			using (var writer = new StreamWriter (foo)) {
 				writer.WriteLine ("bar");
 				writer.Flush ();
 
-				Assert.IsTrue (Files.CopyIfStreamChanged (foo, tempDir), "Should write on new file.");
-				FileAssert.Exists (tempDir);
+				Assert.IsTrue (Files.CopyIfStreamChanged (foo, tempFile), "Should write on new file.");
+				FileAssert.Exists (tempFile);
 			}
 		}
 
 		[Test]
 		public void CopyIfBytesChanged_Readonly ()
 		{
-			if (File.Exists (tempDir)) {
-				File.SetAttributes (tempDir, FileAttributes.Normal);
+			Directory.CreateDirectory (tempDir);
+			var tempFile = Path.Combine (tempDir, "foo.bin");
+
+			if (File.Exists (tempFile)) {
+				File.SetAttributes (tempFile, FileAttributes.Normal);
 			}
-			File.WriteAllText (tempDir, "");
-			File.SetAttributes (tempDir, FileAttributes.ReadOnly);
+			File.WriteAllText (tempFile, "");
+			File.SetAttributes (tempFile, FileAttributes.ReadOnly);
 
 			var foo = new byte [32];
-			Assert.IsTrue (Files.CopyIfBytesChanged (foo, tempDir), "Should write on new file.");
-			FileAssert.Exists (tempDir);
+			Assert.IsTrue (Files.CopyIfBytesChanged (foo, tempFile), "Should write on new file.");
+			FileAssert.Exists (tempFile);
 		}
 
 		[Test]
@@ -133,18 +148,18 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 		{
 			var encoding = Encoding.UTF8;
 			Directory.CreateDirectory (tempDir);
-			tempDir = Path.Combine (tempDir, "foo.txt");
-			if (File.Exists (tempDir)) {
-				File.SetAttributes (tempDir, FileAttributes.Normal);
+			var tempFile = Path.Combine (tempDir, "foo.txt");
+			if (File.Exists (tempFile)) {
+				File.SetAttributes (tempFile, FileAttributes.Normal);
 			}
-			using (var stream = File.Create (tempDir))
+			using (var stream = File.Create (tempFile))
 			using (var writer = new StreamWriter (stream, encoding)) {
 				writer.Write ("This will have a BOM");
 			}
-			File.SetAttributes (tempDir, FileAttributes.ReadOnly);
-			var before = File.ReadAllBytes (tempDir);
-			Files.CleanBOM (tempDir);
-			var after = File.ReadAllBytes (tempDir);
+			File.SetAttributes (tempFile, FileAttributes.ReadOnly);
+			var before = File.ReadAllBytes (tempFile);
+			Files.CleanBOM (tempFile);
+			var after = File.ReadAllBytes (tempFile);
 			var preamble = encoding.GetPreamble ();
 			Assert.AreEqual (before.Length, after.Length + preamble.Length, "BOM should be removed!");
 		}
@@ -152,6 +167,9 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 		[Test]
 		public void CopyIfStreamChanged_MemoryStreamPool_StreamWriter ()
 		{
+			Directory.CreateDirectory (tempDir);
+			var tempFile = Path.Combine (tempDir, "foo.txt");
+
 			var pool = new MemoryStreamPool ();
 			var expected = pool.Rent ();
 			pool.Return (expected);
@@ -160,8 +178,8 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 				writer.WriteLine ("bar");
 				writer.Flush ();
 
-				Assert.IsTrue (Files.CopyIfStreamChanged (writer.BaseStream, tempDir), "Should write on new file.");
-				FileAssert.Exists (tempDir);
+				Assert.IsTrue (Files.CopyIfStreamChanged (writer.BaseStream, tempFile), "Should write on new file.");
+				FileAssert.Exists (tempFile);
 			}
 
 			var actual = pool.Rent ();
@@ -172,6 +190,9 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 		[Test]
 		public void CopyIfStreamChanged_MemoryStreamPool_BinaryWriter ()
 		{
+			Directory.CreateDirectory (tempDir);
+			var tempFile = Path.Combine (tempDir, "foo.bin");
+
 			var pool = new MemoryStreamPool ();
 			var expected = pool.Rent ();
 			pool.Return (expected);
@@ -180,8 +201,8 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 				writer.Write (42);
 				writer.Flush ();
 
-				Assert.IsTrue (Files.CopyIfStreamChanged (writer.BaseStream, tempDir), "Should write on new file.");
-				FileAssert.Exists (tempDir);
+				Assert.IsTrue (Files.CopyIfStreamChanged (writer.BaseStream, tempFile), "Should write on new file.");
+				FileAssert.Exists (tempFile);
 			}
 
 			var actual = pool.Rent ();
@@ -192,14 +213,17 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 		[Test]
 		public void SetWriteable ()
 		{
-			File.WriteAllText (tempDir, contents: "foo");
-			File.SetAttributes (tempDir, FileAttributes.ReadOnly);
+			Directory.CreateDirectory (tempDir);
+			var tempFile = Path.Combine (tempDir, "foo.txt");
 
-			Files.SetWriteable (tempDir);
+			File.WriteAllText (tempFile, contents: "foo");
+			File.SetAttributes (tempFile, FileAttributes.ReadOnly);
 
-			var attributes = File.GetAttributes (tempDir);
+			Files.SetWriteable (tempFile);
+
+			var attributes = File.GetAttributes (tempFile);
 			Assert.AreEqual (FileAttributes.Normal, attributes);
-			File.WriteAllText (tempDir, contents: "bar");
+			File.WriteAllText (tempFile, contents: "bar");
 		}
 
 		[Test]

--- a/tests/Xamarin.Android.Tools.Benchmarks/FilesHashBenchmarks.cs
+++ b/tests/Xamarin.Android.Tools.Benchmarks/FilesHashBenchmarks.cs
@@ -47,6 +47,7 @@ public class FilesHashBenchmarks
 	[Benchmark]
 	public string HashStream () => Files.HashStream (_stream);
 
+	// README.md is currently 3,385 bytes
 	[Benchmark]
 	public string HashFile () => Files.HashFile (_tempFile1);
 

--- a/tests/Xamarin.Android.Tools.Benchmarks/FilesHashBenchmarks.cs
+++ b/tests/Xamarin.Android.Tools.Benchmarks/FilesHashBenchmarks.cs
@@ -47,7 +47,6 @@ public class FilesHashBenchmarks
 	[Benchmark]
 	public string HashStream () => Files.HashStream (_stream);
 
-	// README.md is currently 3,385 bytes
 	[Benchmark]
 	public string HashFile () => Files.HashFile (_tempFile1);
 

--- a/tests/Xamarin.Android.Tools.Benchmarks/README.md
+++ b/tests/Xamarin.Android.Tools.Benchmarks/README.md
@@ -8,9 +8,9 @@ Intel Core i9-14900KF, 1 CPU, 32 logical and 24 physical cores
 
 
 ```
-| Method         | Mean       | Error   | StdDev  | Allocated |
-|--------------- |-----------:|--------:|--------:|----------:|
-| HashBytes      |   468.2 μs | 2.01 μs | 1.57 μs |     232 B |
-| HashStream     |   482.9 μs | 7.47 μs | 6.99 μs |     232 B |
-| HashFile       |   764.9 μs | 8.08 μs | 7.56 μs |     474 B |
-| HasFileChanged | 1,496.6 μs | 5.74 μs | 5.08 μs |     945 B |
+| Method         | Mean      | Error    | StdDev   | Allocated |
+|--------------- |----------:|---------:|---------:|----------:|
+| HashBytes      |  46.00 μs | 0.401 μs | 0.375 μs |      56 B |
+| HashStream     |  44.98 μs | 0.117 μs | 0.104 μs |     184 B |
+| HashFile       |  75.83 μs | 0.605 μs | 0.566 μs |     424 B |
+| HasFileChanged | 163.23 μs | 0.705 μs | 0.589 μs |     848 B |


### PR DESCRIPTION
Replaces the software `Crc64` implementation with hardware-accelerated `XxHash64` from `System.IO.Hashing` 10.0.7 for all hashing in the `Files` class (`HashBytes`, `HashFile`, `HashStream`).

The `Crc64` class is retained — only its usage in `Files` is replaced.

## Changes

- **`Files.cs`**: `HashBytes`, `HashFile(string)`, and `HashStream` now use `XxHash64` instead of `Crc64`. Uses `stackalloc` with Span-based APIs for zero-allocation hashing.  `HashFile(string, HashAlgorithm)` overload is unchanged for backward compat.
- **`Files.cs`**: `ToHexString(ReadOnlySpan<byte>)` is now `public`. Uses `stackalloc` for small hashes (≤64 bytes) to avoid `char[]` allocation. The `byte[]` overload delegates to it.
- **`Files.cs`**: `HashFile` overloads simplified to use `File.OpenRead()`.
- **`Microsoft.Android.Build.BaseTasks.csproj`**: Added `System.IO.Hashing` package reference.
- **`Directory.Build.targets`**: Pinned `System.IO.Hashing` version to 10.0.7 (centralized, matching other packages).
- **`FilesTests.cs`**: Fixed pre-existing bug where tests reassigned `tempDir` from a directory to a file path, causing `TearDown` to skip cleanup. All tests now use `tempDir` as a directory and write to local `tempFile` variables inside it.

## Benchmark results (1 MB data, Intel i9-14900KF)

| Method         | Before (Crc64) | Alloc | After (XxHash64) | Alloc | Speedup |
|--------------- |---------------:|------:|------------------:|------:|--------:|
| HashBytes      |       468.2 μs | 232 B |          46.00 μs |  56 B |   ~10x  |
| HashStream     |       482.9 μs | 232 B |          44.98 μs | 184 B |   ~11x  |
| HashFile       |       764.9 μs | 474 B |          75.83 μs | 424 B |   ~10x  |
| HasFileChanged |     1,496.6 μs | 945 B |         163.23 μs | 848 B |    ~9x  |

Depends on #334