### PR TITLE
[JdkInfo] Remove dead code: GetLibJvmJdks and GetLibJvmJdkPaths

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -467,34 +467,6 @@ namespace Xamarin.Android.Tools
 			return paths;
 		}
 
-		// Linux; Fedora
-		static IEnumerable<JdkInfo> GetLibJvmJdks (Action<TraceLevel, string> logger)
-		{
-			return GetLibJvmJdkPaths ()
-				.Distinct ()
-				.Select (p => TryGetJdkInfo (p, logger, "`ls /usr/lib/jvm/*`"))
-				.Where (jdk => jdk != null)
-				.Select (jdk => jdk!)
-				.OrderByDescending (jdk => jdk, JdkInfoVersionComparer.Default);
-		}
-
-		static IEnumerable<string> GetLibJvmJdkPaths ()
-		{
-			if (!OS.IsLinux) {
-				yield break;
-			}
-
-			var jvm = "/usr/lib/jvm";
-			if (!Directory.Exists (jvm))
-				yield break;
-
-			foreach (var jdk in Directory.EnumerateDirectories (jvm)) {
-				var release = Path.Combine (jdk, "release");
-				if (File.Exists (release))
-					yield return jdk;
-			}
-		}
-
 		// Last-ditch fallback!
 		static IEnumerable<JdkInfo> GetPathEnvironmentJdks (Action<TraceLevel, string> logger)
 		{


### PR DESCRIPTION
## Summary

Remove two unused private static methods (`GetLibJvmJdks` and `GetLibJvmJdkPaths`) from `JdkInfo.cs` — 28 lines of dead code for Fedora `/usr/lib/jvm` JDK discovery that was never called.

## Details

`GetKnownSystemJdkInfos` never calls either method, and no other call sites exist in the repo. These were superseded by `GetJavaAlternativesJdks`, which already covers the same Linux `/usr/lib/jvm` discovery use case.

Both methods were `private static`, so there is no public API change.

## Changes

- Deleted `GetLibJvmJdks` and `GetLibJvmJdkPaths` from `src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs`

## Verification

- Build passes (0 errors)
- 293 tests pass, 16 skipped
- 1 pre-existing failure (JdkDirectory_JavaHome) on main, unrelated to this change
