### PR TITLE
Update Microsoft.Build package references

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -4,7 +4,8 @@
 <Project>
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
-    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.14.28</MSBuildPackageReferenceVersion>
+    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">18.6.3</MSBuildPackageReferenceVersion>
+    <SystemReflectionMetadataPackageVersion Condition=" '$(SystemReflectionMetadataPackageVersion)' == '' ">10.0.3</SystemReflectionMetadataPackageVersion>
     <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >3.3.0</LibZipSharpVersion>
     <MonoUnixVersion>7.1.0-final.1.21458.1</MonoUnixVersion>
   </PropertyGroup>
@@ -14,6 +15,7 @@
     <PackageReference Include="Microsoft.Build.Framework"      Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core"     Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageReferenceVersion)" />
+    <PackageReference Include="System.Reflection.Metadata"     Version="$(SystemReflectionMetadataPackageVersion)" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Mono.Unix" Version="$(MonoUnixVersion)" GeneratePathProperty="true" />


### PR DESCRIPTION
## Summary
- Update Microsoft.Build package references from 17.14.28 to 18.6.3
- Add the matching System.Reflection.Metadata package reference used by the build task project

## Validation
- dotnet restore src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj --disable-parallel --verbosity minimal
- dotnet build src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj --no-restore --verbosity minimal
- dotnet restore tests/Microsoft.Android.Build.BaseTasks-Tests/Microsoft.Android.Build.BaseTasks-Tests.csproj --disable-parallel --verbosity minimal
- dotnet test tests/Microsoft.Android.Build.BaseTasks-Tests/Microsoft.Android.Build.BaseTasks-Tests.csproj --no-restore --verbosity minimal
