### PR TITLE
Add performance and allocation review learnings from PR #327

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,6 +49,7 @@ When setting environment variables for SDK tools (e.g. `sdkmanager`, `avdmanager
 - **Use `FileUtil`**: file operations like extraction, downloads, checksum verification, and path checks belong in `FileUtil.cs`. Don't duplicate file helpers in domain classes.
 - **Concise XML docs**: omit `<summary>` tags for self-explanatory methods. Only add doc comments when the behavior is non-obvious. Avoid restating the method name.
 - **`netstandard2.0` awareness**: many modern .NET APIs are unavailable or have fewer overloads on `netstandard2.0`. When unsure about API availability, search mslearn to check documentation for the target framework.
+- **Reuse buffers**: use `ArrayPool<byte>.Shared.Rent()`/`Return()` with `try/finally` for temporary buffers (see `DownloadUtils.cs`). For fixed-size repeated reads, prefer a reusable `readonly byte[]` field.
 - **Format your code**: always match the existing file indentation (tabs, not spaces — see `.editorconfig`). Only format code you add or modify; never reformat existing lines.
 - **No whitespace-only diffs**: before committing, run `git diff --stat` and verify only files with intentional code changes appear. If a file shows as fully rewritten (all lines removed and re-added) you have introduced line-ending or trailing-whitespace changes — revert that file with `git checkout -- <file>` and re-apply only your code change. Never commit whitespace-only or line-ending-only changes.
 - **File-scoped namespaces**: all new files should use file-scoped namespaces (`namespace Foo;` instead of `namespace Foo { ... }`).
@@ -56,6 +57,7 @@ When setting environment variables for SDK tools (e.g. `sdkmanager`, `avdmanager
 - [Mono Coding Guidelines](http://www.mono-project.com/community/contributing/coding-guidelines/): tabs, K&R braces, `PascalCase` public members.
 - **No null-forgiving operator (`!`)**: do not use the null-forgiving operator after null checks. Instead, use C# property patterns (e.g. `if (value is { Length: > 0 } v)`) which give the compiler proper non-null flow analysis on all target frameworks including `netstandard2.0`.
 - **Prefer switch expressions**: use C# switch expressions over switch statements for simple value mappings (e.g. `return state switch { "x" => A, _ => B };`). Use switch statements only when the body has side effects or complex logic.
+- **Document thread-safety**: when a class reuses mutable state (buffers, caches) assuming single-caller semantics, add `<remarks>This class is not thread-safe.</remarks>`.
 - Nullable enabled in `AndroidSdk`. `NullableAttributes.cs` excluded on `net10.0+`.
 - Strong-named via `product.snk`. In the AndroidSdk project, tests use `InternalsVisibleTo` with full public key (`Properties/AssemblyInfo.cs`).
 - Assembly names support `$(VendorPrefix)`/`$(VendorSuffix)` for branding forks.

--- a/.github/skills/android-tools-reviewer/SKILL.md
+++ b/.github/skills/android-tools-reviewer/SKILL.md
@@ -37,6 +37,8 @@ gh pr view {number} --repo {owner}/{repo} --json files
 
 For each changed file, read the **full source file** (not just the diff) to understand surrounding invariants, call patterns, and data flow. If the change modifies a public/internal API or utility, search for callers. Check whether sibling types need the same fix.
 
+**Prefer existing repo patterns.** Before suggesting new infrastructure, grep for established patterns (`ArrayPool`, `ObjectPool`, `MemoryStreamPool`, `ProcessUtils`) and follow those.
+
 **Form an independent assessment** of what the change does and what problems it has *before* reading the PR description.
 
 ### 3. Incorporate PR narrative and reconcile

--- a/.github/skills/android-tools-reviewer/references/csharp-rules.md
+++ b/.github/skills/android-tools-reviewer/references/csharp-rules.md
@@ -63,6 +63,8 @@ When a library multi-targets (e.g., `netstandard2.0` + a modern TFM), every API 
 
 | Check | What to look for |
 |-------|-----------------|
+| **Reuse hot-path buffers** | Pool repeated `byte[]` allocations with `ArrayPool<byte>.Shared` (see `DownloadUtils.cs`). For fixed-size repeated reads, use a `readonly byte[]` instance field. Document non-thread-safety in `<remarks>`. |
+| **Reuse loop helpers** | If a loop creates resettable helpers (e.g., `TcpClient`), reuse one instance via `Reconnect()`/`Reset()` instead of `new` per iteration. |
 | **XmlReader over LINQ XML** | For forward-only XML parsing (manifests, config files), use `XmlReader` — it's streaming and allocation-free. `XElement`/`XDocument` builds a full DOM tree. |
 | **p/invoke over process spawn** | For single syscalls like `chmod`, use `[DllImport("libc")]` instead of spawning a child process. Process creation is orders of magnitude more expensive. |
 | **Avoid intermediate collections** | Don't create two lists and `AddRange()` one to the other. Build a single list, or use LINQ to chain. |
@@ -85,6 +87,7 @@ When a library multi-targets (e.g., `netstandard2.0` + a modern TFM), every API 
 |-------|-----------------|
 | **File-scoped namespaces** | New files should use `namespace Foo;` (not `namespace Foo { ... }`). Don't reformat existing files. |
 | **Use `record` for data types** | Immutable data-carrier types (progress, version info, license info) should be `record` types. They get value equality, `ToString()`, and deconstruction for free. |
+| **Document thread-safety invariants** | When a class reuses buffers, caches, or mutable state assuming single-caller semantics, add `<remarks>This class is not thread-safe.</remarks>` to the type. Callers need to know if external synchronization is required. |
 | **Remove unused code** | Dead methods, speculative helpers, and code "for later" should be removed. Ship only what's needed. |
 | **No commented-out code** | Commented-out code should be deleted — Git has history. |
 | **Reduce indentation with early returns** | Invert conditions with `continue` or early `return` to reduce nesting. `foreach (var x in items ?? Array.Empty<T>())` eliminates null-check nesting. |


### PR DESCRIPTION
Adds performance and allocation review learnings from PR #327 to the reviewer skill and Copilot instructions.

## Changes

**`.github/copilot-instructions.md`**
- Add **Reuse buffers** guidance (`ArrayPool<byte>.Shared` + reusable `readonly byte[]` fields)
- Add **Document thread-safety** guidance (`<remarks>This class is not thread-safe.</remarks>`)

**`.github/skills/android-tools-reviewer/SKILL.md`**
- Add "Prefer existing repo patterns" workflow step — grep for `ArrayPool`, `ObjectPool`, `MemoryStreamPool`, `ProcessUtils` before suggesting new infrastructure

**`.github/skills/android-tools-reviewer/references/csharp-rules.md`**
- Add **Reuse hot-path buffers** and **Reuse loop helpers** to the Performance section
- Add **Document thread-safety invariants** to the Code Organization section

## Removed from original PR (per review feedback)

- UTF-8 string literal guidance — `ReadOnlySpan<byte>` works on netstandard2.0 via `System.Memory`
- `Encoding.ASCII.GetBytes()` recommendation — wrong for non-ASCII content
- "No string intermediates in protocols" — overly prescriptive
- "No stackalloc in async I/O" — already a compiler error, not a review concern

Also rebased onto main to resolve merge conflicts from PR #355 (which split `review-rules.md` into per-category files).