### PR TITLE
Fix NullReferenceException in DeleteFile catch block

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -597,8 +597,9 @@ namespace Microsoft.Android.Build.Tasks
 			try {
 				File.Delete (filename);
 			} catch (Exception ex) {
-				var helper = log as TaskLoggingHelper;
-				helper.LogErrorFromException (ex);
+				if (log is TaskLoggingHelper helper) {
+					helper.LogErrorFromException (ex);
+				}
 			}
 		}
 

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
@@ -726,5 +726,19 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 			var expected = BitConverter.ToString (bytes).Replace ("-", string.Empty);
 			Assert.AreEqual (expected, Files.ToHexString (bytes));
 		}
+
+		[Test]
+		public void DeleteFile_NullLog_DoesNotThrow ()
+		{
+			var nonexistent = Path.Combine (tempDir, "nonexistent.txt");
+			Assert.DoesNotThrow (() => Files.DeleteFile (nonexistent, null));
+		}
+
+		[Test]
+		public void DeleteFile_NonTaskLoggingHelperLog_DoesNotThrow ()
+		{
+			var nonexistent = Path.Combine (tempDir, "nonexistent.txt");
+			Assert.DoesNotThrow (() => Files.DeleteFile (nonexistent, "not a TaskLoggingHelper"));
+		}
 	}
 }

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
@@ -730,15 +730,17 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 		[Test]
 		public void DeleteFile_NullLog_DoesNotThrow ()
 		{
-			var nonexistent = Path.Combine (tempDir, "nonexistent.txt");
-			Assert.DoesNotThrow (() => Files.DeleteFile (nonexistent, null));
+			var path = Path.Combine (tempDir, "directory-instead-of-file");
+			Directory.CreateDirectory (path);
+			Assert.DoesNotThrow (() => Files.DeleteFile (path, null));
 		}
 
 		[Test]
 		public void DeleteFile_NonTaskLoggingHelperLog_DoesNotThrow ()
 		{
-			var nonexistent = Path.Combine (tempDir, "nonexistent.txt");
-			Assert.DoesNotThrow (() => Files.DeleteFile (nonexistent, "not a TaskLoggingHelper"));
+			var path = Path.Combine (tempDir, "directory-instead-of-file-nontasklog");
+			Directory.CreateDirectory (path);
+			Assert.DoesNotThrow (() => Files.DeleteFile (path, "not a TaskLoggingHelper"));
 		}
 	}
 }


### PR DESCRIPTION
## Summary

In `Files.DeleteFile()`, the catch block used `var helper = log as TaskLoggingHelper` followed by an unconditional dereference of `helper`. Since the `log` parameter is typed `object`, when it is `null` or not a `TaskLoggingHelper`, the `as` cast returns `null` and the next line throws a `NullReferenceException` — masking the original file deletion error with a confusing unrelated exception.

## Changes

- **`src/Microsoft.Android.Build.BaseTasks/Files.cs`** — replaced the unsafe `as` cast + dereference with pattern matching: `if (log is TaskLoggingHelper helper) helper.LogErrorFromException(ex);`. When `log` is null or the wrong type, the deletion exception is now silently caught (preserving the existing API contract that `DeleteFile` does not throw).

- **`tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs`** — added two new tests:
  - `DeleteFile_NullLog_DoesNotThrow` — verifies no exception when `log` is `null`
  - `DeleteFile_NonTaskLoggingHelperLog_DoesNotThrow` — verifies no exception when `log` is a non-`TaskLoggingHelper` object

## Verification

- ✅ `dotnet build Xamarin.Android.Tools.sln` — clean (0 errors)
- ✅ `dotnet test tests/Microsoft.Android.Build.BaseTasks-Tests` — all 103 tests pass