### PR TITLE
[copilot] Restore workflow_dispatch trigger for Copilot coding agent

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,6 +1,7 @@
 name: Copilot Setup Steps CI
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - '.github/workflows/copilot-setup-steps.yml'


### PR DESCRIPTION
The `copilot-setup-steps.yml` was introduced in #307 with `on: pull_request` (CI validation only) and has never had `on: workflow_dispatch`. This means the Copilot coding agent has no setup steps when assigned to issues -- it won't have .NET or `gh-aw` available.

This restores the standard `on: workflow_dispatch` trigger so the Copilot coding agent gets the right build environment.
