### PR TITLE
Remove dead ThrowIfCancellationRequested() in WaitForFullBootAsync

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/EmulatorRunner.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/EmulatorRunner.cs
@@ -291,9 +291,7 @@ public class EmulatorRunner
 		// cancellationToken (a linked CTS with CancelAfter). This method simply
 		// polls until boot completes or the token is cancelled.
 		while (!cancellationToken.IsCancellationRequested) {
-			cancellationToken.ThrowIfCancellationRequested ();
-
-			var bootCompleted = await adbRunner.GetShellPropertyAsync (serial, "sys.boot_completed", cancellationToken).ConfigureAwait (false);
+			var bootCompleted= await adbRunner.GetShellPropertyAsync (serial, "sys.boot_completed", cancellationToken).ConfigureAwait (false);
 			if (string.Equals (bootCompleted, "1", StringComparison.Ordinal)) {
 				var pmResult = await adbRunner.RunShellCommandAsync (serial, "pm path android", cancellationToken).ConfigureAwait (false);
 				if (pmResult != null && pmResult.StartsWith ("package:", StringComparison.Ordinal)) {

--- a/src/Xamarin.Android.Tools.AndroidSdk/Runners/EmulatorRunner.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Runners/EmulatorRunner.cs
@@ -291,7 +291,7 @@ public class EmulatorRunner
 		// cancellationToken (a linked CTS with CancelAfter). This method simply
 		// polls until boot completes or the token is cancelled.
 		while (!cancellationToken.IsCancellationRequested) {
-			var bootCompleted= await adbRunner.GetShellPropertyAsync (serial, "sys.boot_completed", cancellationToken).ConfigureAwait (false);
+			var bootCompleted = await adbRunner.GetShellPropertyAsync (serial, "sys.boot_completed", cancellationToken).ConfigureAwait (false);
 			if (string.Equals (bootCompleted, "1", StringComparison.Ordinal)) {
 				var pmResult = await adbRunner.RunShellCommandAsync (serial, "pm path android", cancellationToken).ConfigureAwait (false);
 				if (pmResult != null && pmResult.StartsWith ("package:", StringComparison.Ordinal)) {


### PR DESCRIPTION
## Summary

The while (!cancellationToken.IsCancellationRequested) loop condition in WaitForFullBootAsync already guarantees the token is **not** cancelled at the start of each iteration. The immediately following cancellationToken.ThrowIfCancellationRequested() call was therefore unreachable dead code — it could never throw.

Actual cancellation propagates correctly via OperationCanceledException thrown by the awaited adb call and Task.Delay(..., cancellationToken) when the token fires asynchronously.

The redundant check also misled readers into thinking it provided an extra cancellation checkpoint, when in reality it added nothing.

## Changes

- **EmulatorRunner.cs**: Removed the dead cancellationToken.ThrowIfCancellationRequested(); line from inside the polling loop in WaitForFullBootAsync. This matches the pattern already used in BootEmulatorAsync's while (newSerial == null) loop, which has no such redundant check.

## No behavior change

Cancellation behavior is identical — Task.Delay and the awaited adb calls already handle it.