### PR TITLE
Add API 37 (CinnamonBun) to KnownVersions

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs
@@ -214,6 +214,9 @@ namespace Xamarin.Android.Tools
 			new AndroidVersion (new Version ("36.1"), "16.0") {
 				AlternateIds = new[]{ "Canary" },
 			},
+			new AndroidVersion (new Version ("37.0"), "17.0") {
+				AlternateIds = new[]{ "CinnamonBun", "Cinnamon Bun" },
+			},
 		};
 	}
 }


### PR DESCRIPTION
Add `AndroidVersion` entry for API level 37.0 (framework v17.0, codename CinnamonBun) to the `KnownVersions` table.

This is needed for `dotnet/android` PR https://github.com/dotnet/android/pull/11254 which makes `net11.0-android37` the default target framework. Without this entry, `GetIdFromApiLevel(37)`, `GetFrameworkVersionFromApiLevel(37)`, etc. don't resolve correctly when `AndroidApiInfo.xml` is not loaded.
