### PR TITLE
Update MSBuild package dependency

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -4,8 +4,8 @@
 <Project>
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
-    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">18.9.0-preview-26310-106</MSBuildPackageReferenceVersion>
-    <SystemReflectionMetadataPackageVersion Condition=" '$(SystemReflectionMetadataPackageVersion)' == '' ">10.0.8</SystemReflectionMetadataPackageVersion>
+    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">18.7.1</MSBuildPackageReferenceVersion>
+    <SystemReflectionMetadataPackageVersion Condition=" '$(SystemReflectionMetadataPackageVersion)' == '' ">10.0.4</SystemReflectionMetadataPackageVersion>
     <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >3.3.0</LibZipSharpVersion>
     <MonoUnixVersion>7.1.0-final.1.21458.1</MonoUnixVersion>
   </PropertyGroup>
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Build.Framework"      Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core"     Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageReferenceVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" IncludeAssets="None" PrivateAssets="All" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Mono.Unix" Version="$(MonoUnixVersion)" GeneratePathProperty="true" />

--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Build.Framework"      Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core"     Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageReferenceVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" IncludeAssets="None" PrivateAssets="All" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Mono.Unix" Version="$(MonoUnixVersion)" GeneratePathProperty="true" />

--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -4,8 +4,8 @@
 <Project>
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
-    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">18.6.3</MSBuildPackageReferenceVersion>
-    <SystemReflectionMetadataPackageVersion Condition=" '$(SystemReflectionMetadataPackageVersion)' == '' ">10.0.3</SystemReflectionMetadataPackageVersion>
+    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">18.9.0-preview-26310-106</MSBuildPackageReferenceVersion>
+    <SystemReflectionMetadataPackageVersion Condition=" '$(SystemReflectionMetadataPackageVersion)' == '' ">10.0.8</SystemReflectionMetadataPackageVersion>
     <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >3.3.0</LibZipSharpVersion>
     <MonoUnixVersion>7.1.0-final.1.21458.1</MonoUnixVersion>
   </PropertyGroup>
@@ -15,7 +15,6 @@
     <PackageReference Include="Microsoft.Build.Framework"      Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core"     Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageReferenceVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" IncludeAssets="None" PrivateAssets="All" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Mono.Unix" Version="$(MonoUnixVersion)" GeneratePathProperty="true" />


### PR DESCRIPTION
## Description

Updates the shared MSBuild package version used by the MSBuild reference import to the latest stable package, and adds a scoped dependency override for the transitive package that the stable package graph has not advanced yet.

## Testing

- Restored affected project graphs and confirmed they resolve through `Microsoft.Build.Tasks.Core` `18.7.1`
- `dotnet restore Xamarin.Android.Tools.sln`
- `dotnet build Xamarin.Android.Tools.sln --no-restore`
