### PR TITLE
[BaseTasks] Bump System.Reflection.Metadata to match Microsoft.Build 18.6.3

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -5,7 +5,7 @@
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
     <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">18.6.3</MSBuildPackageReferenceVersion>
-    <SystemReflectionMetadataPackageVersion Condition=" '$(SystemReflectionMetadataPackageVersion)' == '' ">10.0.3</SystemReflectionMetadataPackageVersion>
+    <SystemReflectionMetadataPackageVersion Condition=" '$(SystemReflectionMetadataPackageVersion)' == '' ">11.0.0-preview.1.26104.118</SystemReflectionMetadataPackageVersion>
     <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >3.3.0</LibZipSharpVersion>
     <MonoUnixVersion>7.1.0-final.1.21458.1</MonoUnixVersion>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

Bump `SystemReflectionMetadataPackageVersion` from `10.0.3` to `11.0.0-preview.1.26104.118` in `MSBuildReferences.projitems`.

## Problem

`Microsoft.Build.Tasks.Core 18.6.3` transitively requires `System.Reflection.Metadata >= 11.0.0-preview.1.26104.118`, but the default in `MSBuildReferences.projitems` was still `10.0.3`. This causes **NU1605** package-downgrade errors in consuming repos that do not override `SystemReflectionMetadataPackageVersion` (e.g. `android-platform-support`), which broke the internal build after the submodule bump in dotnet/android#11521.

## Root cause

This should have been updated in a2ddf1a / PR #369 when MSBuild was bumped to 18.6.3, but the SRM version was missed.