### PR TITLE
Remove unused `key_name` variables in OS.cs and OracleJdkLocations.cs

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Jdks/OracleJdkLocations.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Jdks/OracleJdkLocations.cs
@@ -28,7 +28,6 @@ namespace Xamarin.Android.Tools {
 			string subkey = @"SOFTWARE\JavaSoft\Java Development Kit";
 
 			foreach (var wow64 in new[] { RegistryEx.Wow64.Key32, RegistryEx.Wow64.Key64 }) {
-				string key_name = string.Format (@"{0}\{1}\{2}", "HKLM", subkey, "CurrentVersion");
 				var currentVersion = RegistryEx.GetValueString (RegistryEx.LocalMachine, subkey, "CurrentVersion", wow64);
 
 				if (!string.IsNullOrEmpty (currentVersion)) {

--- a/src/Xamarin.Android.Tools.AndroidSdk/OS.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/OS.cs
@@ -179,8 +179,6 @@ namespace Xamarin.Android.Tools
 		internal static bool CheckRegistryKeyForExecutable (UIntPtr key, string subkey, string valueName, RegistryEx.Wow64 wow64, string subdir, string exe)
 		{
 			try {
-				string key_name = string.Format (@"{0}\{1}\{2}", key == RegistryEx.CurrentUser ? "HKCU" : "HKLM", subkey, valueName);
-
 				var path = AndroidSdkBase.NullIfEmpty (RegistryEx.GetValueString (key, subkey, valueName, wow64));
 
 				if (path == null) {


### PR DESCRIPTION
## Summary

Two methods had an identical dead-code pattern: a `key_name` variable assigned via `string.Format(...)` but never read. This PR removes both unused assignments.

## Changes

- **`OS.cs`** — Deleted `string key_name = string.Format(...)` in `CheckRegistryKeyForExecutable`. This method is called ~14 times across SDK/NDK/JDK registry discovery, so the unused allocation was repeated frequently.
- **`OracleJdkLocations.cs`** — Deleted the same `key_name` dead-code pattern inside the `GetOracleJdkPaths` loop.

Both removals are pure dead-code deletion with zero behavioral change.

## Verification

- ✅ `dotnet build Xamarin.Android.Tools.sln` — 0 warnings, 0 errors
- ✅ 292/310 tests pass — 2 pre-existing failures in `JdkInstaller` tests (file access denied on temp dir, unrelated to this change)