### PR TITLE
Replace `XxHash64` with `System.IO.Hashing.Crc64` in `Files` class

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Hashing;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -26,7 +25,7 @@ namespace Microsoft.Android.Build.Tasks
 
 		const int DEFAULT_FILE_WRITE_RETRY_DELAY_MS = 1000;
 
-		const int XXHASH64_SIZE_IN_BYTES = 8;
+		const int CRC64_SIZE_IN_BYTES = 8;
 
 		static int fileWriteRetry = -1;
 		static int fileWriteRetryDelay = -1;
@@ -534,18 +533,20 @@ namespace Microsoft.Android.Build.Tasks
 
 		public static string HashBytes (byte [] bytes)
 		{
-			Span<byte> hash = stackalloc byte[XXHASH64_SIZE_IN_BYTES];
-			XxHash64.Hash (bytes, hash);
+			Span<byte> hash = stackalloc byte[CRC64_SIZE_IN_BYTES];
+			// NOTE: System.IO.Hashing.Crc64 produces different output than the Crc64 class in this repo
+			System.IO.Hashing.Crc64.Hash (bytes, hash);
 			return ToHexString (hash);
 		}
 
 		public static string HashFile (string filename)
 		{
-			var hasher = new XxHash64 ();
+			// NOTE: System.IO.Hashing.Crc64 produces different output than the Crc64 class in this repo
+			var hasher = new System.IO.Hashing.Crc64 ();
 			using (var file = File.OpenRead (filename)) {
 				hasher.Append (file);
 			}
-			Span<byte> hash = stackalloc byte[XXHASH64_SIZE_IN_BYTES];
+			Span<byte> hash = stackalloc byte[CRC64_SIZE_IN_BYTES];
 			hasher.GetCurrentHash (hash);
 			return ToHexString (hash);
 		}
@@ -561,9 +562,10 @@ namespace Microsoft.Android.Build.Tasks
 		public static string HashStream (Stream stream)
 		{
 			stream.Position = 0;
-			var hasher = new XxHash64 ();
+			// NOTE: System.IO.Hashing.Crc64 produces different output than the Crc64 class in this repo
+			var hasher = new System.IO.Hashing.Crc64 ();
 			hasher.Append (stream);
-			Span<byte> hash = stackalloc byte[XXHASH64_SIZE_IN_BYTES];
+			Span<byte> hash = stackalloc byte[CRC64_SIZE_IN_BYTES];
 			hasher.GetCurrentHash (hash);
 			return ToHexString (hash);
 		}

--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using Xamarin.Tools.Zip;
@@ -25,6 +26,7 @@ namespace Microsoft.Android.Build.Tasks
 
 		const int DEFAULT_FILE_WRITE_RETRY_DELAY_MS = 1000;
 
+		// NOTE: System.IO.Hashing.Crc64 produces different output than the Crc64 class in this repo
 		const int CRC64_SIZE_IN_BYTES = 8;
 
 		static int fileWriteRetry = -1;
@@ -536,6 +538,7 @@ namespace Microsoft.Android.Build.Tasks
 			Span<byte> hash = stackalloc byte[CRC64_SIZE_IN_BYTES];
 			// NOTE: System.IO.Hashing.Crc64 produces different output than the Crc64 class in this repo
 			System.IO.Hashing.Crc64.Hash (bytes, hash);
+			XorLength (hash, (ulong) bytes.Length);
 			return ToHexString (hash);
 		}
 
@@ -543,11 +546,14 @@ namespace Microsoft.Android.Build.Tasks
 		{
 			// NOTE: System.IO.Hashing.Crc64 produces different output than the Crc64 class in this repo
 			var hasher = new System.IO.Hashing.Crc64 ();
+			long length;
 			using (var file = File.OpenRead (filename)) {
 				hasher.Append (file);
+				length = file.Length;
 			}
 			Span<byte> hash = stackalloc byte[CRC64_SIZE_IN_BYTES];
 			hasher.GetCurrentHash (hash);
+			XorLength (hash, (ulong) length);
 			return ToHexString (hash);
 		}
 
@@ -567,7 +573,15 @@ namespace Microsoft.Android.Build.Tasks
 			hasher.Append (stream);
 			Span<byte> hash = stackalloc byte[CRC64_SIZE_IN_BYTES];
 			hasher.GetCurrentHash (hash);
+			XorLength (hash, (ulong) stream.Length);
 			return ToHexString (hash);
+		}
+
+		/// XOR the data length into the hash to avoid collisions on zero-filled inputs.
+		static void XorLength (Span<byte> hash, ulong length)
+		{
+			ref var crc = ref Unsafe.As<byte, ulong> (ref hash [0]);
+			crc ^= length;
 		}
 
 		public static string ToHexString (byte[] hash)

--- a/tests/Xamarin.Android.Tools.Benchmarks/README.md
+++ b/tests/Xamarin.Android.Tools.Benchmarks/README.md
@@ -10,7 +10,7 @@ Intel Core i9-14900KF, 1 CPU, 32 logical and 24 physical cores
 ```
 | Method         | Mean      | Error    | StdDev   | Allocated |
 |--------------- |----------:|---------:|---------:|----------:|
-| HashBytes      |  46.00 μs | 0.401 μs | 0.375 μs |      56 B |
-| HashStream     |  44.98 μs | 0.117 μs | 0.104 μs |     184 B |
-| HashFile       |  75.83 μs | 0.605 μs | 0.566 μs |     424 B |
-| HasFileChanged | 163.23 μs | 0.705 μs | 0.589 μs |     848 B |
+| HashBytes      |  23.34 μs | 0.123 μs | 0.115 μs |      56 B |
+| HashStream     |  23.07 μs | 0.075 μs | 0.070 μs |     120 B |
+| HashFile       |  52.98 μs | 0.766 μs | 0.716 μs |     360 B |
+| HasFileChanged | 118.44 μs | 2.285 μs | 2.138 μs |     720 B |


### PR DESCRIPTION
## Benchmark Results

| Method | XxHash64 (before) | Crc64 (after) | Speedup | Alloc Delta |
|---|--:|--:|--:|--:|
| `HashBytes` | 46.00 us | 23.34 us | **~2x faster** | 56 B -> 56 B |
| `HashStream` | 44.98 us | 23.07 us | **~2x faster** | 184 B -> 120 B |
| `HashFile` | 75.83 us | 52.98 us | **~1.4x faster** | 424 B -> 360 B |
| `HasFileChanged` | 163.23 us | 118.44 us | **~1.4x faster** | 848 B -> 720 B |

## Changes

Replaced all `XxHash64` usage in `Files.cs` with `System.IO.Hashing.Crc64`:

- `HashBytes` -- `XxHash64.Hash()` to `Crc64.Hash()`
- `HashFile` -- `new XxHash64()` to `new Crc64()`
- `HashStream` -- `new XxHash64()` to `new Crc64()`
- Renamed constant `XXHASH64_SIZE_IN_BYTES` to `CRC64_SIZE_IN_BYTES`

Used fully-qualified `System.IO.Hashing.Crc64` to avoid ambiguity with the existing `Crc64 : HashAlgorithm` class in the same namespace (which uses a different CRC-64-Jones variant).

### XorLength

Standard CRC64 maps all-zero inputs (of any length, including empty) to `0000000000000000`. This caused a hash collision in `HasBytesChanged` when comparing an empty file against zero-filled byte arrays. To prevent this, we XOR the data length into the final hash -- the same technique the repo's custom `Crc64` class uses in its `HashFinal()` method. This ensures that inputs with identical CRC values but different lengths produce distinct hashes.