### PR TITLE
Add Dependabot config for weekly NuGet updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Enables Dependabot to keep our NuGet dependencies current without manual tracking. Weekly cadence keeps update noise manageable while still surfacing security and version bumps in a timely fashion.

Adds `.github/dependabot.yml` with a single `nuget` ecosystem entry rooted at the repo, scheduled weekly.