### PR TITLE
Fix reviewer not posting body-only reviews

### DIFF
--- a/.github/skills/android-tools-reviewer/SKILL.md
+++ b/.github/skills/android-tools-reviewer/SKILL.md
@@ -85,7 +85,7 @@ Post your findings directly:
 - **Inline comments** on specific lines of the diff with the severity, category, and explanation.
 - **Review summary** with the overall verdict (✅ LGTM, ⚠️ Needs Changes, or ❌ Reject), issue counts by severity, and positive callouts.
 
-If no issues found **and CI is green**, submit with at most one or two 💡 suggestions and a positive summary.
+If no issues found **and CI is green**, submit with one or two 💡 suggestions on key implementation lines and a positive summary. **Always post at least one inline comment** — the review submission framework requires it.
 
 **Copilot-authored PRs:** If the PR author is `Copilot` (the GitHub Copilot coding agent) and the verdict is ⚠️ Needs Changes or ❌ Reject, prefix the review summary with `@copilot ` so the comment automatically triggers Copilot to address the feedback. Do NOT add the prefix for ✅ LGTM verdicts.
 

--- a/.github/workflows/android-tools-reviewer.md
+++ b/.github/workflows/android-tools-reviewer.md
@@ -50,6 +50,7 @@ A maintainer commented `/review` on this pull request. Perform a thorough code r
 
 ## Constraints
 
+- **Always post at least one inline review comment**, even for clean PRs — add a brief 💡 observation on a key implementation line. The review framework requires at least one inline comment to submit the review.
 - Only comment on added/modified lines visible in the diff.
 - One issue per inline comment.
 - If the same issue appears many times, flag it once listing all affected files.


### PR DESCRIPTION
## Summary

Fixes the android-tools-reviewer workflow silently failing to post review comments when the PR is clean (LGTM, no inline comments).

## Root Cause

The `gh-aw` safe_outputs framework requires at least one `create_pull_request_review_comment` call before `submit_pull_request_review` will work. When the reviewer agent gives a clean LGTM with zero inline comments, the review fails silently with:

```
##[warning]No review context set - cannot submit review
##[warning]✗ Failed to submit PR review: No review context available
```

Despite this, the workflow reports "success" because the warning isn't treated as a fatal error.

### Example

- PR that triggered the bug: https://github.com/dotnet/android-tools/pull/325
- Broken workflow run: https://github.com/dotnet/android-tools/actions/runs/25168175699
  - See the `safe_outputs` → `Process Safe Outputs` step: `"Submitting PR review (body-only, no inline comments)"` → `"No review context set - cannot submit review"`
- Completion comment (with no actual review posted): https://github.com/dotnet/android-tools/pull/325#issuecomment-4352875794

### Why dotnet/android works fine

The dotnet/android reviewer workflow uses identical `safe-outputs` configuration (`v0.68.3`, same handler config). However, dotnet/android PRs always generate at least one inline comment due to the larger/more complex codebase — so this bug never triggers there. Every successful dotnet/android reviewer run has `create_pull_request_review_comment` entries before `submit_pull_request_review`.

## Fix

Update the workflow prompt and SKILL.md to require at least one inline review comment on every review, even for clean PRs (e.g., a brief 💡 observation on a key implementation line). This works around the `gh-aw` framework limitation.
