### PR TITLE
Pass stdout to ThrowIfFailed in three runner list methods

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbRunner.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AdbRunner.cs
@@ -58,7 +58,7 @@ public class AdbRunner
 		var psi = ProcessUtils.CreateProcessStartInfo (adbPath, "devices", "-l");
 		var exitCode = await ProcessUtils.StartProcess (psi, stdout, stderr, cancellationToken, environmentVariables).ConfigureAwait (false);
 
-		ProcessUtils.ThrowIfFailed (exitCode, "adb devices -l", stderr);
+		ProcessUtils.ThrowIfFailed (exitCode, "adb devices -l", stderr, stdout);
 
 		var devices = ParseAdbDevicesOutput (stdout.ToString ().Split ('\n'));
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/AvdManagerRunner.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/AvdManagerRunner.cs
@@ -43,7 +43,7 @@ public class AvdManagerRunner
 		logger.Invoke (TraceLevel.Verbose, "Running: avdmanager list avd");
 		var exitCode = await ProcessUtils.StartProcess (psi, stdout, stderr, cancellationToken, environmentVariables).ConfigureAwait (false);
 
-		ProcessUtils.ThrowIfFailed (exitCode, "avdmanager list avd", stderr);
+		ProcessUtils.ThrowIfFailed (exitCode, "avdmanager list avd", stderr, stdout);
 
 		return ParseAvdListOutput (stdout.ToString ());
 	}

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/EmulatorRunner.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/EmulatorRunner.cs
@@ -102,7 +102,7 @@ public class EmulatorRunner
 
 		logger.Invoke (TraceLevel.Verbose, "Running: emulator -list-avds");
 		var exitCode = await ProcessUtils.StartProcess (psi, stdout, stderr, cancellationToken, environmentVariables).ConfigureAwait (false);
-		ProcessUtils.ThrowIfFailed (exitCode, "emulator -list-avds", stderr);
+		ProcessUtils.ThrowIfFailed (exitCode, "emulator -list-avds", stderr, stdout);
 
 		return ParseListAvdsOutput (stdout.ToString ());
 	}


### PR DESCRIPTION
## Summary

Three runner list methods captured stdout from their process invocation but didn't pass it to `ProcessUtils.ThrowIfFailed`, violating the repo convention:

> When a method captures stdout, pass it to `ProcessUtils.ThrowIfFailed(exitCode, command, stderr, stdout)` so failure messages include all output, not just stderr.

For list commands (`adb devices -l`, `avdmanager list avd`, `emulator -list-avds`), the primary diagnostic output on failure goes to stdout, not stderr. Omitting it meant the `InvalidOperationException` thrown on failure contained only the (possibly empty) stderr, losing the most useful diagnostic information.

## Changes

- **`AdbRunner.cs`** (`ListDevicesAsync`): `ThrowIfFailed(exitCode, "adb devices -l", stderr)` → `ThrowIfFailed(exitCode, "adb devices -l", stderr, stdout)`
- **`AvdManagerRunner.cs`** (`ListAvdsAsync`): `ThrowIfFailed(exitCode, "avdmanager list avd", stderr)` → `ThrowIfFailed(exitCode, "avdmanager list avd", stderr, stdout)`
- **`EmulatorRunner.cs`** (`ListAvdNamesAsync`): `ThrowIfFailed(exitCode, "emulator -list-avds", stderr)` → `ThrowIfFailed(exitCode, "emulator -list-avds", stderr, stdout)`

The already-conforming reference is `ListReversePortsAsync` in `AdbRunner.cs`, which correctly passes both streams.

## Testing

No behavior change on the happy path. Build passes, 145/149 tests pass (4 skipped are pre-existing Windows bash-script skips unrelated to this change).
