### PR TITLE
Remove unused System.Reflection.Metadata reference

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -11,7 +11,6 @@ using System.Text;
 using Xamarin.Tools.Zip;
 using Microsoft.Build.Utilities;
 using System.Threading;
-using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 using System.Collections;
 

--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -15,7 +15,6 @@
     <PackageReference Include="Microsoft.Build.Framework"      Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core"     Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageReferenceVersion)" />
-    <PackageReference Include="System.Reflection.Metadata"     Version="$(SystemReflectionMetadataPackageVersion)" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Mono.Unix" Version="$(MonoUnixVersion)" GeneratePathProperty="true" />


### PR DESCRIPTION
The `System.Reflection.Metadata` namespace isn't actually used in `Files.cs`, and the matching `PackageReference` in `MSBuildReferences.projitems` adds an unnecessary dependency to this project. Drop both.

The `$(SystemReflectionMetadataPackageVersion)` MSBuild property is intentionally left in place since downstream consumers (e.g. dotnet/android) may still rely on it.

### Changes
- Remove `using System.Reflection.Metadata;` from `Files.cs`
- Remove the `System.Reflection.Metadata` `PackageReference` from `MSBuildReferences.projitems`
- Keep the `$(SystemReflectionMetadataPackageVersion)` property for downstream use

Verified with a clean build of `Microsoft.Android.Build.BaseTasks`.