### PR TITLE
Update MSBuild package references to 18.6.3

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -11,7 +11,6 @@ using System.Text;
 using Xamarin.Tools.Zip;
 using Microsoft.Build.Utilities;
 using System.Threading;
-using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 using System.Collections;
 

--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -4,7 +4,7 @@
 <Project>
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
-    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.14.28</MSBuildPackageReferenceVersion>
+    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">18.6.3</MSBuildPackageReferenceVersion>
     <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >3.3.0</LibZipSharpVersion>
     <MonoUnixVersion>7.1.0-final.1.21458.1</MonoUnixVersion>
   </PropertyGroup>


### PR DESCRIPTION
Keeps our MSBuild reference assemblies current with the latest stable release ([Microsoft.Build.Framework 18.6.3](https://www.nuget.org/packages/Microsoft.Build.Framework/18.6.3)), so consumers building against newer MSBuild surfaces line up with what ships in current SDKs.

## Changes

- Bump `MSBuildPackageReferenceVersion` in `src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems` from `17.14.28` to `18.6.3`. This flows to `Microsoft.Build`, `Microsoft.Build.Framework`, `Microsoft.Build.Tasks.Core`, and `Microsoft.Build.Utilities.Core`.
- Remove an unused `using System.Reflection.Metadata;` from `Files.cs`. It was previously satisfied transitively by the 17.x MSBuild packages and no longer resolves with 18.6.3. Nothing in the file actually uses the namespace.

## Verification

`dotnet build Xamarin.Android.Tools.sln --no-incremental` succeeds with 0 errors on both `netstandard2.0` and `net10.0`.